### PR TITLE
cmp_exact for xsha512-cuda

### DIFF
--- a/src/cuda_xsha512.h
+++ b/src/cuda_xsha512.h
@@ -24,6 +24,7 @@
 #define BINARY_SIZE 64
 #else
 #define BINARY_SIZE 8
+#define FULL_BINARY_SIZE 64
 #endif
 
 #if 0


### PR DESCRIPTION
Hi, magnum

Here is cmp_exact for xsha512-cuda to examine the correctness for rare situation. Previous we only compare first 8 byte of hash.

Signed-off-by: Myrice qqlddg@gmail.com

Conflicts:

```
src/cuda_xsha512_fmt.c
```
