### PR TITLE
Default value for number of iterations

### DIFF
--- a/run/agilekc2john.py
+++ b/run/agilekc2john.py
@@ -127,7 +127,7 @@ class AgileKeychain(Keychain):
                               kd['level'],
                               b64decode(kd['data'][:-1]),
                               b64decode(kd['validation'][:-1]),
-                              kd['iterations'])
+                              kd.get('iterations', Key.ITERATIONS))
                     self.keys.append(key)
             finally:
                 keys_file.close()


### PR DESCRIPTION
Some versions of the keychain do not include an explicit `iterations`
key in `encryptionKey.js`; the default should be used to avoid a crash.
