### PR TITLE
cmp_exact for xsha512-cuda

### DIFF
--- a/src/cuda_xsha512.h
+++ b/src/cuda_xsha512.h
@@ -24,6 +24,7 @@
 #define BINARY_SIZE 64
 #else
 #define BINARY_SIZE 8
+#define FULL_BINARY_SIZE 8
 #endif
 
 #if 0

--- a/src/cuda_xsha512_fmt.c
+++ b/src/cuda_xsha512_fmt.c
@@ -10,8 +10,12 @@
  * There's ABSOLUTELY NO WARRANTY, express or implied.
  */
 
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER >= 0x00908000
 
 #include <string.h>
+#include <openssl/sha.h>
+
 
 #include "cuda_xsha512.h"
 #include "arch.h"
@@ -257,7 +261,25 @@ static int cmp_one(void *binary, int index)
 
 static int cmp_exact(char *source, int index)
 {
+	SHA512_CTX ctx;
+	uint64_t crypt_out[8];
+	
+	SHA512_Init(&ctx);
+	SHA512_Update(&ctx, gsalt.v, SALT_SIZE);
+	SHA512_Update(&ctx, gkey[index].v, gkey[index].length);
+	SHA512_Final((unsigned char *)(crypt_out), &ctx);	
+
+	int i;
+	uint64_t *b = (uint64_t *)get_binary(source);
+	uint64_t *c = (uint64_t *)crypt_out;
+
+	
+	for (i = 0; i < FULL_BINARY_SIZE / 8; i++) { //examin 512bits
+		if (b[i] != c[i])
+			return 0;
+	}
 	return 1;
+
 }
 
 struct fmt_main fmt_cuda_xsha512 = {
@@ -310,3 +332,9 @@ struct fmt_main fmt_cuda_xsha512 = {
 		cmp_exact
 	}
 };
+#else
+#ifdef __GNUC__
+#warning Note: Mac OS X Lion format disabled - it needs OpenSSL 0.9.8 or above
+#endif
+#endif
+


### PR DESCRIPTION
Hi, magnum

Here is cmp_exact for xsha512-cuda to examine the correctness for rare situation. Previous we only compare first 8 byte of hash.

Signed-off-by: Myrice qqlddg@gmail.com
