### PR TITLE
Refer to "doc/OPTIONS" for help regarding --fix-state-delay=N

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -292,7 +292,7 @@ void print_hidden_usage(void)
 	puts("--min-length=N            request a minimum candidate length");
 	puts("--max-length=N            request a maximum candidate length");
 	puts("--field-separator-char=C  use 'C' instead of the ':' in input and pot files");
-	puts("--fix-state-delay=N       performance tweak, see documentation");
+	puts("--fix-state-delay=N       performance tweak, see doc/OPTIONS");
 	puts("--nolog                   disables creation and writing to john.log file");
 	puts("--log-stderr              log to screen instead of file");
 	puts("--raw-always-valid=C      if C is 'Y' or 'y', then the dynamic format will");


### PR DESCRIPTION
All the other options mention specific files in the doc
subdirectory, e.g., "see doc/OPTIONS" instead of just
"see documentation".
The hidden option --fix-state-delay=N was the only exception.
