### PR TITLE
PDF Metadata values grabbed by pdf2john

### DIFF
--- a/run/pdf2john.py
+++ b/run/pdf2john.py
@@ -147,7 +147,7 @@ class PdfParser:
 
     def get_xmp_values(self, xmp_metadata_object):
         xmp_metadata_object = xmp_metadata_object.partition(b"stream")[2]
-        xmp_metadata_object = xmp_metadata_object.partition(b"endstreamendobj")[0]
+        xmp_metadata_object = xmp_metadata_object.partition(b"endstream")[0]
         xml_metadata = minidom.parseString(xmp_metadata_object)
         values = []
         values.append(self.get_dc_value("title", xml_metadata))


### PR DESCRIPTION
pdf2john now grabs certain values from the pdfs xmp metadata if the metadata is left unencrypted. At the moment it grabs:
- Title
- Creator/Author
- Subject 
- Tags/Description
- Year of creation
##### Pull request also includes:
- A bug fix for how objects in pdf files are retrieved by pdf2john. This fix probably should be put into unstable.
- A fix for checking if metadata in encrypted in python 3. It previously broke if metadata wasn't encrypted. I've included a sample file on the wiki so something this doesn't happen again.
