### PR TITLE
Fix "Compiler error in ./john.conf at line 612: Unknown identifier"

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -512,6 +512,10 @@ MinLen = 0
 MaxLen = 7
 CharCount = 69
 
+# See ../doc/EXTERNAL for help about defining external modes,
+# which external functions and pre-defined variables
+# can be used
+#
 # Some pre-defined word filters
 [List.External:Filter_Alpha]
 void filter()
@@ -605,11 +609,7 @@ void generate()
 		word[i--] = 'A';	// Yes, move to the left, and repeat
 	else				// No
 
-	// For LanMan, the maximum password length is 7.
-	// If we use the new variable "cipher_limit" instead,
-	// the same external mode can be used for other formats
-	// with a different maximum password length.
-	if (length < max_length) {
+	if (length < maxlength) {
 		word[i = ++length] = 0;	// Switch to the next length
 		while (i--)
 			word[i] = 'A';
@@ -1359,12 +1359,6 @@ void generate()
 
 	c = minc;
 
-	// "cipher_limit" is a new predefined variable, see ../doc/EXTERNAL
-	// john sets this variable to the maximum plaintext length
-	// of the format or to the length from --stdout[=LENGTH]
-	// Password candidates longer than "cipher_limit" would be cut to
-	// length "cipher_limit" anyway, so the external mode would produce
-	// duplicate password candidates if we didn't stop here.
 	if (++length > maxlength)
 		c = 0; // Will NUL out the next "word" and thus terminate
 }
@@ -1769,7 +1763,10 @@ void init()
 		minlength = req_minlen;
 	else
 		minlength = 1;
+
 	// Maximum password length to try, must be at least same as minlength
+	// This external mode's default maximum length can be adjusted
+	// using --max-length= on the command line
 	if (req_maxlen)
 		maxlength = req_maxlen;
 	else


### PR DESCRIPTION
which occurred when using
$ ./john --list=ext-filters-only

Also, remove some comments regarding "cipher_limit" which
after commit f6a6c2214550131623620b33cb9b63bc41818a96 were
confusing instead of helpful
