### PR TITLE
timer.h: remove unneeded include (sys/timeb.h)

### DIFF
--- a/src/timer.h
+++ b/src/timer.h
@@ -21,6 +21,7 @@
 #include <time.h>
 
 #if defined (_MSC_VER) || defined (__MINGW32__)
+#include <sys/timeb.h> /* for ftime(), which is not used */
 #undef MEM_FREE
 #include <windows.h>
 #undef MEM_FREE


### PR DESCRIPTION
not only is the header not needed, it was obsoleted in posix
and thus is missing in musl libc.
