### PR TITLE
Update memory.c

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -108,7 +108,7 @@ void *mem_alloc_tiny(size_t size, size_t align)
 			}
 		}
 
-		if (size + mask > MEM_ALLOC_SIZE ||
+		if (size + mask >= MEM_ALLOC_SIZE ||
 		    bufree > MEM_ALLOC_MAX_WASTE)
 			break;
 


### PR DESCRIPTION
break condition is never being met when loading saltless hashes
