### PR TITLE
Add ssh2sshng.py utility for converting ssh hashes into sshng hashes

### DIFF
--- a/run/ssh2sshng.py
+++ b/run/ssh2sshng.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+"""Utility to convert old style ssh format hashes into new sshng format hashes."""
+
+import sys
+from sshng2john import RSADSSKey
+import StringIO
+import binascii
+
+
+def process_file(filename):
+    with open(filename, "r") as f:
+        for line in f.readlines():
+            data = line.split(":")
+            assert(len(data) < 3)
+            if len(data) < 2:
+                name = "Unknown"
+            else:
+                name = data[0]
+                data = data[1]
+
+            if data.startswith("$ssh2$"):
+                data = data.split("*")
+                assert(len(data) == 2)
+                data = binascii.unhexlify(data[0][6:])
+                f = StringIO.StringIO(data)
+                f.name = name
+                RSADSSKey.from_private_key(f, '')
+            else:
+                continue
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print >>sys.stderr, "Usage: %s <ssh2john output file(s)>" % sys.argv[0]
+        sys.exit(-1)
+
+    for i in range(1, len(sys.argv)):
+        process_file(sys.argv[i])


### PR DESCRIPTION
For testing you can use the following steps,

```
✗ python ../run/ssh2sshng.py unused/sshdump > sshngdump
✗ ../run/john sshngdump 
Loaded 2 password hashes with 2 different salts (ssh-ng SSH RSA / DSA [32/64])
12345            (rsa_test.key)
12345            (dsa_test.key)
...
guesses: 4  time: 0:00:00:01 0.00% (3)  c/s: 319823  trying: 0101996
```

I was too lazy to add this functionality into the sshng format itself.
