### PR TITLE
Print to stdout without message for consistency

### DIFF
--- a/src/unicode.c
+++ b/src/unicode.c
@@ -754,7 +754,7 @@ UTF8 *utf16_to_enc_r (UTF8 *dst, int dst_len, const UTF16 *source) {
 }
 
 void listEncodings(void) {
-	fprintf(stderr, "Supported encodings within john are:\nutf-8, iso-8859-1 (or ansi)"
+	printf("utf-8, iso-8859-1 (or ansi)"
 	        ", iso-8859-2"
 	        ", iso-8859-7"
 	        ", iso-8859-15"


### PR DESCRIPTION
Other list= commands does not display greeting message. Also other list commands are displayed to stdout and not to stderr which helps in scripting. 

For example (ignore not parsing correctly ,):
➜  run  ./john --list=externals 2> /dev/null | wc -l 
      29
➜  run  ./john --list=formats 2> /dev/null | wc -l 
      15
➜  run  ./john --list=rules 2> /dev/null | wc -l 
      67

Problem:
➜  run  ./john --list=encodings 2> /dev/null | wc -l 
       0

This small patch fixes it. 
