### PR TITLE
Prepare Method for PDF

### DIFF
--- a/src/pdf_fmt_plug.c
+++ b/src/pdf_fmt_plug.c
@@ -3,7 +3,10 @@
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
  *
- * Uses code from Sumatra PDF and MuPDF which are under GPL */
+ * Uses code from Sumatra PDF and MuPDF which are under GPL 
+ *
+ * Edited by Shane Quigley 2013
+ */
 
 #include <string.h>
 #include "arch.h"
@@ -231,8 +234,6 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 	if (strncmp(split_fields[1], "$pdf$Standard*", 14) == 0){
 		if(old_valid(split_fields[1], self)) {
 			char * in_new_format = convert_old_to_new(split_fields[1]);
-			//Presume its ok to use the memory in split_fields[1] to hold the
-			//data i  the new format
 			strcpy(split_fields[1], in_new_format);
 			free(in_new_format);
 			return split_fields[1];


### PR DESCRIPTION
As discussed on the [mailing list](http://www.openwall.com/lists/john-dev/2013/01/24/19) I added a prepare method to the pdf_fmt_plug.c.  

The prepare method added to pdf_fmt_plug.c does the following:
- Checks if the format is the old style of pdf format. If it isn't return what prepare normally would otherwise:
- Check if input in the old format is valid. If it isn't return an invalid string otherwise:
- Converts the input to the new format and returns it.

I presumed this was needed for jumbo-8 but if it isn't sorry feel free to reject it and I'll send another pull request to the bleeding branch.
