### PR TITLE
Fix bash completion for --subformat

### DIFF
--- a/doc/README.bash-completion
+++ b/doc/README.bash-completion
@@ -203,10 +203,6 @@ dynamic_1003  dynamic_12    dynamic_2     dynamic_27    dynamic_8
 dynamic_1004  dynamic_13    dynamic_20    dynamic_28    dynamic_9
 dynamic_1005  dynamic_14    dynamic_21    dynamic_29
 
-The list of dynamic formats available can also be listed using this command:
-$ ./john --subformat=LIST
-(Jumbo versions only)
-
 
 	--rules and --single
 

--- a/run/john.bash_completion
+++ b/run/john.bash_completion
@@ -147,7 +147,7 @@ _john()
 
 #	Just those options that can be used together with a value,
 #	even if that value is optional:
-	valopts=`echo "$options"|grep '^ *--[a-z\[-]*='|grep -v '^ *--subformat='|sed 's#^ *\([a-z=-]*\).*$#\1#'`
+	valopts=`echo "$options"|grep '^ *--[a-z\[-]*='|sed 's#^ *\([a-z=-]*\).*$#\1#'`
 #	This is used to decide whether or not the completion should add
 #	a trailing space.
 #	(That means, for a jumbo build, --rules doesn't get a trailing space,
@@ -555,9 +555,14 @@ _john()
 			;;
 		-?(-)su?(b|bf|bfo|bfor|bform|bforma|bformat)+(=|:)*)
 			if [[ "${options}" == *--subformat=LIST* ]] ; then
+				# may be this deprecated version should be
+				# ignored!
 				cur=`echo ${cur#*[=:]}|LC_ALL=C tr a-z A-Z`
 				COMPREPLY=( $(compgen -W "LIST" -- ${cur}) )
 			else
+				# possible subformats for --format=crypt
+				# (descrypt, md5crypt, bcrypt, sha256crypt,
+				# sha512crypt)
 				if [[ "${valopts}" == *--subformat=* ]] ; then
 					cur=`echo ${cur#*[=:]}|LC_ALL=C tr A-Z a-z`
 					# Should I test if --format=crypt
@@ -569,7 +574,7 @@ _john()
 					# and filter out those with a message:
 					# "appears to be unsupported on this
 					# system; will not load such hashes."?
-					subformats=`${first} --test=0 --format=crypt --subformat=? 2>&1|sed -n 's#,# #g;/^Subformat / s#^[^:]*:\(.*\)$#\L\1# p'`
+					subformats=`${first} --test=0 --format=crypt --subformat=\? 2>&1|sed -n 's#,# #g;/^Subformat / s#^[^:]*:\(.*\)$#\L\1# p'`
 					COMPREPLY=( $(compgen -W "${subformats}" -- ${cur}) )
 				fi
 			fi
@@ -594,7 +599,7 @@ _john()
 			# --device=LIST isn't supported for CUDA, but for CUDA
 			# --platform= is not a valid option
 			if [[ "${valopts}" == *--platform=* && "_${list}" != *-devices* ]] ; then
-				# Calling john --platform=LIST just to fin
+				# Calling john --platform=LIST just to find
 				# possible completions will take too long
 				cur=${cur#*[=:]}
 				COMPREPLY=( $(compgen -W "LIST N" -- ${cur}) )


### PR DESCRIPTION
I can't test this on OS X, but for Linux this works:

$ ./john -su[tab]
completes to
$ ./john --subformat=
(without a trailing space) and
$ ./john --subformat=[tab][tab]
lists these possible completions:
bcrypt       descrypt     md5crypt     sha256crypt  sha512crypt
