### PR TITLE
Fix bash completion for hidden options

### DIFF
--- a/run/john.bash_completion
+++ b/run/john.bash_completion
@@ -139,15 +139,15 @@ _john()
 #	All options (the '=' will be removed for options with an optional value)
 	options=""
 # FIXME: How do I suppress the error message if someone tries to be clever: cd run; ./john --[tab] ???
-	options="`( ${first} 2>/dev/null|sed -n -e 's#^ *\(--[a-z-]*=\?\(LIST\)\?\).*$#\1#' -e '/^--/ p'; ./john --list=hidden-options 2>/dev/null|sed -n -e 's#^\(--[a-z-]*=\?\).*$#\1#' -e '/--/ p')` --stdin"
-	if [[ "_${options}" == "_ --stdin" ]] ; then
+	options="`( ${first} 2>/dev/null|sed -n -e 's#^ *\(--[a-z-]*=\?\(LIST\)\?\).*$#\1#' -e '/^--/ p'; echo --stdin; ${first} --list=hidden-options 2>/dev/null|sed -n -e 's#^\(--[a-z-]*=\?\).*$#\1#' -e '/--/ p')`"
+	if [[ "_${options}" == "_--stdin" ]] ; then
 		_filedir_xspec 2> /dev/null
 		return 0
 	fi
 
 #	Just those options that can be used together with a value,
 #	even if that value is optional:
-	valopts=`${first} 2>/dev/null|grep '^ *--[a-z\[-]*='|grep -v '^ *--subformat='|sed 's#^ *\([a-z=-]*\).*$#\1#'`
+	valopts=`echo "$options"|grep '^ *--[a-z\[-]*='|grep -v '^ *--subformat='|sed 's#^ *\([a-z=-]*\).*$#\1#'`
 #	This is used to decide whether or not the completion should add
 #	a trailing space.
 #	(That means, for a jumbo build, --rules doesn't get a trailing space,


### PR DESCRIPTION
This commit fixes 2 bugs introduced with previous bash completion change:
1. Bash completion didn't work for hidden options if the john binary wasn't started from within the run directory
2. completion for hidden options always added a trailng space, even if a value had to be added after the = sign.
