### PR TITLE
Added Python 3 support for pdf2john

### DIFF
--- a/run/pdf2john.py
+++ b/run/pdf2john.py
@@ -23,6 +23,7 @@
 import re
 import sys
 
+PY3 = sys.version_info[0] == 3
 
 class PdfParser:
     def __init__(self, file_name):
@@ -31,7 +32,7 @@ class PdfParser:
         self.encrypted = f.read()
         f.close()
         self.process = True
-        psr = re.compile(r'PDF-\d\.\d')
+        psr = re.compile(b'PDF-\d\.\d')
         try:
             self.pdf_spec = psr.findall(self.encrypted)[0]
         except IndexError:
@@ -50,75 +51,79 @@ class PdfParser:
             return
         object_id = self.get_encrypted_object_id(trailer)
         encryption_dictionary = self.get_encryption_dictionary(object_id)
-        dr = re.compile(r'\d+')
-        vr = re.compile(r'\/V \d')
-        rr = re.compile(r'\/R \d')
+        dr = re.compile(b'\d+')
+        vr = re.compile(b'\/V \d')
+        rr = re.compile(b'\/R \d')
         v = dr.findall(vr.findall(encryption_dictionary)[0])[0]
         r = dr.findall(rr.findall(encryption_dictionary)[0])[0]
-        lr = re.compile(r'\/Length \d+')
+        lr = re.compile(b'\/Length \d+')
         longest = 0
         length = ''
         for le in lr.findall(encryption_dictionary):
             if(int(dr.findall(le)[0]) > longest):
                 longest = int(dr.findall(le)[0])
                 length = dr.findall(le)[0]
-        pr = re.compile(r'\/P -\d+')
+        pr = re.compile(b'\/P -\d+')
         p = pr.findall(encryption_dictionary)[0]
-        pr = re.compile(r'-\d+')
+        pr = re.compile(b'-\d+')
         p = pr.findall(p)[0]
         meta = self.is_meta_data_encrypted(encryption_dictionary)
-        idr = re.compile(r'\/ID\s*\[\s*<\w+>\s*<\w+>\s*\]')
+        idr = re.compile(b'\/ID\s*\[\s*<\w+>\s*<\w+>\s*\]')
         try:
             i_d = idr.findall(trailer)[0] # id key word
         except IndexError:
             # some pdf files use () instead of <>
-            idr = re.compile(r'\/ID\s*\[\s*\(\w+\)\s*\(\w+\)\s*\]')
+            idr = re.compile(b'\/ID\s*\[\s*\(\w+\)\s*\(\w+\)\s*\]')
             i_d = idr.findall(trailer)[0] # id key word
-        idr = re.compile(r'<\w+>')
+        idr = re.compile(b'<\w+>')
         try:
             i_d = idr.findall(trailer)[0]
         except IndexError:
-            idr = re.compile(r'\(\w+\)')
+            idr = re.compile(b'\(\w+\)')
             i_d = idr.findall(trailer)[0]
-        i_d = i_d.replace(r'<','')
-        i_d = i_d.replace(r'>','')
+        i_d = i_d.replace(b'<',b'')
+        i_d = i_d.replace(b'>',b'')
         i_d = i_d.lower()
         passwords = self.get_passwords_for_JtR(encryption_dictionary)
-        output = self.file_name+':$pdf$'+v+'*'+r+'*'+length+'*'+p+'*'+meta+'*'
-        output += str(len(i_d)/2)+'*'+i_d+'*'+passwords
+        output = self.file_name+':$pdf$'+v.decode('ascii')+'*'+r.decode('ascii')+'*'+length.decode('ascii')+'*'
+        output += p.decode('ascii')+'*'+meta+'*'
+        output += str(int(len(i_d)/2))+'*'+i_d.decode('ascii')+'*'+passwords
         sys.stdout.write("%s\n" % output)
 
     def get_passwords_for_JtR(self, encryption_dictionary):
         output = ""
-        letters = ["U", "O"]
-        if("1.7" in self.pdf_spec):
-            letters = ["U", "O", "UE", "OE"]
+        letters = [b"U", b"O"]
+        if(b"1.7" in self.pdf_spec):
+            letters = [b"U", b"O", b"UE", b"OE"]
         for let in letters:
-            pr_str = r'\/' + let + r'\s*\([^)]+\)'
+            pr_str = b'\/' + let + b'\s*\([^)]+\)'
             pr = re.compile(pr_str)
             pas = pr.findall(encryption_dictionary)
             if(len(pas) > 0):
                 pas = pr.findall(encryption_dictionary)[0]
                 #Because regexs in python suck
-                while(pas[-2] == '\\'):
-                    pr_str += r'[^)]+\)'
+                while(pas[-2] == b'\\'):
+                    pr_str += b'[^)]+\)'
                     pr = re.compile(pr_str)
                     pas = pr.findall(encryption_dictionary)[0]
                 output +=  self.get_password_from_byte_string(pas)+"*"
             else:
-                pr = re.compile(let + r'\s*<\w+>')
+                pr = re.compile(let + b'\s*<\w+>')
                 pas = pr.findall(encryption_dictionary)[0]
-                pr = re.compile(r'<\w+>')
+                pr = re.compile(b'<\w+>')
                 pas = pr.findall(pas)[0]
