### PR TITLE
tcphdr.h: special-case endian.h for mac/bsd

### DIFF
--- a/src/tcphdr.h
+++ b/src/tcphdr.h
@@ -6,7 +6,11 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#ifdef __linux
 #include <endian.h>
+#else
+#include <machine/endian.h>
+#endif
 
 struct tcp_hdr {
 	uint16_t th_sport;


### PR DESCRIPTION
this _should_ work

if it doesn't, add this right down after the endian block:

```
#ifndef __BYTE_ORDER
#define __BYTE_ORDER BYTE_ORDER
#endif
#ifndef __LITTLE_ENDIAN
#define __LITTLE_ENDIAN LITTLE_ENDIAN
#define __BIG_ENDIAN BIG_ENDIAN
#endif
```
