### PR TITLE
expose markov stats file as command line option

### DIFF
--- a/src/mkv.c
+++ b/src/mkv.c
@@ -330,7 +330,14 @@ void get_markov_options(struct db_main *db,
 		error();
 	}
 
-	*statfile = cfg_get_param(SECTION_MARKOV, mode, "Statsfile");
+	if (options.mkv_stats == NULL) 
+	{
+		*statfile = cfg_get_param(SECTION_MARKOV, mode, "Statsfile");
+	} 
+	else 
+	{
+		*statfile = options.mkv_stats;
+	}
 	if(*statfile == NULL)
 	{
 		log_event("Statsfile not defined");

--- a/src/options.c
+++ b/src/options.c
@@ -72,6 +72,8 @@ static struct opt_entry opt_list[] = {
 		0, 0, OPT_FMT_STR_ALLOC, &options.charset},
 	{"markov", FLG_MKV_SET, FLG_CRACKING_CHK,
 		0, 0, OPT_FMT_STR_ALLOC, &options.mkv_param},
+	{"markov-stats", FLG_MKV_SET, FLG_CRACKING_CHK,
+		0, 0, OPT_FMT_STR_ALLOC, &options.mkv_stats},
 	{"external", FLG_EXTERNAL_SET, FLG_EXTERNAL_CHK,
 		0, OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &options.external},
 	{"stdout", FLG_STDOUT, FLG_STDOUT,
@@ -187,6 +189,7 @@ static struct opt_entry opt_list[] = {
 "--rules[=SECTION]         enable word mangling rules for wordlist modes\n" \
 "--incremental[=MODE]      \"incremental\" mode [using section MODE]\n" \
 "--markov[=OPTIONS]        \"Markov\" mode (see doc/MARKOV)\n" \
+"--markov-stats[=FILE]     \"Markov\" stats file (see doc/MARKOV)\n" \
 "--external=MODE           external mode or word filter\n" \
 "--stdout[=LENGTH]         just output candidate passwords [cut at LENGTH]\n" \
 "--restore[=NAME]          restore an interrupted session [called NAME]\n" \

--- a/src/options.h
+++ b/src/options.h
@@ -157,6 +157,7 @@ struct options_main {
 
 /* Markov stuff */
 	char *mkv_param;
+	char *mkv_stats;
 
 /* Maximum plaintext length for stdout mode */
 	int length;


### PR DESCRIPTION
I'm just tired of editing john.conf each time I have new stats file. Therefore, I think it is useful. 