-                pas = pas.replace(r"<","")
-                pas = pas.replace(r">","")
-                output += str(len(pas)/2)+'*'+pas.lower()+'*'
+                pas = pas.replace(b"<",b"")
+                pas = pas.replace(b">",b"")
+                if PY3:
+                    output += str(int(len(pas)/2))+'*'+str(pas.lower(),'ascii')+'*'
+                else:
+                    output += str(int(len(pas)/2))+'*'+pas.lower()+'*'
         return output[:-1]
 
     def is_meta_data_encrypted(self, encryption_dictionary):
-        mr = re.compile(r'\/EncryptMetadata\s\w+')
+        mr = re.compile(b'\/EncryptMetadata\s\w+')
         if(len(mr.findall(encryption_dictionary)) > 0):
-            wr = re.compile(r'\w+')
+            wr = re.compile(b'\w+')
             is_encrypted = wr.findall(mr.findall(encryption_dictionary)[0])[-1]
             if(is_encrypted == "false"):
                 return "0"
@@ -129,33 +134,34 @@ class PdfParser:
 
     def get_encryption_dictionary(self, object_id):
         encryption_dictionary = \
-                self.get_data_between(object_id+" obj", "endobj")
-        for o in encryption_dictionary.split("endobj"):
-            if(object_id+" obj" in o):
+                self.get_data_between(object_id+b" obj", b"endobj")
+        for o in encryption_dictionary.split(b"endobj"):
+            if(object_id+b" obj" in o):
                 encryption_dictionary = o
         return encryption_dictionary
 
     def get_encrypted_object_id(self, trailer):
-        oir = re.compile(r'\/Encrypt\s\d+\s\d\sR')
+        oir = re.compile(b'\/Encrypt\s\d+\s\d\sR')
         object_id = oir.findall(trailer)[0]
-        oir = re.compile(r'\d+ \d')
+        oir = re.compile(b'\d+ \d')
         object_id = oir.findall(object_id)[0]
         return object_id
 
     def get_trailer(self):
-        trailer = self.get_data_between("trailer", ">>")
-        if(trailer == ""):
-            trailer = self.get_data_between("DecodeParms", "stream")
+        trailer = self.get_data_between(b"trailer", b">>")
+        if(trailer == b""):
+            trailer = self.get_data_between(b"DecodeParms", b"stream")
             if(trailer == ""):
                 raise RuntimeError("Can't find trailer")
-        if(trailer != "" and trailer.find("Encrypt") == -1):
+        if(trailer != "" and trailer.find(b"Encrypt") == -1):
+            print(trailer)
             raise RuntimeError("File not encrypted")
         return trailer
 
     def get_data_between(self, s1, s2):
-        output = ""
+        output = b""
         inside_first = False
-        lines = self.encrypted.split('\n')
+        lines = self.encrypted.split(b'\n')
         for line in lines:
             inside_first = inside_first or line.find(s1) != -1
             if(inside_first):
@@ -164,29 +170,47 @@ class PdfParser:
                     break
         return output
 
+    def get_hex_byte(self, o_or_u, i):
+        if PY3:
+            return hex(o_or_u[i]).replace('0x', '')
+        else:
+            return hex(ord(o_or_u[i])).replace('0x', '')
+
     def get_password_from_byte_string(self, o_or_u):
         pas = ""
         escape_seq = False
         escapes = 0
         excluded_indexes = [0, 1, 2]
         #For UE & OE in 1.7 spec
-        if(o_or_u[2] != '('):
-            excluded_indexes.append(3)
+        if not PY3:
+            if(o_or_u[2] != '('):
+                excluded_indexes.append(3)
+        else:
+            if(o_or_u[2] != 40):
+                excluded_indexes.append(3)
         for i in range(len(o_or_u)):
             if(i not in excluded_indexes):
-                if(len(hex(ord(o_or_u[i])).replace('0x', '')) == 1 \
+                if(len(self.get_hex_byte(o_or_u, i)) == 1 \
                    and o_or_u[i] != "\\"[0]):
                     pas += "0"  # need to be 2 digit hex numbers
-                if(o_or_u[i] != "\\"[0] or escape_seq):
+                is_back_slash = True
+                if not PY3:
+                    is_back_slash = o_or_u[i] != "\\"[0]
+                else:
+                    is_back_slash = o_or_u[i] != 92
+                if(is_back_slash or escape_seq):
                     if(escape_seq):
-                        esc = "\\"+o_or_u[i]
+                        if not PY3:
+                            esc = "\\"+o_or_u[i]
+                        else:
+                            esc = "\\"+chr(o_or_u[i])
                         esc = self.unescape(esc)
                         if(len(hex(ord(esc[0])).replace('0x', '')) == 1):
                             pas += "0"
                         pas += hex(ord(esc[0])).replace('0x', '')
                         escape_seq = False
                     else:
-                        pas += hex(ord(o_or_u[i])).replace('0x', '')
+                        pas += self.get_hex_byte(o_or_u, i)
                 else:
                     escape_seq = True
                     escapes += 1


### PR DESCRIPTION
pdf2john.py should now work with Python 3 as well as Python 2. Tested it against all the file from the wiki and it worked fine on:
- Python 3.2.3
- Python 2.7.3

Dhiru @kholia asked me to do this earlier today:
https://github.com/magnumripper/JohnTheRipper/issues/294
