### PR TITLE
Add poor OpenMP scalability flag to --list=format-all-details

### DIFF
--- a/src/listconf.c
+++ b/src/listconf.c
@@ -408,6 +408,8 @@ void listconf_parse_late(void)
 			printf(" A $dynamic$ format                  %s\n", (format->params.flags & FMT_DYNAMIC) ? "yes" : "no");
 #ifdef _OPENMP
 			printf(" Parallelized with OpenMP            %s\n", (format->params.flags & FMT_OMP) ? "yes" : "no");
+			if (format->params.flags & FMT_OMP)
+				printf("  Poor OpenMP scalability            %s\n", (format->params.flags & FMT_OMP_BAD) ? "yes" : "no");
 #endif
 			printf("Number of test vectors               %d\n", ntests);
 			printf("Algorithm name                       %s\n", format->params.algorithm_name);


### PR DESCRIPTION
 Parallelized with OpenMP            yes
  Poor OpenMP scalability            no

(indented by 2 spaces, because it will only be listed for
formats with OpenMP support)
