### PR TITLE
Fix: make OpenCL BuildOptions work on Mac OS X

### DIFF
--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -106,7 +106,7 @@ static char *include_source(char *pathname, int dev_id)
 	    "-DDEVICE_IS_CPU" : "",
 	    "-DDEVICE_INFO=", device_info[dev_id],
 	    gpu_nvidia(device_info[dev_id]) ? "-cl-nv-verbose" : "",
-	    "-cl-strict-aliasing -cl-mad-enable");
+	    OPENCLBUILDOPTIONS);
 
 	//fprintf(stderr, "Options used: %s\n", include);
 	return include;

--- a/src/common-opencl.h
+++ b/src/common-opencl.h
@@ -21,6 +21,12 @@
 #define SUBSECTION_OPENCL	":OpenCL"
 #define MAX_OCLINFO_STRING_LEN	2048
 
+#ifdef __APPLE__
+#define OPENCLBUILDOPTIONS ""
+#else
+#define OPENCLBUILDOPTIONS "-cl-strict-aliasing -cl-mad-enable"
+#endif
+
 /* Comment if you do not want to see OpenCL warnings during kernel compilation */
 #define REPORT_OPENCL_WARNINGS
 


### PR DESCRIPTION
Fix: If Apple is in question, turn off build options as Apple OpenCL does not like
it. At least on Mac Book Pros having ATI Radeon HD 6750M. 

Maybe to have it as command line option (like --device or --platform)? 
