### PR TITLE
Bash completion: add trailing space for --nolog etc.

### DIFF
--- a/run/john.bash_completion
+++ b/run/john.bash_completion
@@ -100,7 +100,8 @@
 ## have grep && have sed && have tr &&
 _john()
 {
-	local first cur options valopts compreplya compreplyb encodings formats subformats list hidden dir cmd i ver ver1 ver2 ver3 prev words prefix
+	local first cur options valopts compreplya compreplyb encodings formats 
+	local subformats list dir cmd i ver ver1 ver2 ver3 prev words prefix
 
 	# Without LC_ALL=C, [A-Z] match [a-z] (case "${cur}" in ... esac)
 	LC_ALL=C
@@ -130,30 +131,29 @@ _john()
 #	We need to make sure we run the correct program, not some other program
 #	called john which is located somewhere in $PATH
 	first="${COMP_WORDS[0]}"
-#	Most options are listed at the begin of the line, but the line with the --pipe option
-#	does have trailing spaces, and --stdin is mentioned after --wordlist=FILE.
+
+#	Most options are listed at the begin of the line, but the line with 
+#	the --pipe option does have trailing spaces, and --stdin is mentioned
+#	after --wordlist=FILE.
 #
 #	All options (the '=' will be removed for options with an optional value)
 	options=""
 # FIXME: How do I suppress the error message if someone tries to be clever: cd run; ./john --[tab] ???
-	options="`${first} 2>/dev/null|sed -n -e 's#^ *\(--[a-z-]*=\?\(LIST\)\?\).*$#\1#' -e '/^--/ p'` --stdin"
+	options="`( ${first} 2>/dev/null|sed -n -e 's#^ *\(--[a-z-]*=\?\(LIST\)\?\).*$#\1#' -e '/^--/ p'; ./john --list=hidden-options 2>/dev/null|sed -n -e 's#^\(--[a-z-]*=\?\).*$#\1#' -e '/--/ p')` --stdin"
 	if [[ "_${options}" == "_ --stdin" ]] ; then
 		_filedir_xspec 2> /dev/null
 		return 0
 	fi
 
-#	Just those options that can be used together with a value, even if that value is optional:
+#	Just those options that can be used together with a value,
+#	even if that value is optional:
 	valopts=`${first} 2>/dev/null|grep '^ *--[a-z\[-]*='|grep -v '^ *--subformat='|sed 's#^ *\([a-z=-]*\).*$#\1#'`
-#	This is used to decide whether or not the completion should add a trailing space.
-#	(That means, for a jumbo build, --rules doesn't get a trailing space, but for the john version
-#	distributed by fedora16, --rules does get a trailing space during completion.
-#	The same applies for --show and single)
-
-#	now add the "hidden options" (not mentioned in the usage output, but in doc/OPTIONS and
-#       with --list=hidden-options
-#	Currently, all hidden options do have mandatory values (--option=value), this makes
-#       addition of these easier
-	hidden=`${first} --list=hidden-options 2>/dev/null|sed 's#^\(--[a-z-]*=\?\).*$#\1#'`
+#	This is used to decide whether or not the completion should add
+#	a trailing space.
+#	(That means, for a jumbo build, --rules doesn't get a trailing space,
+#	but for the john version distributed by fedora16, --rules does get
+#	a trailing space during completion.
+#	The same applies for the --show and --single options)
 
 	case "${cur}" in
 		-?(-)f?(o|or|orm|orma|ormat)+(=|:)dynamic*)
@@ -209,17 +209,21 @@ _john()
 					return 0
 				fi
 			fi
