### PR TITLE
Add support for cracking Siemens S7 authentication protocol hashes

### DIFF
--- a/run/s7tojohn.py
+++ b/run/s7tojohn.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+"""
+
+s7tojohn.py, parse .pcap files and output JtR compatible hashes.
+Extended by Narendra Kangralkar <narendrakangralkar at gmail.com>
+and Dhiru Kholia <dhiru at openwall.com>
+
+S7 protocol, is used for communication between Engineering Stations,
+SCADA, HMI & PLC and can be protected by password.
+
+Original PoC Authors: Alexander Timorin, Dmitry Sklyarov
+http://scadastrangelove.org
+
+"""
+
+
+import logging
+l = logging.getLogger("scapy.runtime")
+l.setLevel(49)
+import sys
+from binascii import hexlify
+try:
+    from scapy.all import rdpcap
+except ImportError:
+    print "please install scapy: http://www.secdev.org/projects/scapy/ "
+    sys.exit()
+
+
+def get_challenge_response(cfg_pcap_file):
+    r = rdpcap(cfg_pcap_file)
+
+    lens = map(lambda x: x.len, r)
+    pckt_lens = dict([(i, lens[i]) for i in range(0, len(lens))])
+
+    # try to find challenge packet
+    pckt_108 = 0  # challenge packet (from server)
+    for (pckt_indx, pckt_len) in pckt_lens.items():
+        if pckt_len + 14 == 108 and hexlify(r[pckt_indx].load)[14:24] == '7202002732':
+            pckt_108 = pckt_indx
+            break
+
+    # try to find response packet
+    pckt_141 = 0  # response packet (from client)
+    _t1 = dict([(i, lens[i]) for i in pckt_lens.keys()[pckt_108:]])
+    for pckt_indx in sorted(_t1.keys()):
+        pckt_len = _t1[pckt_indx]
+        if pckt_len + 14 == 141 and hexlify(r[pckt_indx].load)[14:24] == '7202004831':
+            pckt_141 = pckt_indx
+            break
+
+    # try to find auth result packet
+    pckt_84 = 0  # auth answer from plc: pckt_len==84 -> auth ok
+    pckt_92 = 0  # auth answer from plc: pckt_len==92 -> auth bad
+    for pckt_indx in sorted(_t1.keys()):
+        pckt_len = _t1[pckt_indx]
+        if pckt_len + 14 == 84 and hexlify(r[pckt_indx].load)[14:24] == '7202000f32':
+            pckt_84 = pckt_indx
+            assert(pckt_84)
+            break
+        if pckt_len + 14 == 92 and hexlify(r[pckt_indx].load)[14:24] == '7202001732':
+            pckt_92 = pckt_indx
+            assert(pckt_92)
+            break
+
+    # print "found packets indeces: pckt_108=%d, pckt_141=%d, pckt_84=%d, pckt_92=%d" % (pckt_108, pckt_141, pckt_84, pckt_92)
+    # if pckt_84:
+    #    print "auth ok"
+    # else:
+    #    print "auth bad. for brute we need right auth result. exit"
+    #    sys.exit()
+
+    challenge = None
+    response = None
+
+    raw_challenge = hexlify(r[pckt_108].load)
+    if raw_challenge[46:52] == '100214' and raw_challenge[92:94] == '00':
+        challenge = raw_challenge[52:92]
+        # print "found challenge: %s" % challenge
+    else:
+        print >> sys.stderr, "cannot find challenge for %s. exiting..." % cfg_pcap_file
+        return
+
+    raw_response = hexlify(r[pckt_141].load)
+    if raw_response[64:70] == '100214' and raw_response[110:112] == '00':
+        response = raw_response[70:110]
+        # print "found  response: %s" % response
+    else:
+        print >> sys.stderr, "cannot find response for %s. exiting..." % cfg_pcap_file
+        return
+
+    if pckt_84:
+        outcome = 1
+    else:
+        outcome = 0
+    print "%s:$siemens-s7$%s$%s$%s" % (cfg_pcap_file, outcome, challenge, response)
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) < 2:
+        print >> sys.stderr, "Usage: %s <.pcap files>" % sys.argv[0]
+        sys.exit(-1)
+
+    for j in range(1, len(sys.argv)):
+        data = get_challenge_response(sys.argv[j])

