### PR TITLE
Benchmark-unify: map KRB5 format names

### DIFF
--- a/run/benchmark-unify
+++ b/run/benchmark-unify
@@ -102,6 +102,8 @@ EPiServer SID Hashes	EPiServer SID salted SHA-1
 Eggdrop	Eggdrop Blowfish
 HTTP Digest access authentication	HTTP Digest access authentication MD5
 IPB2 MD5	Invision Power Board 2.x salted MD5
+KRB5 aes256-cts-hmac-sha1-96	Kerberos 5 db etype 18 aes256-cts-hmac-sha1-96
+KRB5 arcfour-hmac	Kerberos 5 db etype 23 rc4-hmac
 Kerberos v4 TGT	Kerberos v4 TGT DES
 Kerberos v5 TGT	Kerberos v5 TGT 3DES
 Lotus5	Lotus Notes/Domino 5


### PR DESCRIPTION
Even though these names have only been used in 1.7.9-jumbo-7+unstable
and 1.7.9-jumbo-8-unstable, make sure they are mapped to the names
that will be used for 1.7.9-jumbo-8.
