### PR TITLE
Fix issue #494 (some log info was printed once per forked process)

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1155,6 +1155,7 @@ static void john_load(void)
 		} else
 		if (database.password_count < total) {
 			log_event("Remaining %s", john_loaded_counts());
+			if (john_main_process)
 			printf("Remaining %s\n", john_loaded_counts());
 		}
 


### PR DESCRIPTION
Since this is a core bug, the core version should be changed
in a similar way.
