### PR TITLE
Added License to pdf2john

### DIFF
--- a/run/pdf2john.py
+++ b/run/pdf2john.py
@@ -1,6 +1,23 @@
 #!/usr/bin/env python
 
-# Written in 2013 by Shane Quigley, < shane at softwareontheside.info >
+# Copyright (c) 2013 Shane Quigley, < shane at softwareontheside.info >
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of 
+# this software and associated documentation files (the "Software"), to deal in 
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all 
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import re
 import sys


### PR DESCRIPTION
Noticed when going over pull requests for the final report of my project that Dhiru [asked me](https://github.com/magnumripper/JohnTheRipper/pull/156#issuecomment-11959353) to add a license. It's the MIT license ie. Do whatever you want with it just don't remove the copyright and don't hold me liable. It's also GPL compatible.
