### PR TITLE
--list=format-tests: Handle tests that contain line feed characters

### DIFF
--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -485,6 +485,11 @@ If an additional option --config=FILE
                           If a format uses encoding specific tests, you can
                           use --encoding=NAME as an additional option to see
                           these encoding specific tests.
+                          If a ciphertext contains line feeds or the separator
+                          character (horizontal tab), just the format name and
+                          the test number are written. If the password contains
+                          line feeds, it will not be written.
+                          (A warning message is written to stderr in this case.)
 --list=subformats	  all the built-in dynamic formats, and exits
                           (replaces the now deprecated --subformat=LIST)
 


### PR DESCRIPTION
Currently, scrypt format has a test where both the ciphertext
and the plaintext contain line feed characters and
horizontal tab characters.

Since .pot files don't work well with line breaks inside of
hashes or passwords, those problematic test cases are ignored.

If the ciphertext is OK, but the password contains a line feed,
the plaintext field is not written to stdout.
(The line just contains 3 fields in this case.)

If the ciphertext contains a line feed character, both the
ciphertext and the plaintext are suppressed.
(A line with just two fields will be written to stdout.)

If the ciphertext contains a separator character (currently '\t'),
the ciphertext and the plaintext will be suppressed.
(A line with just two fields will be written to stdout.)
Otherwise parsing the output of --list=format-tests would be
harder.

If just the plaintext contains separator characters, but no line feeds,
it will not be suppressed.

If some columns are suppressed due to line feed characters or separator
characters, a warning message is written to stderr.

$ ./john --list=format-tests --format=scrypt 2> /dev/null
scrypt  0   $7$C6..../....SodiumChloride$kBGj9fHznVYFQMEn/qDCfrDevf9YDtcDdKvEqHJLV8D    pleaseletmein
scrypt  1
scrypt  2   $7$2/..../....$rNxJWVHNv/mCNcgE/f6/L4zO6Fos5c2uTzhyzoisI62
scrypt  3   $7$86....E....NaCl$xffjQo7Bm/.SKRS4B2EuynbOLjAmXU5AbDbRXhoBl64  password

$ ./john --list=format-tests --format=scrypt > /dev/null
Test scrypt 1: plaintext contains line feed
Test scrypt 1: ciphertext contains line feed or separator character '   '