-# If there is no .rec file in the current directory, the old completion logic will show all files:
+# If there is no .rec file in the current directory, the old completion logic
+# will show all files:
 ##echo _`for f in *.rec; do echo ${f%.rec};done`_
 			cur=${cur#*[=:]}
-# cd $JOHN/ or Private home for system-wide builds, if ./john --list=build-info works?
+# cd $JOHN/ or Private home for system-wide builds, if ./john --list=build-info
+# works?
 # NO, this would be wrong!
-# .rec files are stored in the current directory (or a subdirectory if the session name contains a slash)
+# .rec files are stored in the current directory (or a subdirectory if the
+# session name contains a slash)
 
 			__expand_tilde_by_ref cur 2>/dev/null
 			_filedir "rec"
 			for (( i=0; i < ${#COMPREPLY[@]}; i++)); do
-				# Do I have to add the trailing / for directories? Apparently not!
+				# Do I have to add the trailing / for
+				# directories? Apparently not!
 				COMPREPLY[$i]="${COMPREPLY[$i]%*.rec}"
 			done
 			return 0
@@ -261,8 +265,8 @@ _john()
 			return 0
 			;;
 		-?(-)ru?(l|le|les)+(=|:)*|-?(-)si?(n|ng|ngl|ngle)+(=|:)*)
-			# let's assume every john version which supports --single=
-			# also supports --rules=, and vice versa
+			# let's assume every john version which supports
+			# --single= also supports --rules=, and vice versa
 			if [[ "${valopts}" == *--rules* ]] ; then
 				cmd=`echo ${COMP_LINE}|sed "s# ${cur}# --list=rules #"`
 				list=`${cmd} 2>/dev/null`
@@ -385,12 +389,16 @@ _john()
 					COMPREPLY=( $(compgen -W "${cur}=" -- ${cur}) )
 					compopt -o nospace
 				else
-					# FIXME: Should I mention [MIN_LEVEL-] and [MIN_LENGTH-]?
-					#        I think not all jumbo versions support these.
-					# FIXME: How to find out whether --markov=MODE is
-					#        supported?
-					#        Assume it is supported if at least one
-					#        section [Markov:mode] exists, e.g. [Markov:Default]?
+					# FIXME: Should I mention [MIN_LEVEL-]
+					#        and [MIN_LENGTH-]?
+					#        I think not all jumbo versions
+					#        support these.
+					# FIXME: How to find out whether
+					#        --markov=MODE is supported?
+					#        Assume it is supported if
+					#        at least one section
+					#        [Markov:mode] exists, e.g.
+					#        [Markov:Default]?
 					COMPREPLY=( $(compgen -W "--markov --markov=LEVEL[:START[:END[:LENGTH]]] --markov=MODE --markov=MODE:LEVEL[:START[:END[:LENGTH]]]" -- ${cur}) )
 				fi
 			fi
@@ -398,15 +406,18 @@ _john()
 			;;
 		-?(-)mar?(k|ko|kov)+(:|=)*)
 			if [[ "${valopts}" == *--markov* ]] ; then
-				# Ignore the  --markov=[MINLVL-]LEVEL[:START[:END[:[MINLEN-]LENGTH]]]?
-				# Just try completion for --markov=MODE for all [Markov:...] sections?
-				if [[ "${hidden}" == *--list=* || "${valopts}" == *--list=* ]] ; then
+				# Ignore the --markov=[MINLVL-]LEVEL...?
+				# Just try completion for --markov=MODE
+				# for all [Markov:...] sections?
+				if [[ "${valopts}" == *--list=* ]] ; then
 					cur=`echo ${cur#*[=:]}|LC_ALL=C tr A-Z a-z`
-					# Don't include subsection names that contain a ':' or that
-					# contain just '-' and digits
+					# Don't include subsection names which
+					# contain a ':' or which contain
+					# just '-' and digits
 					list=`${first} --list=Markov 2>/dev/null | LC_ALL=C sed 's#^.*:.*$##'|LC_ALL=C sed 's#^[-0-9]*$##'`
 					COMPREPLY=( $(compgen -W "${list}" -- ${cur}) )
-					# no trailing space, just in case the user wants to add :lvl...
+					# no trailing space, just in case
+					# the user wants to add :LEVEL...
 					compopt -o nospace
 				fi
 			fi
@@ -465,7 +476,7 @@ _john()
 			;;
 		-?(-)en?(c|co|cod|codi|codin|coding)+(=|:)*)
 			if [[ "${valopts}" == *--encoding=* ]] ; then
-				# --encoding=LIST writes to stderr
+				# --encoding=LIST wrote to stderr in the past
 				list=`${first} --list=\? 2>/dev/null|sed 's#\(,\)\?\( or\)\?[ ]*[<].*$##; s#,##g'`
 				if [[ "_${list}" == *encoding* ]] ; then
 					cmd="${first} --list=encodings"
@@ -475,10 +486,12 @@ _john()
 				encodings=`${cmd} 2>&1|grep -v 'Supported encodings'|sed 's#[,)]##g'|sed 's#(or ##g'`
 			cur=${cur#*[=:]}
 				if [[ ${COMP_CWORD} -eq 2 || ${COMP_CWORD} -eq 3 && "_${cur}" != "_" ]] ; then
-					# Don't add LIST if --list=encodings is supported
+					# Don't add LIST if --list=encodings
+					# is supported
 					if [[ "_${list}" != *encoding* ]] ; then
 						encodings="${encodings} LIST"
-						# make sure LIST will be the first option:
+						# make sure LIST will be
+						# the first option:
 						LC_ALL=C
 					fi
 				fi
@@ -488,13 +501,15 @@ _john()
 			;;
 		-?(-)po?(t)+(=|:)*)
 			if  [[ "${valopts}" == *--pot=* ]] ; then
-				# if --pot= is used, john always looks for the file $PWD
-				# (tested with system-wide and local build of john)
+				# if --pot= is used, john always looks for
+				# the file in $PWD (tested with system-wide
+				# and local builds of john)
 				cur=${cur#*[=:]}
-				#redirect stderr just in case __expand_tilde_by_ref
-				#doesn't exist everywhere
-				#(I'm a bit worried because of the __ at the begin.
-				#May be this function isn't part of an "official" API.)
+				# redirect stderr just in case
+				# __expand_tilde_by_ref doesn't exist everywhere
+				# (I'm a bit worried because of the __
+				# at the begin. May be this function isn't part
+				# of an "official" API.)
 				__expand_tilde_by_ref cur 2>/dev/null
 				_filedir "pot"
 			fi
@@ -502,7 +517,8 @@ _john()
 			;;
 		-?(-)co?(n|nf|nfi|nfig)+(=|:)*)
 			if [[ "${valopts}" == *--config=* ]] ; then
-				# if --config= is used, john always looks for files in $PWD
+				# if --config= is used, john always looks
+				# for files in $PWD
 				# (tested for system-wide and local builds)
 				cur=${cur#*[=:]}
 				__expand_tilde_by_ref cur 2>/dev/null
@@ -542,16 +558,17 @@ _john()
 				cur=`echo ${cur#*[=:]}|LC_ALL=C tr a-z A-Z`
 				COMPREPLY=( $(compgen -W "LIST" -- ${cur}) )
 			else
-				if [[ "${hidden}" == *--subformat=* ]] ; then
+				if [[ "${valopts}" == *--subformat=* ]] ; then
 					cur=`echo ${cur#*[=:]}|LC_ALL=C tr A-Z a-z`
-					# Should I test if --format=crypt (or -fo:crypt ...) is specified?
+					# Should I test if --format=crypt
+					# (or -fo:crypt ...) is specified?
 					# Should I really parse the output of
-					# 	$[first} --test --format=crypt --subformat=?
-					# (BTW: The output is wrong. It lists upper case formats,
-					# but expects lower case instead)
-					# should I even test this (with --test=0, and filter out those
-					# with a message:
-					# appears to be unsupported on this system; will not load such hashes.
+					# 	$[first} --test --format=crypt \
+					# 	--subformat=?
+					# should I even test this (with --test=0,
+					# and filter out those with a message:
+					# "appears to be unsupported on this
+					# system; will not load such hashes."?
 					subformats=`${first} --test=0 --format=crypt --subformat=? 2>&1|sed -n 's#,# #g;/^Subformat / s#^[^:]*:\(.*\)$#\L\1# p'`
 					COMPREPLY=( $(compgen -W "${subformats}" -- ${cur}) )
 				fi
@@ -560,7 +577,8 @@ _john()
 			;;
 		-?(-)+(pla?(t|tf|tfo|tfor|tform)|d?(e|ev|evi|evic|evice))+(=|:)[Ll]?([Ii]|[Ii][Ss]|[Ii][Ss][Tt]))
 			list=`${first} --list=\? 2>/dev/null|sed 's#\(,\)\?\( or\)\?[ ]*[<].*$##; s#,##g'`
-			# Only complete to lIST if --list=cuda-devices and --list=opencl-devices don't exist
+			# Only complete to lIST if --list=cuda-devices 
+			# and --list=opencl-devices don't exist
 			# CUDA doesn't allow --device=LIST
 			# workaround: check if --platform= is allowed
 			if [[ "${valopts}" == *--platform=* && "_${list}" != *-devices* ]] ; then
@@ -576,8 +594,8 @@ _john()
 			# --device=LIST isn't supported for CUDA, but for CUDA
 			# --platform= is not a valid option
 			if [[ "${valopts}" == *--platform=* && "_${list}" != *-devices* ]] ; then
-				# Calling john --platform=LIST just to find possible completions
-				# will take too long
+				# Calling john --platform=LIST just to fin
+				# possible completions will take too long
 				cur=${cur#*[=:]}
 				COMPREPLY=( $(compgen -W "LIST N" -- ${cur}) )
 			fi
@@ -607,32 +625,36 @@ _john()
 			return 0
 			;;
 		-?(-)l?(i|is|ist)+(=|:)*)
-			if [[ "${hidden}" == *--list=* || "${valopts}" == *--list=* ]] ; then
-				#meanwhile, there can be more than one option name starting with l...
+			if [[ "${valopts}" == *--list=* ]] ; then
+				# in newer jumbo versions, there can be
+				# more than one option name starting with l...
 				if [[ "${cur#*l}" == [=:]* ]] ; then
 					if [[ `echo "${valopts}"|grep -c "^-*${cur%[=:]*}"` -ne 1 ]] ; then
 						return 0
 					fi
 				fi
 				cur=${cur#*[=:]}
-				# the --list=? output changed, that's why a more complex regex is used
-				# to cover all cases.
-				# Meanwhile, even --list=format-methods[:WHICH] works
-				# (or --list:format-methods[:WHICH] or --list:format-methods=WHICH, but
-				# not --list:format-methods=WHICH)
-				# format-methods[:WHICH],
+				# the --list=? output changed, that's why a more
+				# complex regex is used to cover all cases.
+				# Meanwhile, even --list=format-methods[:WHICH]
+				# works (or --list:format-methods[:WHICH] or
+				# --list:format-methods=WHICH, but not
+				# --list=format-methods[=WHICH])
 				list=`${first} --list=\? 2>/dev/null|sed 's#\(,\)\?\(or\)\?[ ]*[<].*$##; s#,##g'`
 				if [[ $? -eq 0 ]] ; then
-					# add "?" to the list of possible completions, but don't add any
+					# add "?" to the list of possible
+					# completions, but don't add any
 					# section names like "Options"...
 					if [[ "${list}" == *help* ]] ; then
 						# Don't advertise --list=?
 						COMPREPLY=( $(compgen -W "${list}" -- ${cur}) )
 					else
-						# Add "?" to the possible completions
+						# Add "?" to the possible
+						# completions
 						COMPREPLY=( $(compgen -W "${list} ?" -- ${cur}) )
 					fi
-					# if the only value contains a ':', special treatment required
+					# if the only value contains a ':',
+					# special treatment required
 					if [[ ${#COMPREPLY[@]} -eq 1 && "_${COMPREPLY[0]}" == _*:* ]] ; then
 						if [[ "_${COMPREPLY[0]}" == _*\[:* ]] ; then
 							COMPREPLY[0]=${COMPREPLY[0]%\[*}
@@ -652,13 +674,13 @@ _john()
 			return 0;
 			;;
 		-*)
-			compreplya=`compgen -W "${options} ${hidden}" -- ${cur}`
+			compreplya=`compgen -W "${options}" -- ${cur}`
 			if [[ "_${compreplya}_" == "__" ]] ; then
 				cur="-${cur}"
-				compreplya=`compgen -W "${options} ${hidden}" -- ${cur}`
+				compreplya=`compgen -W "${options}" -- ${cur}`
 			fi
-			compreplyb=`compgen -W "${valopts} ${hidden}" -- ${cur}`
-			COMPREPLY=( $(compgen -W "${options} ${hidden}" -- ${cur}) )
+			compreplyb=`compgen -W "${valopts}" -- ${cur}`
+			COMPREPLY=( $(compgen -W "${options}" -- ${cur}) )
 			if [[ "_${compreplya}" == "_${compreplyb}" ]] ; then
 				compopt -o nospace
 			fi


### PR DESCRIPTION
Bash completion should add a trailing space for options without
parameters. This didn't work for hidden options.
$ ./john -n[tab]
would complete to
$ ./john --nolog
without adding a trailing space.
(The excuse is that in older versions, all hidden options had
parameters.)
This commit fixes the problem, which otherwise would only get
worse if we move more options from the regular usage output
to the output of --list=hidden-options.

In addition, some comments have been cleaned up or reformatted.
