### PR TITLE
Ignore "reserved" dynamic formats for --list=subformats

### DIFF
--- a/src/dynamic_preloads.c
+++ b/src/dynamic_preloads.c
@@ -3478,14 +3478,14 @@ int IsOMP_Valid(int j) {
 	return 1;
 }
 
-// -1 is NOT valid  ( num > 5000 is 'hidden' values )
+// -1 is NOT valid  ( num >= 5000 is 'hidden' values )
 // 0 is valid, but NOT usable by this build (i.e. no SSE2)
 // 1 is valid.
 int dynamic_IS_VALID(int i)
 {
 	char Type[20];
 	sprintf(Type, "dynamic_%d", i);
-	if (i < 0 || i > 5000)
+	if (i < 0 || i >= 5000)
 		return -1;
 	if (i < 1000) {
 		int j,len;

--- a/src/dynamic_utils.c
+++ b/src/dynamic_utils.c
@@ -66,7 +66,9 @@ void dynamic_DISPLAY_ALL_FORMATS()
 	for (i = 1000; i < 10000; ++i)
 	{
 		char *sz = dynamic_LOAD_PARSER_SIGNATURE(i);
-		if (sz && dynamic_IS_PARSER_VALID(i))
+		if (sz &&
+		    // dynamic_IS_PARSER_VALID(i)) // this would include "reserved" formats 
+		    dynamic_IS_VALID(i) == 1) // skip "reserved" formats 
 			printf ("UserFormat = dynamic_%d  type = %s\n", i, sz);
 	}
 }


### PR DESCRIPTION
Dynamic formats that are ignored for
    ./john --test --format=dynamic
and other commands should also be ignored for
    ./john --list=subformats

There was an inconsistency about the "reserved" formats
(all formats > 5000 vs. all formats >= 5000).
This inconsistency has been removed.
Dynamic formats >= 5000 are reserved now.
These reserved dynamic formats can still be used, if specified exactly:
    ./john --test --format=dynamic_9025
