### PR TITLE
misc. fixes for zip stuff

### DIFF
--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -297,7 +297,6 @@ static int valid(char *ciphertext, struct fmt_main *self)
 					unsigned char *tbuf = mem_alloc_tiny(complen, MEM_ALIGN_WORD);
 					if (fread(tbuf, 1, complen, in) != complen) {
 						fclose(in);
-						MEM_FREE(tbuf);
 						return 0;
 					}
 					data_len = complen;

--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -558,5 +558,6 @@ int zip2john(int argc, char **argv)
 	for (; i < argc; i++)
 		process_file(argv[i]);
 
+	cleanup_tiny_memory();
 	return 0;
 }


### PR DESCRIPTION
1. Don't use the inappropriate free function in zip format.
2. Don't free memory which will be freed later on in zip format.
3. Use correct free function in zip2john.
