### PR TITLE
Fix broken links in source code

### DIFF
--- a/src/NETLM_fmt_plug.c
+++ b/src/NETLM_fmt_plug.c
@@ -25,7 +25,7 @@
  * broadcasts, IE, Outlook, social engineering, ...).
  *
  * [1] http://davenport.sourceforge.net/ntlm.html#theLmResponse
- * [2] http://www.foofus.net/fizzgig/fgdump/
+ * [2] http://www.foofus.net/~fizzgig/fgdump/
  * [3] http://ettercap.sourceforge.net/
  * [4] http://www.oxid.it/cain.html
  * [5] http://www.foofus.net/jmk/smbchallenge.html

--- a/src/NETLMv2_fmt_plug.c
+++ b/src/NETLMv2_fmt_plug.c
@@ -32,7 +32,7 @@
  * broadcasts, IE, Outlook, social engineering, ...).
  *
  * [1] http://davenport.sourceforge.net/ntlm.html#theLmv2Response
- * [2] http://www.foofus.net/fizzgig/fgdump/
+ * [2] http://www.foofus.net/~fizzgig/fgdump/
  * [3] http://ettercap.sourceforge.net/
  * [4] http://www.oxid.it/cain.html
  * [5] http://www.foofus.net/jmk/smbchallenge.html

--- a/src/NETNTLM_fmt_plug.c
+++ b/src/NETNTLM_fmt_plug.c
@@ -25,8 +25,8 @@
  * trickery may actually be as an exercise for the reader (HINT: Karma, NMB
  * broadcasts, IE, Outlook, social engineering, ...).
  *
- * [1] http://davenport.sourceforge.net/ntlm.html#theNtLmResponse
- * [2] http://www.foofus.net/fizzgig/fgdump/
+ * [1] http://davenport.sourceforge.net/ntlm.html#theNtlmResponse
+ * [2] http://www.foofus.net/~fizzgig/fgdump/
  * [3] http://ettercap.sourceforge.net/
  * [4] http://www.oxid.it/cain.html
  * [5] http://www.foofus.net/jmk/smbchallenge.html

--- a/src/NETNTLMv2_fmt_plug.c
+++ b/src/NETNTLMv2_fmt_plug.c
@@ -31,7 +31,7 @@
  * broadcasts, IE, Outlook, social engineering, ...).
  *
  * [1] http://davenport.sourceforge.net/ntlm.html#theNtlmv2Response
- * [2] http://www.foofus.net/fizzgig/fgdump/
+ * [2] http://www.foofus.net/~fizzgig/fgdump/
  * [3] http://ettercap.sourceforge.net/
  * [4] http://www.oxid.it/cain.html
  * [5] http://www.foofus.net/jmk/smbchallenge.html

--- a/src/chap_fmt_plug.c
+++ b/src/chap_fmt_plug.c
@@ -10,8 +10,9 @@
  *
  * References:
  *
- * http://ftp.samba.org/pub/unpacked/ppp/pppd/chap-md5.c
- * http://www.blackhat.com/presentations/bh-usa-05/bh-us-05-Dwivedi-update.pdf */
+ * ftp://ftp.samba.org/pub/unpacked/ppp/pppd/chap-md5.c
+ * http://www.blackhat.com/presentations/bh-usa-05/bh-us-05-Dwivedi-update.pdf
+ */
 
 #include "md5.h"
 #include <string.h>

--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -397,6 +397,9 @@ static void init(struct fmt_main *self)
 	// http://www.garykessler.net/library/file_sigs.html
 	// http://en.wikipedia.org/wiki/List_of_file_signatures
 	// http://toorcon.techpathways.com/uploads/headersig.txt
+	// 	FIXME: not available, 2012-12-28)
+	// 	archive.org still has a version:
+	// 	http://web.archive.org/web/20110725085828/http://toorcon.techpathways.com/uploads/headersig.txt
 	// there are many more.
 
 //case 1: // DOC/XLS

--- a/src/putty2john.c
+++ b/src/putty2john.c
@@ -4,7 +4,8 @@
  * p-ppk-crack v0.5 made by michu@neophob.com — PuTTY private key cracker
  *
  * Source code based on putty svn version, check
- * http://chiark.greenend.org.uk/~sgtatham/putty/licence.html. */
+ * http://www.chiark.greenend.org.uk/~sgtatham/putty/licence.html
+ */
 
 #ifndef PUTTY_COMMON_H
 #define PUTTY_COMMON_H

--- a/src/putty_fmt_plug.c
+++ b/src/putty_fmt_plug.c
@@ -6,7 +6,8 @@
  * p-ppk-crack v0.5 made by michu@neophob.com — PuTTY private key cracker
  *
  * Source code based on putty svn version, check
- * http://chiark.greenend.org.uk/~sgtatham/putty/licence.html. */
+ * http://www.chiark.greenend.org.uk/~sgtatham/putty/licence.html
+ */
 
 #include <string.h>
 #include "arch.h"


### PR DESCRIPTION
For  http://www.foofus.net/, I got:
Read error (Connection reset by peer) in headers

Archive.org still has the old contents, but got a redirect to
http://www.foofus.net/~fizzgig/fgdump/
from
http://www.foofus.net/fizzgig/fgdump/
on 26.07.2011 02:47:49

I did not yet update the foofus.net links to
http://web.archive.org/web/20110726024907/http://www.foofus.net/~fizzgig/fgdump/
or
http://web.archive.org/web/20090212071450/http://www.foofus.net/jmk/smbchallenge.html
