### PR TITLE
Fixed bug in office2john.py

### DIFF
--- a/run/office2john.py
+++ b/run/office2john.py
@@ -1923,7 +1923,6 @@ def process_new_office(filename):
         headerLength -= 4
         CSPName = stm.read(headerLength)
         provider = CSPName.decode('utf-16').lower()
-        assert(provider)
         # print provider
         # Encryption verifier
         saltSize = unpack("<I", stm.read(4))[0]


### PR DESCRIPTION
Removed an assert which was causing a error to be thrown on docx generated with office for the mac. Checked all of the sample non hashes on the [wiki](http://openwall.info/wiki/john/sample-non-hashes) and the same output was produced for all of them before and after the change.

Here's the file in question: 
http://ubuntuone.com/5xXslhIqY2sLWZVIpMKzbq
