### PR TITLE
Unstable jumbo: 2 benchmark-unify commits

### DIFF
--- a/run/benchmark-unify
+++ b/run/benchmark-unify
@@ -96,9 +96,10 @@ while (<>) {
 # test vector has changed: (one 2048-bit RSA and one 1024-bit DSA key)
 #
 # For readability, please keep this list sorted by old format name
-# (use sort -f or sort --ignore-case, please)
+# (ignoring case, so use sort -f or sort --ignore-case, please)
 __DATA__
 DIGEST-MD5	DIGEST-MD5 C/R
+dynamic_20: Cisco PIX	dynamic_20: Cisco ASA
 dynamic_38: sha1($s.sha1($s.($p))) (Wolt3BB)	dynamic_38: sha1($s.sha1($s.sha1($p))) (Wolt3BB)
 Eggdrop	Eggdrop Blowfish
 EPiServer SID Hashes	EPiServer SID salted SHA-1
@@ -112,7 +113,8 @@ KRB5 aes256-cts-hmac-sha1-96	Kerberos 5 db etype 18 aes256-cts-hmac-sha1-96
 KRB5 arcfour-hmac	Kerberos 5 db etype 23 rc4-hmac
 Lotus5	Lotus Notes/Domino 5
 M$ Cache Hash 2 (DCC2)	M$ Cache Hash 2 (DCC2) PBKDF2-HMAC-SHA-1
-M$ Cache Hash	M$ Cache Hash MD4
+M$ Cache Hash	M$ Cache Hash (DCC) MD4
+M$ Cache Hash MD4	M$ Cache Hash (DCC) MD4
 MediaWiki -- md5($s.'-'.md5($p))	MediaWiki md5($s.'-'.md5($p))
 More Secure Internet Password	Lotus Notes/Domino 6 More Secure Internet Password
 Mozilla SHA-1 3DES	Mozilla (key3.db) SHA-1 3DES
@@ -120,8 +122,10 @@ MS Kerberos 5 AS-REQ Pre-Auth	Kerberos 5 AS-REQ Pre-Auth etype 23 md4, rc4-hmac-
 MS Kerberos 5 AS-REQ Pre-Auth MD4 MD5 RC4	Kerberos 5 AS-REQ Pre-Auth etype 23 md4, rc4-hmac-md5
 MS-SQL05	MS SQL 2005 SHA-1
 MS-SQL	MS SQL SHA-1
-MYSQL_fast	MySQL
-MYSQL	MySQL
+MySQL 4.1 double-SHA-1	MySQL 4.1+ double-SHA-1
+MYSQL_fast	MySQL pre-4.1
+MySQL	MySQL pre-4.1
+MYSQL	MySQL pre-4.1
 Netscape LDAP SHA	Netscape LDAP SHA-1
 NT v2	NT MD4
 ODF SHA-1 Blowfish	ODF SHA-1 Blowfish / SHA-256 AES
@@ -132,6 +136,7 @@ PDF MD5 RC4	PDF MD5 SHA-2 RC4 / AES
 pdf	PDF MD5 SHA-2 RC4 / AES
 PHPass MD5	phpass MD5 ($P$9)
 PHPS -- md5(md5($pass).$salt)	PHPS md5(md5($pass).$salt)
+PIX MD5	Cisco PIX MD5
 pkzip	PKZIP
 rar	RAR3 SHA-1 AES (4 characters)
 Raw SHA	Raw SHA-0
@@ -139,4 +144,5 @@ SAP BCODE	SAP CODVN B (BCODE)
 SAP CODVN G (PASSCODE)	SAP CODVN F/G (PASSCODE)
 ssh-ng SSH RSA / DSA	SSH RSA/DSA (one 2048-bit RSA and one 1024-bit DSA key)
 sybasease	Sybase ASE salted SHA-256
+WPA-PSK PBKDF2-HMAC-SHA-1	WPA/WPA2 PSK PBKDF2-HMAC-SHA-1
 zip	WinZip PBKDF2-HMAC-SHA-1


### PR DESCRIPTION
to improve mapping --test output of 1.7.9-jumbo7 (and older versions) to --test output of unstable
