### PR TITLE
fix opencl kernel build on macosx

### DIFF
--- a/src/common-opencl.c
+++ b/src/common-opencl.c
@@ -169,14 +169,14 @@ static char *include_source(char *pathname, int dev_id, char *options)
 {
 	static char include[PATH_BUFFER_SIZE];
 
-	sprintf(include, "-I %s %s %s%d %s %s", path_expand(pathname),
+	sprintf(include, "-I%s%s%s%d%s%s", path_expand(pathname),
 	        get_device_type(dev_id) == CL_DEVICE_TYPE_CPU ?
-	        "-DDEVICE_IS_CPU" : "",
-	        "-DDEVICE_INFO=", device_info[dev_id],
+	        " -DDEVICE_IS_CPU" : "",
+	        " -DDEVICE_INFO=", device_info[dev_id],
 #ifdef __APPLE__
-	        "-DAPPLE",
+	        " -DAPPLE",
 #else
-	        gpu_nvidia(device_info[dev_id]) ? "-cl-nv-verbose" : "",
+	        gpu_nvidia(device_info[dev_id]) ? " -cl-nv-verbose" : "",
 #endif
 	        OPENCLBUILDOPTIONS);
 


### PR DESCRIPTION
On OSX (10.9), some OpenCL kernels fail to build because Apple's compiler doesn't accept more than one space character between the arguments:

```
src $ CL_LOG_ERRORS=stdout ../run/john --te --fo=rar-opencl
OpenCL platform 0: Apple, 2 device(s).
Device 1: HD Graphics 5000
[CL_INVALID_BUILD_OPTIONS] : OpenCL Error : clBuildProgram failed: Invalid build options "-I ../run/kernels  -DDEVICE_INFO=258 -DAPPLE  -DHASH_LOOPS=8 -DPLAINTEXT_LENGTH=22"
Break on OpenCLErrorBreak to debug.
Build log: 
Error -43 building kernel. DEVICE_INFO=258
OpenCL error (CL_INVALID_BUILD_OPTIONS) in file (common-opencl.c) at line (222) - (clBuildProgram failed.)
src $
```

I saw that bleeding-jumbo branch fixes this issue, but unfortunately I can't compile it due to an unresolved MD5_body reference in the final linking stage (should I open a new issue about it?). So I propose this temporary fix while the other changes from the bleeding branch aren't merged.