--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -1,0 +1,257 @@
+/* Siemens S7 authentication protocol cracker. Written  by Narendra Kangralkar
+ * <narendrakangralkar at gmail.com> and Dhiru Kholia <dhiru at openwall.com>.
+ *
+ * This software is Copyright (c) 2013, Dhiru Kholia <dhiru.kholia at gmail.com>
+ * and Narendra Kangralkar <narendrakangralkar at gmail.com>  and it is hereby
+ * released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted.
+ */
+
+#include <openssl/sha.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "options.h"
+#include "gladman_hmac.h"
+#ifdef _OPENMP
+static int omp_t = 1;
+#include <omp.h>
+#define OMP_SCALE               64
+#endif
+
+#define FORMAT_LABEL		"siemens-s7"
+#define FORMAT_NAME		"Siemens S7 HMAC-SHA-1"
+#define ALGORITHM_NAME		"32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT	""
+#define BENCHMARK_LENGTH	-1
+#define PLAINTEXT_LENGTH	125
+#define BINARY_SIZE		20
+#define SALT_SIZE		20
+#define MIN_KEYS_PER_CRYPT	1
+#define MAX_KEYS_PER_CRYPT	1
+
+static struct fmt_tests s7_tests[] = {
+	{"$siemens-s7$1$599fe00cdb61f76cc6e949162f22c95943468acb$002e45951f62602b2f5d15df217f49da2f5379cb", "123"},
+	{"$siemens-s7$0$387c1fe4ce97e0e71f5a93b4a9557a947cd40d6c$d7789feee651559a09e2f2d92b57306d2835e209", "321"},
+	{NULL}
+};
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static ARCH_WORD_32 (*crypt_out)[BINARY_SIZE / sizeof(ARCH_WORD_32)];
+
+unsigned char *challenge;
+
+static void init(struct fmt_main *self)
+{
+#ifdef _OPENMP
+	omp_t = omp_get_max_threads();
+	self->params.min_keys_per_crypt *= omp_t;
+	omp_t *= OMP_SCALE;
+	self->params.max_keys_per_crypt *= omp_t;
+#endif
+	saved_key = mem_calloc_tiny(sizeof(*saved_key) *
+			self->params.max_keys_per_crypt, MEM_ALIGN_WORD);
+	crypt_out = mem_calloc_tiny(sizeof(*crypt_out) * self->params.max_keys_per_crypt, MEM_ALIGN_WORD);
+}
+
+static int valid(char *ciphertext, struct fmt_main *self)
+{
+	char *p;
+	char *ctcopy;
+	char *keeptr;
+	int outcome;
+	if (strncmp(ciphertext, "$siemens-s7$", 12) != 0)
+		return 0;
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += 12;		/* skip over "$siemens-s7$" */
+	if ((p = strtok(ctcopy, "$")) == NULL)	/* outcome */
+		goto bail;
+	outcome = atoi(p);
+	if (outcome != 1 && outcome != 0)
+		goto bail;
+	if ((p = strtok(NULL, "$")) == NULL)	/* challenge */
+		goto bail;
+	if (strlen(p) != 40)
+		goto bail;
+	MEM_FREE(keeptr);
+	return 1;
+bail:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+static void *get_salt(char *ciphertext)
+{
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	char *p;
+	int i;
+	static unsigned char lchallenge[20];
+	ctcopy += 12;		/* skip over "$siemens-s7$" */
+	p = strtok(ctcopy, "$");
+	p = strtok(NULL, "$");
+	for (i = 0; i < 20; i++)
+		lchallenge[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	MEM_FREE(keeptr);
+	return (void *)lchallenge;
+}
+
+static void *get_binary(char *ciphertext)
+{
+	static union {
+		unsigned char c[BINARY_SIZE];
+		ARCH_WORD dummy;
+	} buf;
+	unsigned char *out = buf.c;
+	char *p;
+	int i;
+	p = strrchr(ciphertext, '$') + 1;
+	for (i = 0; i < BINARY_SIZE; i++) {
+		out[i] =
+		    (atoi16[ARCH_INDEX(*p)] << 4) |
+		    atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+
+	return out;
+}
+
+static int binary_hash_0(void *binary) { return *(ARCH_WORD_32 *)binary & 0xf; }
+static int binary_hash_1(void *binary) { return *(ARCH_WORD_32 *)binary & 0xff; }
+static int binary_hash_2(void *binary) { return *(ARCH_WORD_32 *)binary & 0xfff; }
+static int binary_hash_3(void *binary) { return *(ARCH_WORD_32 *)binary & 0xffff; }
+static int binary_hash_4(void *binary) { return *(ARCH_WORD_32 *)binary & 0xfffff; }
+static int binary_hash_5(void *binary) { return *(ARCH_WORD_32 *)binary & 0xffffff; }
+static int binary_hash_6(void *binary) { return *(ARCH_WORD_32 *)binary & 0x7ffffff; }
+
+static int get_hash_0(int index) { return crypt_out[index][0] & 0xf; }
+static int get_hash_1(int index) { return crypt_out[index][0] & 0xff; }
+static int get_hash_2(int index) { return crypt_out[index][0] & 0xfff; }
+static int get_hash_3(int index) { return crypt_out[index][0] & 0xffff; }
+static int get_hash_4(int index) { return crypt_out[index][0] & 0xfffff; }
+static int get_hash_5(int index) { return crypt_out[index][0] & 0xffffff; }
+static int get_hash_6(int index) { return crypt_out[index][0] & 0x7ffffff; }
+
+static void set_salt(void *salt)
+{
+	challenge = (unsigned char*)salt;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	int count = *pcount;
+	int index = 0;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index++)
+	{
+		unsigned char mackey[20];
+		SHA_CTX ctx;
+		SHA1_Init(&ctx);
+		SHA1_Update(&ctx, saved_key[index], strlen(saved_key[index]));
+		SHA1_Final(mackey, &ctx);
+		hmac_sha1(mackey, 20, challenge, 20, (unsigned char*)crypt_out[index], 20);
+	}
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index = 0;
+#ifdef _OPENMP
+	for (; index < count; index++)
+#endif
+		if (!memcmp(binary, crypt_out[index], BINARY_SIZE))
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+static void s7_set_key(char *key, int index)
+{
+	int saved_key_length = strlen(key);
+	if (saved_key_length > PLAINTEXT_LENGTH)
+		saved_key_length = PLAINTEXT_LENGTH;
+	memcpy(saved_key[index], key, saved_key_length);
+	saved_key[index][saved_key_length] = 0;
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+struct fmt_main fmt_s7 = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		DEFAULT_ALIGN,
+		SALT_SIZE,
+		DEFAULT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		s7_tests
+	}, {
+		init,
+		fmt_default_done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		valid,
+		fmt_default_split,
+		get_binary,
+		get_salt,
+		fmt_default_source,
+		{
+			binary_hash_0,
+			binary_hash_1,
+			binary_hash_2,
+			binary_hash_3,
+			binary_hash_4,
+			binary_hash_5,
+			binary_hash_6
+		},
+		fmt_default_salt_hash,
+		set_salt,
+		s7_set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			get_hash_0,
+			get_hash_1,
+			get_hash_2,
+			get_hash_3,
+			get_hash_4,
+			get_hash_5,
+			get_hash_6
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};


### PR DESCRIPTION
Add support for cracking Siemens S7 authentication protocol hashes.

Usage:

```
✗ ../run/s7tojohn.py target.pcap > hash

✗ cat hash 
target.pcap:$siemens-s7$1$62e375eb621bba3a7af9fc06f32d952fcedeec7b$fc8c6bfe744ef880cac56f073829c82d1418f8a9

✗ ../run/john hash  
Loaded 1 password hash (Siemens S7 HMAC-SHA-1 [32/64])
123              (target.pcap)
```

Thanks to Frank for the feedback.
