### PR TITLE
dynamic_THIN_FORMAT_LINK: use PASSWORD_HASH_SIZES ...

### DIFF
--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -106,6 +106,7 @@ static DYNAMIC_primitive_funcp _Funcs_1[] =
 #include "misc.h"
 #include "common.h"
 #include "formats.h"
+#include "params.h"
 #include "md5.h"
 #include "md4.h"
 #include "dynamic.h"
@@ -7487,7 +7488,7 @@ struct fmt_main *dynamic_THIN_FORMAT_LINK(struct fmt_main *pFmt, char *ciphertex
 	pFmt->methods.clear_keys = pFmtLocal->methods.clear_keys;
 	pFmt->methods.crypt_all  = pFmtLocal->methods.crypt_all;
 	pFmt->methods.prepare    = pFmtLocal->methods.prepare;
-	for (i = 0; i < 5; ++i)
+	for (i = 0; i < PASSWORD_HASH_SIZES; ++i)
 	{
 		pFmt->methods.binary_hash[i] = pFmtLocal->methods.binary_hash[i];
 		pFmt->methods.get_hash[i]    = pFmtLocal->methods.get_hash[i];


### PR DESCRIPTION
to make sure all the binary_hash[i] and get_hash[i] methods
get passed to the thin formats.
