### PR TITLE
First revision of testing for different tunable costs among hashes

### DIFF
--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -160,6 +160,27 @@ loaded where there are more than MAX salts.  This is so that if you
 have run --salts=25 and then later can run --salts=10:24 and none of
 the hashes that were already done from the --salts=25 will be re-done.
 
+--costs=[-]Cn[:Mn][,...]	load salts with[out] cost value Cn [to Mn]
+				for tunable cost parameters
+				(comma separated values/ranges per param.)
+
+The option --cost= can be used to crack only hashes with similar
+tunable costs, to avoid a slowdown caused by expensive cost parameter
+settings of some hashes if there are other hashes which are less
+expensive to compute.
+This feature allows you to focus on salts with lower cost values first.
+For formats with different tunable costs, you can specify a comma
+separated list of values/ranges.
+ --cost=-2 (cost of first cost parameter must be smaller than 2)
+ --cost=2,10:20 (cost of 1st parameter is >= 2, of 2nd between 10 and 20)
+ --cost=:,10:20 (first cost parameter ignored, 2nd between 10 and 20)
+ --cost=:,-3 (first cost parameter ignored, 2nd smaller than 3)
+Very few formats have more than one tunable cost parameter.
+(All saltless hashes and several salted hashes don't have tunable cost
+parameters. For these, a dummy cost of 1 is reported.)
+The --list=format-details and --list=format-all-details options will
+list the tunable cost parameters supported by a given format.
+
 --pot=NAME			pot filename to use
 
 By default, john will use john.pot.  This override allows using a different

--- a/src/7z_fmt_plug.c
+++ b/src/7z_fmt_plug.c
@@ -405,6 +405,10 @@ struct fmt_main fmt_sevenzip = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		sevenzip_tests
 	}, {
 		init,
@@ -415,6 +419,10 @@ struct fmt_main fmt_sevenzip = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/AFS_fmt.c
+++ b/src/AFS_fmt.c
@@ -454,6 +454,10 @@ struct fmt_main fmt_AFS = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -464,6 +468,10 @@ struct fmt_main fmt_AFS = {
 		fmt_default_split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/BFEgg_fmt_plug.c
+++ b/src/BFEgg_fmt_plug.c
@@ -184,6 +184,10 @@ struct fmt_main fmt_BFEgg = {
     MIN_KEYS_PER_CRYPT,
     MAX_KEYS_PER_CRYPT,
     FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
     tests
   }, {
     init,
@@ -194,6 +198,10 @@ struct fmt_main fmt_BFEgg = {
     fmt_default_split,
     binary,
     fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
     fmt_default_source,
     {
 			fmt_default_binary_hash_0,

--- a/src/BF_fmt.c
+++ b/src/BF_fmt.c
@@ -262,6 +262,11 @@ struct fmt_main fmt_BF = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+			"iteration count",
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -272,6 +277,11 @@ struct fmt_main fmt_BF = {
 		fmt_default_split,
 		BF_std_get_binary,
 		BF_std_get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+			BF_iteration_count,
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/BF_std.c
+++ b/src/BF_std.c
@@ -830,6 +830,17 @@ void *BF_std_get_salt(char *ciphertext)
 	return &salt;
 }
 
+#if FMT_MAIN_VERSION > 11
+/* For BF, the tunable cost parameter is the iteratioon count */
+unsigned int BF_iteration_count(void *salt)
+{
+	BF_salt *bf_salt;
+
+	bf_salt = (BF_salt *) salt;
+	return (unsigned int) (1 << bf_salt->rounds);
+}
+#endif
+
 void *BF_std_get_binary(char *ciphertext)
 {
 	static BF_binary binary;

--- a/src/BF_std.h
+++ b/src/BF_std.h
@@ -17,6 +17,7 @@
 
 #include "arch.h"
 #include "common.h"
+#include "formats.h"
 
 typedef ARCH_WORD_32 BF_word;
 
@@ -87,6 +88,14 @@ extern void BF_std_crypt_exact(int index);
  * Returns the salt for BF_std_crypt().
  */
 extern void *BF_std_get_salt(char *ciphertext);
+
+#if FMT_MAIN_VERSION > 11
+/*
+ * Returns the number of iterations for a given salt,
+ * this is BF's tunable cost parameter
+ */
+extern unsigned int BF_iteration_count(void *salt);
+#endif
 
 /*
  * Converts an ASCII ciphertext to binary.

--- a/src/BSDI_fmt.c
+++ b/src/BSDI_fmt.c
@@ -413,6 +413,10 @@ struct fmt_main fmt_BSDI = {
 #else
 		FMT_CASE,
 #endif
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -428,6 +432,10 @@ struct fmt_main fmt_BSDI = {
 			DES_std_get_binary,
 #endif
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/DES_fmt.c
+++ b/src/DES_fmt.c
@@ -377,6 +377,10 @@ struct fmt_main fmt_DES = {
 #else
 		FMT_CASE,
 #endif
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -392,6 +396,10 @@ struct fmt_main fmt_DES = {
 			DES_std_get_binary,
 #endif
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/DMD5_fmt_plug.c
+++ b/src/DMD5_fmt_plug.c
@@ -393,6 +393,10 @@ struct fmt_main fmt_DMD5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	},
 	{
@@ -404,6 +408,10 @@ struct fmt_main fmt_DMD5 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/DOMINOSEC_fmt_plug.c
+++ b/src/DOMINOSEC_fmt_plug.c
@@ -485,6 +485,10 @@ struct fmt_main fmt_DOMINOSEC = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	},
 	{
@@ -496,6 +500,10 @@ struct fmt_main fmt_DOMINOSEC = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/EPI_fmt_plug.c
+++ b/src/EPI_fmt_plug.c
@@ -177,6 +177,10 @@ struct fmt_main fmt_EPI =
 		1,
 		1,
 		FMT_CASE | FMT_8_BIT, // flags XXX, these are just guesses
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		global_tests
 	},
 	{ // fmt_methods
@@ -188,6 +192,10 @@ struct fmt_main fmt_EPI =
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/FGT_fmt_plug.c
+++ b/src/FGT_fmt_plug.c
@@ -210,6 +210,10 @@ struct fmt_main fmt_FGT = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP ,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fgt_tests
 	}, {
 		fmt_default_init,
@@ -220,6 +224,10 @@ struct fmt_main fmt_FGT = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/HDAA_fmt_plug.c
+++ b/src/HDAA_fmt_plug.c
@@ -670,6 +670,10 @@ struct fmt_main fmt_HDAA = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -680,6 +684,10 @@ struct fmt_main fmt_HDAA = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/IPB2_fmt_plug.c
+++ b/src/IPB2_fmt_plug.c
@@ -470,6 +470,10 @@ struct fmt_main fmt_IPB2 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	},
 	{
@@ -481,6 +485,10 @@ struct fmt_main fmt_IPB2 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/KRB4_fmt_plug.c
+++ b/src/KRB4_fmt_plug.c
@@ -252,6 +252,10 @@ struct fmt_main fmt_KRB4 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_default_init,
@@ -262,6 +266,10 @@ struct fmt_main fmt_KRB4 = {
 		fmt_default_split,
 		fmt_default_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash,

--- a/src/KRB5_fmt_plug.c
+++ b/src/KRB5_fmt_plug.c
@@ -330,6 +330,10 @@ struct fmt_main fmt_KRB5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_tests
 	}, {
 		init,
@@ -340,6 +344,10 @@ struct fmt_main fmt_KRB5 = {
 		fmt_default_split,
 		fmt_default_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash,

--- a/src/LM_fmt.c
+++ b/src/LM_fmt.c
@@ -212,6 +212,10 @@ struct fmt_main fmt_LM = {
 		FMT_OMP | FMT_OMP_BAD |
 #endif
 		FMT_8_BIT | FMT_BS | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -222,6 +226,10 @@ struct fmt_main fmt_LM = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		source,
 		{
 			binary_hash_0,

--- a/src/MD5_fmt.c
+++ b/src/MD5_fmt.c
@@ -377,6 +377,10 @@ struct fmt_main fmt_MD5 = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -387,6 +391,10 @@ struct fmt_main fmt_MD5 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/MSCHAPv2_bs_fmt_plug.c
+++ b/src/MSCHAPv2_bs_fmt_plug.c
@@ -550,6 +550,10 @@ struct fmt_main fmt_MSCHAPv2_old = {
 #endif
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -560,6 +564,10 @@ struct fmt_main fmt_MSCHAPv2_old = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/NETLM_fmt_plug.c
+++ b/src/NETLM_fmt_plug.c
@@ -359,6 +359,10 @@ struct fmt_main fmt_NETLM = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -369,6 +373,10 @@ struct fmt_main fmt_NETLM = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/NETLMv2_fmt_plug.c
+++ b/src/NETLMv2_fmt_plug.c
@@ -438,6 +438,10 @@ struct fmt_main fmt_NETLMv2 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -448,6 +452,10 @@ struct fmt_main fmt_NETLMv2 = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/NETNTLM_bs_fmt_plug.c
+++ b/src/NETNTLM_bs_fmt_plug.c
@@ -426,6 +426,10 @@ struct fmt_main fmt_NETNTLM_old = {
 #endif
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -436,6 +440,10 @@ struct fmt_main fmt_NETNTLM_old = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/NETNTLMv2_fmt_plug.c
+++ b/src/NETNTLMv2_fmt_plug.c
@@ -503,6 +503,10 @@ struct fmt_main fmt_NETNTLMv2 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -513,6 +517,10 @@ struct fmt_main fmt_NETNTLMv2 = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/NETSPLITLM_fmt_plug.c
+++ b/src/NETSPLITLM_fmt_plug.c
@@ -318,6 +318,10 @@ struct fmt_main fmt_NETHALFLM = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -328,6 +332,10 @@ struct fmt_main fmt_NETHALFLM = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/NS_fmt_plug.c
+++ b/src/NS_fmt_plug.c
@@ -272,6 +272,10 @@ struct fmt_main fmt_NS = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		NS_init,
@@ -282,6 +286,10 @@ struct fmt_main fmt_NS = {
 		fmt_default_split,
 		(void *(*)(char *))get_binary,
 		(void *(*)(char *))get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/NT_fmt.c
+++ b/src/NT_fmt.c
@@ -977,6 +977,10 @@ struct fmt_main fmt_NT = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_NT_init,
@@ -987,6 +991,10 @@ struct fmt_main fmt_NT = {
 		nt_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		source,
 		{
 			binary_hash_0,

--- a/src/PHPS_fmt_plug.c
+++ b/src/PHPS_fmt_plug.c
@@ -151,7 +151,11 @@ struct fmt_main fmt_PHPS =
 		// setup the labeling and stuff. NOTE the max and min crypts are set to 1
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
-		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT, phps_tests
+		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{ },
+#endif
+		phps_tests
 	},
 	{
 		/*  All we setup here, is the pointer to valid, and the pointer to init */

--- a/src/PO_fmt_plug.c
+++ b/src/PO_fmt_plug.c
@@ -208,6 +208,10 @@ struct fmt_main fmt_PO = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		po_init,
@@ -218,6 +222,10 @@ struct fmt_main fmt_PO = {
 		fmt_default_split,
 		get_binary,
 		(void *(*)(char *))get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/SKEY_fmt.c
+++ b/src/SKEY_fmt.c
@@ -231,6 +231,10 @@ struct fmt_main fmt_SKEY = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		skey_tests
 	}, {
 		fmt_default_init,
@@ -241,6 +245,10 @@ struct fmt_main fmt_SKEY = {
 		fmt_default_split,
 		fmt_default_binary,
 		skey_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash,

--- a/src/SybaseASE_fmt_plug.c
+++ b/src/SybaseASE_fmt_plug.c
@@ -265,6 +265,10 @@ struct fmt_main fmt_SybaseASE = {
         MIN_KEYS_PER_CRYPT,
         MAX_KEYS_PER_CRYPT,
         FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         SybaseASE_tests
     }, {
         init,
@@ -275,6 +279,10 @@ struct fmt_main fmt_SybaseASE = {
         fmt_default_split,
         get_binary,
         salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         fmt_default_source,
         {
 		fmt_default_binary_hash_0,

--- a/src/SybasePROP_fmt_plug.c
+++ b/src/SybasePROP_fmt_plug.c
@@ -203,6 +203,10 @@ struct fmt_main fmt_sybaseprop = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP, // XXX
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		SybasePROP_tests
 	}, {
 		init,
@@ -213,6 +217,10 @@ struct fmt_main fmt_sybaseprop = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/XSHA512_fmt_plug.c
+++ b/src/XSHA512_fmt_plug.c
@@ -280,6 +280,10 @@ struct fmt_main fmt_XSHA512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -290,6 +294,10 @@ struct fmt_main fmt_XSHA512 = {
 		fmt_default_split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/XSHA_fmt_plug.c
+++ b/src/XSHA_fmt_plug.c
@@ -445,6 +445,10 @@ struct fmt_main fmt_XSHA = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -455,6 +459,10 @@ struct fmt_main fmt_XSHA = {
 		fmt_default_split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/aesni_o5logon_fmt_plug.c
+++ b/src/aesni_o5logon_fmt_plug.c
@@ -243,6 +243,10 @@ struct fmt_main fmt_o5logon_aesni = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		o5logon_tests
 	}, {
 		init,
@@ -253,6 +257,10 @@ struct fmt_main fmt_o5logon_aesni = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/agilekeychain_fmt_plug.c
+++ b/src/agilekeychain_fmt_plug.c
@@ -283,6 +283,10 @@ struct fmt_main fmt_agile_keychain = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		agile_keychain_tests
 	}, {
 		init,
@@ -293,6 +297,10 @@ struct fmt_main fmt_agile_keychain = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/aix_smd5_fmt_plug.c
+++ b/src/aix_smd5_fmt_plug.c
@@ -354,6 +354,10 @@ struct fmt_main fmt_smd5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		smd5_tests
 	}, {
 		init,
@@ -364,6 +368,10 @@ struct fmt_main fmt_smd5 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/aix_ssha_fmt_plug.c
+++ b/src/aix_ssha_fmt_plug.c
@@ -378,6 +378,10 @@ struct fmt_main fmt_aixssha1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		aixssha_tests1
 	}, {
 		init,
@@ -388,6 +392,10 @@ struct fmt_main fmt_aixssha1 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -434,6 +442,10 @@ struct fmt_main fmt_aixssha256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		aixssha_tests256
 	}, {
 		init,
@@ -444,6 +456,10 @@ struct fmt_main fmt_aixssha256 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -490,6 +506,10 @@ struct fmt_main fmt_aixssha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		aixssha_tests512
 	}, {
 		init,
@@ -500,6 +520,10 @@ struct fmt_main fmt_aixssha512 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/androidfde_fmt_plug.c
+++ b/src/androidfde_fmt_plug.c
@@ -310,6 +310,10 @@ struct fmt_main fmt_fde = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fde_tests
 	}, {
 		init,
@@ -320,6 +324,10 @@ struct fmt_main fmt_fde = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/asaMD5_fmt_plug.c
+++ b/src/asaMD5_fmt_plug.c
@@ -103,7 +103,11 @@ struct fmt_main fmt_asaMD5 = {
 		// setup the labeling and stuff. NOTE the max and min crypts are set to 1
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
-		12, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT, tests
+		12, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{ },
+#endif
+		tests
 	},
 	{
 		/* All we setup here, is the pointer to valid, and the pointer to init */

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -315,6 +315,10 @@ struct fmt_main fmt_bitcoin = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		bitcoin_tests
 	}, {
 		init,
@@ -326,6 +330,10 @@ struct fmt_main fmt_bitcoin = {
 		fmt_default_binary,
 		get_salt,
 #if FMT_MAIN_VERSION > 9
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 #endif
 		{

--- a/src/blackberry_ES10_fmt_plug.c
+++ b/src/blackberry_ES10_fmt_plug.c
@@ -231,6 +231,10 @@ struct fmt_main fmt_blackberry1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		blackberry_tests
 	}, {
 		init,
@@ -241,6 +245,10 @@ struct fmt_main fmt_blackberry1 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/blockchain_fmt_plug.c
+++ b/src/blockchain_fmt_plug.c
@@ -265,6 +265,10 @@ struct fmt_main fmt_blockchain = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		agile_keychain_tests
 	}, {
 		init,
@@ -275,6 +279,10 @@ struct fmt_main fmt_blockchain = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/chap_fmt_plug.c
+++ b/src/chap_fmt_plug.c
@@ -214,6 +214,10 @@ struct fmt_main fmt_chap = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		chap_tests
 	}, {
 		init,
@@ -224,6 +228,10 @@ struct fmt_main fmt_chap = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/citrix_ns_fmt_plug.c
+++ b/src/citrix_ns_fmt_plug.c
@@ -381,6 +381,10 @@ struct fmt_main fmt_ctrxns = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -391,6 +395,10 @@ struct fmt_main fmt_ctrxns = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/clipperz_srp_fmt_plug.c
+++ b/src/clipperz_srp_fmt_plug.c
@@ -420,6 +420,10 @@ struct fmt_main fmt_clipperz = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -430,6 +434,10 @@ struct fmt_main fmt_clipperz = {
 		fmt_default_split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cloudkeychain_fmt_plug.c
+++ b/src/cloudkeychain_fmt_plug.c
@@ -396,6 +396,10 @@ struct fmt_main fmt_cloud_keychain = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		cloud_keychain_tests
 	}, {
 		init,
@@ -406,6 +410,10 @@ struct fmt_main fmt_cloud_keychain = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/crc32_fmt_plug.c
+++ b/src/crc32_fmt_plug.c
@@ -223,6 +223,10 @@ struct fmt_main fmt_crc32 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_NOT_EXACT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -233,6 +237,10 @@ struct fmt_main fmt_crc32 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cryptsha256_fmt_plug.c
+++ b/src/cryptsha256_fmt_plug.c
@@ -939,6 +939,10 @@ struct fmt_main fmt_cryptsha256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -949,6 +953,10 @@ struct fmt_main fmt_cryptsha256 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cryptsha512_fmt_plug.c
+++ b/src/cryptsha512_fmt_plug.c
@@ -320,6 +320,10 @@ struct fmt_main fmt_cryptsha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -330,6 +334,10 @@ struct fmt_main fmt_cryptsha512 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cuda_cryptmd5_fmt.c
+++ b/src/cuda_cryptmd5_fmt.c
@@ -286,6 +286,10 @@ struct fmt_main fmt_cuda_cryptmd5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -296,6 +300,10 @@ struct fmt_main fmt_cuda_cryptmd5 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cuda_cryptsha256_fmt.c
+++ b/src/cuda_cryptsha256_fmt.c
@@ -327,6 +327,10 @@ struct fmt_main fmt_cuda_cryptsha256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -337,6 +341,10 @@ struct fmt_main fmt_cuda_cryptsha256 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cuda_cryptsha512_fmt.c
+++ b/src/cuda_cryptsha512_fmt.c
@@ -316,6 +316,10 @@ struct fmt_main fmt_cuda_cryptsha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -326,6 +330,10 @@ struct fmt_main fmt_cuda_cryptsha512 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cuda_mscash2_fmt.c
+++ b/src/cuda_mscash2_fmt.c
@@ -256,6 +256,10 @@ struct fmt_main fmt_cuda_mscash2 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -266,6 +270,10 @@ struct fmt_main fmt_cuda_mscash2 = {
 		mscash2_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/cuda_mscash_fmt.c
+++ b/src/cuda_mscash_fmt.c
@@ -253,6 +253,10 @@ struct fmt_main fmt_cuda_mscash = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -263,6 +267,10 @@ struct fmt_main fmt_cuda_mscash = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cuda_phpass_fmt.c
+++ b/src/cuda_phpass_fmt.c
@@ -247,6 +247,10 @@ struct fmt_main fmt_cuda_phpass = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -257,6 +261,10 @@ struct fmt_main fmt_cuda_phpass = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cuda_pwsafe_fmt.c
+++ b/src/cuda_pwsafe_fmt.c
@@ -186,6 +186,10 @@ struct fmt_main fmt_cuda_pwsafe = {
 		KEYS_PER_CRYPT,
 		KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		pwsafe_tests
 	}, {
 		init,
@@ -196,6 +200,10 @@ struct fmt_main fmt_cuda_pwsafe = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/cuda_rawsha256_fmt.c
+++ b/src/cuda_rawsha256_fmt.c
@@ -237,6 +237,10 @@ struct fmt_main FMT_MAIN = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		TESTS
 	}, {
 		init,
@@ -247,6 +251,10 @@ struct fmt_main FMT_MAIN = {
 		fmt_default_split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/cuda_rawsha512_fmt.c
+++ b/src/cuda_rawsha512_fmt.c
@@ -272,6 +272,10 @@ struct fmt_main fmt_cuda_rawsha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -282,6 +286,10 @@ struct fmt_main fmt_cuda_rawsha512 = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/cuda_wpapsk_fmt.c
+++ b/src/cuda_wpapsk_fmt.c
@@ -80,6 +80,10 @@ struct fmt_main fmt_cuda_wpapsk = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -90,6 +94,10 @@ struct fmt_main fmt_cuda_wpapsk = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/cuda_xsha512_fmt.c
+++ b/src/cuda_xsha512_fmt.c
@@ -365,6 +365,10 @@ struct fmt_main fmt_cuda_xsha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -375,6 +379,10 @@ struct fmt_main fmt_cuda_xsha512 = {
 		fmt_default_split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/django_fmt.c
+++ b/src/django_fmt.c
@@ -264,6 +264,10 @@ struct fmt_main fmt_django = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		django_tests
 	}, {
 		init,
@@ -274,6 +278,10 @@ struct fmt_main fmt_django = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/django_scrypt_fmt_plug.c
+++ b/src/django_scrypt_fmt_plug.c
@@ -239,6 +239,10 @@ struct fmt_main fmt_django_scrypt = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		scrypt_tests
 	}, {
 		init,
@@ -249,6 +253,10 @@ struct fmt_main fmt_django_scrypt = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/dmg_fmt_plug.c
+++ b/src/dmg_fmt_plug.c
@@ -696,6 +696,10 @@ struct fmt_main fmt_dmg = {
 		FMT_NOT_EXACT |
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		dmg_tests
 	}, {
 		init,
@@ -706,6 +710,10 @@ struct fmt_main fmt_dmg = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/dragonfly3_fmt_plug.c
+++ b/src/dragonfly3_fmt_plug.c
@@ -276,6 +276,10 @@ struct fmt_main fmt_dragonfly3_32 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests_32
 	}, {
 		init,
@@ -286,6 +290,10 @@ struct fmt_main fmt_dragonfly3_32 = {
 		fmt_default_split,
 		get_binary,
 		get_salt_32,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -332,6 +340,10 @@ struct fmt_main fmt_dragonfly3_64 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests_64
 	}, {
 		init,
@@ -342,6 +354,10 @@ struct fmt_main fmt_dragonfly3_64 = {
 		fmt_default_split,
 		get_binary,
 		get_salt_64,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/dragonfly4_fmt_plug.c
+++ b/src/dragonfly4_fmt_plug.c
@@ -281,6 +281,10 @@ struct fmt_main fmt_dragonfly4_32 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests_32
 	}, {
 		init,
@@ -291,6 +295,10 @@ struct fmt_main fmt_dragonfly4_32 = {
 		fmt_default_split,
 		get_binary,
 		get_salt_32,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -337,6 +345,10 @@ struct fmt_main fmt_dragonfly4_64 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests_64
 	}, {
 		init,
@@ -347,6 +359,10 @@ struct fmt_main fmt_dragonfly4_64 = {
 		fmt_default_split,
 		get_binary,
 		get_salt_64,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/drupal7_fmt_plug.c
+++ b/src/drupal7_fmt_plug.c
@@ -252,6 +252,10 @@ struct fmt_main fmt_drupal7 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -262,6 +266,10 @@ struct fmt_main fmt_drupal7 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/dummy.c
+++ b/src/dummy.c
@@ -302,6 +302,10 @@ struct fmt_main fmt_dummy = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_default_init,
@@ -312,6 +316,10 @@ struct fmt_main fmt_dummy = {
 		fmt_default_split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -2569,6 +2569,10 @@ static struct fmt_main fmt_Dynamic =
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		dynamic_tests
 	}, {
 		init,
@@ -2582,6 +2586,10 @@ static struct fmt_main fmt_Dynamic =
 		binary,
 		salt,
 #if FMT_MAIN_VERSION > 9
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 #endif
 		{
@@ -7505,6 +7513,12 @@ struct fmt_main *dynamic_THIN_FORMAT_LINK(struct fmt_main *pFmt, char *ciphertex
 	pFmt->methods.cmp_one    = pFmtLocal->methods.cmp_one;
 	pFmt->methods.cmp_exact  = pFmtLocal->methods.cmp_exact;
 #if FMT_MAIN_VERSION > 9
+#if FMT_MAIN_VERSION > 11
+	for (i = 0; i < FMT_TUNABLE_COSTS; ++i) {
+		pFmt->methods.tunable_cost_value[i] = pFmtLocal->methods.tunable_cost_value[i];
+		pFmt->params.tunable_cost_name[i] = pFmtLocal->params.tunable_cost_name[i];
+	}
+#endif
 	pFmt->methods.source     = pFmtLocal->methods.source;
 #endif
 	pFmt->methods.set_salt   = pFmtLocal->methods.set_salt;

--- a/src/ecryptfs_fmt_plug.c
+++ b/src/ecryptfs_fmt_plug.c
@@ -232,6 +232,10 @@ struct fmt_main fmt_ecryptfs1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		ecryptfs_tests
 	}, {
 		init,
@@ -242,6 +246,10 @@ struct fmt_main fmt_ecryptfs1 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/efs_fmt_plug.c
+++ b/src/efs_fmt_plug.c
@@ -346,6 +346,10 @@ struct fmt_main fmt_efs = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		efs_tests
 	}, {
 		init,
@@ -356,6 +360,10 @@ struct fmt_main fmt_efs = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/encfs_fmt_plug.c
+++ b/src/encfs_fmt_plug.c
@@ -465,6 +465,10 @@ struct fmt_main fmt_encfs = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		encfs_tests
 	}, {
 		init,
@@ -475,6 +479,10 @@ struct fmt_main fmt_encfs = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/episerver_fmt_plug.c
+++ b/src/episerver_fmt_plug.c
@@ -262,6 +262,10 @@ struct fmt_main fmt_episerver = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		episerver_tests
 	}, {
 		init,
@@ -272,6 +276,10 @@ struct fmt_main fmt_episerver = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/formspring_fmt_plug.c
+++ b/src/formspring_fmt_plug.c
@@ -105,7 +105,11 @@ struct fmt_main fmt_FORMSPRING =
 		// setup the labeling and stuff. NOTE the max and min crypts are set to 1
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
-		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT, formspring_tests
+		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{ },
+#endif
+		formspring_tests
 	},
 	{
 		/*  All we setup here, is the pointer to valid, and the pointer to init */

--- a/src/gost_fmt_plug.c
+++ b/src/gost_fmt_plug.c
@@ -239,6 +239,10 @@ struct fmt_main fmt_gost = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		gost_tests
 	}, {
 		init,
@@ -249,6 +253,10 @@ struct fmt_main fmt_gost = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/gpg_fmt_plug.c
+++ b/src/gpg_fmt_plug.c
@@ -1286,6 +1286,10 @@ struct fmt_main fmt_gpg = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		gpg_tests
 	},
 	{
@@ -1297,6 +1301,10 @@ struct fmt_main fmt_gpg = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/haval_fmt_plug.c
+++ b/src/haval_fmt_plug.c
@@ -224,6 +224,10 @@ struct fmt_main fmt_haval_256_3 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		haval_256_3_tests
 	}, {
 		init,
@@ -234,6 +238,10 @@ struct fmt_main fmt_haval_256_3 = {
 		fmt_default_split,
 		get_binary_256,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -281,6 +289,10 @@ struct fmt_main fmt_haval_128_4 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		haval_128_4_tests
 	}, {
 		init,
@@ -291,6 +303,10 @@ struct fmt_main fmt_haval_128_4 = {
 		fmt_default_split,
 		get_binary_128,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/hmacMD5_fmt.c
+++ b/src/hmacMD5_fmt.c
@@ -455,6 +455,10 @@ struct fmt_main fmt_hmacMD5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -465,6 +469,10 @@ struct fmt_main fmt_hmacMD5 = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/hmacSHA1_fmt.c
+++ b/src/hmacSHA1_fmt.c
@@ -456,6 +456,10 @@ struct fmt_main fmt_hmacSHA1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -466,6 +470,10 @@ struct fmt_main fmt_hmacSHA1 = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/hmacSHA224_fmt_plug.c
+++ b/src/hmacSHA224_fmt_plug.c
@@ -234,6 +234,10 @@ struct fmt_main fmt_hmacSHA224 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -244,6 +248,10 @@ struct fmt_main fmt_hmacSHA224 = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/hmacSHA256_fmt_plug.c
+++ b/src/hmacSHA256_fmt_plug.c
@@ -235,6 +235,10 @@ struct fmt_main fmt_hmacSHA256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -245,6 +249,10 @@ struct fmt_main fmt_hmacSHA256 = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/hmacSHA384_fmt_plug.c
+++ b/src/hmacSHA384_fmt_plug.c
@@ -249,6 +249,10 @@ struct fmt_main fmt_hmacSHA384 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -259,6 +263,10 @@ struct fmt_main fmt_hmacSHA384 = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/hmacSHA512_fmt_plug.c
+++ b/src/hmacSHA512_fmt_plug.c
@@ -250,6 +250,10 @@ struct fmt_main fmt_hmacSHA512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -260,6 +264,10 @@ struct fmt_main fmt_hmacSHA512 = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/hmailserver_fmt_plug.c
+++ b/src/hmailserver_fmt_plug.c
@@ -206,6 +206,10 @@ struct fmt_main fmt_hmailserver = {
         MIN_KEYS_PER_CRYPT,
         MAX_KEYS_PER_CRYPT,
         FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         hmailserver_tests
     }, {
         fmt_default_init,
@@ -216,6 +220,10 @@ struct fmt_main fmt_hmailserver = {
         fmt_default_split,
         get_binary,
         salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         fmt_default_source,
         {
 		fmt_default_binary_hash_0,

--- a/src/ike_fmt_plug.c
+++ b/src/ike_fmt_plug.c
@@ -286,6 +286,10 @@ struct fmt_main fmt_ike = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		ike_tests
 	}, {
 		init,
@@ -296,6 +300,10 @@ struct fmt_main fmt_ike = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/john.c
+++ b/src/john.c
@@ -1107,6 +1107,9 @@ static void john_load(void)
 
 	if (options.flags & FLG_PASSWD) {
 		int total;
+#if FMT_MAIN_VERSION > 11
+		int i;
+#endif
 
 		if (options.flags & FLG_SHOW_CHK) {
 			options.loader.flags |= DB_CRACKED;
@@ -1190,7 +1193,21 @@ static void john_load(void)
 			if (john_main_process)
 			printf("Remaining %s\n", john_loaded_counts());
 		}
-
+#if FMT_MAIN_VERSION > 11
+		for (i = 0; i < FMT_TUNABLE_COSTS; i++) {
+			if (database.min_cost[i] < database.max_cost[i]) {
+				log_event("Loaded hashes with cost %d (%s)"
+				          " varying from %u to %u",
+				          i+1, database.format->params.tunable_cost_name[i],
+				          database.min_cost[i], database.max_cost[i]);
+				if (john_main_process)
+					printf("Loaded hashes with cost %d (%s)"
+					       " varying from %u to %u\n",
+					       i+1, database.format->params.tunable_cost_name[i],
+					        database.min_cost[i], database.max_cost[i]);
+			}
+		}
+#endif
 		if ((options.flags & FLG_PWD_REQ) && !database.salts) exit(0);
 
 		if (options.regen_lost_salts)

--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -404,6 +404,10 @@ struct fmt_main fmt_KeePass = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		KeePass_tests
 	}, {
 		init,
@@ -414,6 +418,10 @@ struct fmt_main fmt_KeePass = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/keychain_fmt_plug.c
+++ b/src/keychain_fmt_plug.c
@@ -255,6 +255,10 @@ struct fmt_main fmt_keychain = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		keychain_tests
 	}, {
 		init,
@@ -265,6 +269,10 @@ struct fmt_main fmt_keychain = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/keyring_fmt_plug.c
+++ b/src/keyring_fmt_plug.c
@@ -333,6 +333,10 @@ struct fmt_main fmt_keyring = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		keyring_tests
 	}, {
 		init,
@@ -343,6 +347,10 @@ struct fmt_main fmt_keyring = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/keystore_fmt_plug.c
+++ b/src/keystore_fmt_plug.c
@@ -272,6 +272,10 @@ struct fmt_main fmt_keystore = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		keystore_tests
 	}, {
 		init,
@@ -282,6 +286,10 @@ struct fmt_main fmt_keystore = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/krb5-18_fmt.c
+++ b/src/krb5-18_fmt.c
@@ -283,6 +283,10 @@ struct fmt_main fmt_krb5_18 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		kinit_tests
 	}, {
 		init,
@@ -293,6 +297,10 @@ struct fmt_main fmt_krb5_18 = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/krb5-23_fmt.c
+++ b/src/krb5-23_fmt.c
@@ -251,6 +251,10 @@ struct fmt_main fmt_KRB5_kinit = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		kinit_tests
 	}, {
 		init,
@@ -261,6 +265,10 @@ struct fmt_main fmt_KRB5_kinit = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/krb5pa-md5_fmt_plug.c
+++ b/src/krb5pa-md5_fmt_plug.c
@@ -420,6 +420,10 @@ struct fmt_main fmt_mskrb5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -430,6 +434,10 @@ struct fmt_main fmt_mskrb5 = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/krb5pa-sha1_fmt_plug.c
+++ b/src/krb5pa-sha1_fmt_plug.c
@@ -595,6 +595,10 @@ struct fmt_main fmt_krb5pa = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -605,6 +609,10 @@ struct fmt_main fmt_krb5pa = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/kwallet_fmt_plug.c
+++ b/src/kwallet_fmt_plug.c
@@ -295,6 +295,10 @@ struct fmt_main fmt_kwallet = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		kwallet_tests
 	}, {
 		init,
@@ -305,6 +309,10 @@ struct fmt_main fmt_kwallet = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/lastpass_fmt_plug.c
+++ b/src/lastpass_fmt_plug.c
@@ -241,6 +241,10 @@ struct fmt_main fmt_lastpass = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		lastpass_tests
 	}, {
 		init,
@@ -251,6 +255,10 @@ struct fmt_main fmt_lastpass = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/lastpass_sniffed_fmt_plug.c
+++ b/src/lastpass_sniffed_fmt_plug.c
@@ -252,6 +252,10 @@ struct fmt_main fmt_sniffed_lastpass = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		lastpass_tests
 	}, {
 		init,
@@ -262,6 +266,10 @@ struct fmt_main fmt_sniffed_lastpass = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/loader.h
+++ b/src/loader.h
@@ -138,6 +138,11 @@ struct db_salt {
 
 /* Buffered keys, allocated for "single crack" mode only */
 	struct db_keys *keys;
+
+#if FMT_MAIN_VERSION > 11
+/* Tunable costs */
+	unsigned int cost[FMT_TUNABLE_COSTS];
+#endif
 };
 
 /*
@@ -180,6 +185,12 @@ struct db_options {
 /* Requested passwords per salt */
 	int min_pps, max_pps;
 
+#if FMT_MAIN_VERSION > 11
+/* Requested cost values */
+	unsigned int min_cost[FMT_TUNABLE_COSTS];
+	unsigned int max_cost[FMT_TUNABLE_COSTS];
+#endif
+
 /* Pot file used (default is $JOHN/john.pot) */
 	char *activepot;
 
@@ -221,6 +232,12 @@ struct db_main {
 
 /* Number of salts, passwords and guesses */
 	int salt_count, password_count, guess_count;
+
+#if FMT_MAIN_VERSION > 11
+/* min. and max. tunable costs */
+	unsigned int min_cost[FMT_TUNABLE_COSTS];
+	unsigned int max_cost[FMT_TUNABLE_COSTS];
+#endif
 
 /* Ciphertext format */
 	struct fmt_main *format;

--- a/src/lotus5_fmt_plug.c
+++ b/src/lotus5_fmt_plug.c
@@ -279,6 +279,10 @@ struct fmt_main fmt_lotus5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -289,6 +293,10 @@ struct fmt_main fmt_lotus5 = {
 		fmt_default_split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash1,

--- a/src/lotus85_fmt_plug.c
+++ b/src/lotus85_fmt_plug.c
@@ -439,6 +439,10 @@ struct fmt_main fmt_lotus_85 =
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		lotus85_tests
 	}, {
 		lotus85_init,
@@ -449,6 +453,10 @@ struct fmt_main fmt_lotus_85 =
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash,

--- a/src/luks_fmt_plug.c
+++ b/src/luks_fmt_plug.c
@@ -504,6 +504,10 @@ struct fmt_main fmt_luks = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		luks_tests
 	}, {
 		init,
@@ -514,6 +518,10 @@ struct fmt_main fmt_luks = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/md2_fmt_plug.c
+++ b/src/md2_fmt_plug.c
@@ -179,6 +179,10 @@ struct fmt_main fmt_md2_ = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		md2__tests
 	}, {
 		init,
@@ -189,6 +193,10 @@ struct fmt_main fmt_md2_ = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/md4_gen_fmt_plug.c
+++ b/src/md4_gen_fmt_plug.c
@@ -213,6 +213,10 @@ struct fmt_main fmt_md4_gen = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_default_init,
@@ -223,6 +227,10 @@ struct fmt_main fmt_md4_gen = {
 		fmt_default_split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/mediawiki_fmt_plug.c
+++ b/src/mediawiki_fmt_plug.c
@@ -157,7 +157,11 @@ struct fmt_main fmt_mediawiki =
 		// setup the labeling and stuff. NOTE the max and min crypts are set to 1
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
-		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT, mediawiki_tests
+		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{ },
+#endif
+		mediawiki_tests
 	},
 	{
 		/*  All we setup here, is the pointer to valid, and the pointer to init */

--- a/src/mongodb_fmt_plug.c
+++ b/src/mongodb_fmt_plug.c
@@ -271,6 +271,10 @@ struct fmt_main fmt_mongodb = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		mongodb_tests
 	}, {
 		init,
@@ -281,6 +285,10 @@ struct fmt_main fmt_mongodb = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/mozilla_fmt.c
+++ b/src/mozilla_fmt.c
@@ -321,6 +321,10 @@ struct fmt_main fmt_mozilla = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		mozilla_tests
 	}, {
 		init,
@@ -331,6 +335,10 @@ struct fmt_main fmt_mozilla = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/mscash1_fmt_plug.c
+++ b/src/mscash1_fmt_plug.c
@@ -896,6 +896,10 @@ struct fmt_main fmt_mscash = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -906,6 +910,10 @@ struct fmt_main fmt_mscash = {
 		ms_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/mscash2_fmt_plug.c
+++ b/src/mscash2_fmt_plug.c
@@ -749,6 +749,10 @@ struct fmt_main fmt_mscash2 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -759,6 +763,10 @@ struct fmt_main fmt_mscash2 = {
 		mscash2_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/mssql-old_fmt_plug.c
+++ b/src/mssql-old_fmt_plug.c
@@ -370,6 +370,10 @@ struct fmt_main fmt_mssql = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_8_BIT | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -380,6 +384,10 @@ struct fmt_main fmt_mssql = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/mssql05_fmt_plug.c
+++ b/src/mssql05_fmt_plug.c
@@ -506,6 +506,10 @@ struct fmt_main fmt_mssql05 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -516,6 +520,10 @@ struct fmt_main fmt_mssql05 = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/mssql12_fmt_plug.c
+++ b/src/mssql12_fmt_plug.c
@@ -257,6 +257,10 @@ struct fmt_main fmt_mssql12 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_UTF8 | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -267,6 +271,10 @@ struct fmt_main fmt_mssql12 = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/mysqlSHA1_fmt_plug.c
+++ b/src/mysqlSHA1_fmt_plug.c
@@ -411,6 +411,10 @@ struct fmt_main fmt_mysqlSHA1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -421,6 +425,10 @@ struct fmt_main fmt_mysqlSHA1 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/mysql_fmt_plug.c
+++ b/src/mysql_fmt_plug.c
@@ -284,6 +284,10 @@ struct fmt_main fmt_MYSQL_fast =
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -294,6 +298,10 @@ struct fmt_main fmt_MYSQL_fast =
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/mysql_netauth_fmt_plug.c
+++ b/src/mysql_netauth_fmt_plug.c
@@ -230,6 +230,10 @@ struct fmt_main fmt_mysqlna = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		mysqlna_tests
 	}, {
 		init,
@@ -240,6 +244,10 @@ struct fmt_main fmt_mysqlna = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/net_md5_fmt_plug.c
+++ b/src/net_md5_fmt_plug.c
@@ -224,6 +224,10 @@ struct fmt_main fmt_netmd5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -234,6 +238,10 @@ struct fmt_main fmt_netmd5 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/net_sha1_fmt_plug.c
+++ b/src/net_sha1_fmt_plug.c
@@ -213,6 +213,10 @@ struct fmt_main fmt_netsha1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -223,6 +227,10 @@ struct fmt_main fmt_netsha1 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/nsldap_fmt_plug.c
+++ b/src/nsldap_fmt_plug.c
@@ -283,6 +283,10 @@ struct fmt_main fmt_nsldap = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -293,6 +297,10 @@ struct fmt_main fmt_nsldap = {
 		fmt_default_split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/nt2_fmt_plug.c
+++ b/src/nt2_fmt_plug.c
@@ -698,6 +698,10 @@ struct fmt_main fmt_NT2 = {
 		FMT_OMP | FMT_OMP_BAD |
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -708,6 +712,10 @@ struct fmt_main fmt_NT2 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -1244,6 +1244,10 @@ struct fmt_main fmt_MSCHAPv2_new = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		chap_tests
 	}, {
 		init,
@@ -1254,6 +1258,10 @@ struct fmt_main fmt_MSCHAPv2_new = {
 		chap_split,
 		get_binary,
 		chap_get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,
@@ -1303,6 +1311,10 @@ struct fmt_main fmt_NETNTLM_new = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		ntlm_tests
 	}, {
 		init,
@@ -1313,6 +1325,10 @@ struct fmt_main fmt_NETNTLM_new = {
 		ntlm_split,
 		get_binary,
 		ntlm_get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/nukedclan_fmt_plug.c
+++ b/src/nukedclan_fmt_plug.c
@@ -262,6 +262,10 @@ struct fmt_main fmt_nk = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		nk_tests
 	}, {
 		init,
@@ -272,6 +276,10 @@ struct fmt_main fmt_nk = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/o5logon_fmt_plug.c
+++ b/src/o5logon_fmt_plug.c
@@ -214,6 +214,10 @@ struct fmt_main fmt_o5logon = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		o5logon_tests
 	}, {
 		init,
@@ -224,6 +228,10 @@ struct fmt_main fmt_o5logon = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/odf_fmt_plug.c
+++ b/src/odf_fmt_plug.c
@@ -401,6 +401,10 @@ struct fmt_main fmt_odf = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		odf_tests
 	}, {
 		init,
@@ -411,6 +415,10 @@ struct fmt_main fmt_odf = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/office_fmt_plug.c
+++ b/src/office_fmt_plug.c
@@ -531,6 +531,10 @@ struct fmt_main fmt_office = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		office_tests
 	}, {
 		init,
@@ -541,6 +545,10 @@ struct fmt_main fmt_office = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/oldoffice_fmt_plug.c
+++ b/src/oldoffice_fmt_plug.c
@@ -301,6 +301,10 @@ struct fmt_main fmt_oldoffice = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		oo_tests
 	}, {
 		init,
@@ -311,6 +315,10 @@ struct fmt_main fmt_oldoffice = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_DES_fmt.c
+++ b/src/opencl_DES_fmt.c
@@ -168,6 +168,10 @@ struct fmt_main fmt_opencl_DES = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_BS,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -181,6 +185,10 @@ struct fmt_main fmt_opencl_DES = {
 			opencl_DES_bs_get_binary,
 
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_aesni_o5logon_fmt.c
+++ b/src/opencl_aesni_o5logon_fmt.c
@@ -460,6 +460,10 @@ struct fmt_main fmt_opencl_o5logon_aesni = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT, // Changed for OpenCL
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		o5logon_tests
 	}, {
 		init,
@@ -470,6 +474,10 @@ struct fmt_main fmt_opencl_o5logon_aesni = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_agilekeychain_fmt.c
+++ b/src/opencl_agilekeychain_fmt.c
@@ -384,6 +384,10 @@ struct fmt_main fmt_opencl_agilekeychain = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		keychain_tests
 	}, {
 		init,
@@ -394,6 +398,10 @@ struct fmt_main fmt_opencl_agilekeychain = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_bf_fmt.c
+++ b/src/opencl_bf_fmt.c
@@ -229,6 +229,10 @@ struct fmt_main fmt_opencl_bf = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -239,6 +243,10 @@ struct fmt_main fmt_opencl_bf = {
 		fmt_default_split,
 		opencl_BF_std_get_binary,
 		opencl_BF_std_get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_blockchain_fmt.c
+++ b/src/opencl_blockchain_fmt.c
@@ -363,6 +363,10 @@ struct fmt_main fmt_opencl_blockchain = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		blockchain_tests
 	}, {
 		init,
@@ -373,6 +377,10 @@ struct fmt_main fmt_opencl_blockchain = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_cryptmd5_fmt.c
+++ b/src/opencl_cryptmd5_fmt.c
@@ -511,6 +511,10 @@ struct fmt_main fmt_opencl_cryptMD5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -521,6 +525,10 @@ struct fmt_main fmt_opencl_cryptMD5 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_cryptsha256_fmt.c
+++ b/src/opencl_cryptsha256_fmt.c
@@ -506,6 +506,10 @@ struct fmt_main fmt_opencl_cryptsha256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -516,6 +520,10 @@ struct fmt_main fmt_opencl_cryptsha256 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_cryptsha512_fmt.c
+++ b/src/opencl_cryptsha512_fmt.c
@@ -492,6 +492,10 @@ struct fmt_main fmt_opencl_cryptsha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -502,6 +506,10 @@ struct fmt_main fmt_opencl_cryptsha512 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_dmg_fmt.c
+++ b/src/opencl_dmg_fmt.c
@@ -783,6 +783,10 @@ struct fmt_main fmt_opencl_dmg = {
 		FMT_NOT_EXACT |
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		dmg_tests
 	}, {
 		init,
@@ -793,6 +797,10 @@ struct fmt_main fmt_opencl_dmg = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_encfs_fmt.c
+++ b/src/opencl_encfs_fmt.c
@@ -761,6 +761,10 @@ struct fmt_main fmt_opencl_encfs = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -771,6 +775,10 @@ struct fmt_main fmt_opencl_encfs = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_gpg_fmt.c
+++ b/src/opencl_gpg_fmt.c
@@ -1027,6 +1027,10 @@ struct fmt_main fmt_opencl_gpg = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		gpg_tests
 	},
 	{
@@ -1038,6 +1042,10 @@ struct fmt_main fmt_opencl_gpg = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_keychain_fmt.c
+++ b/src/opencl_keychain_fmt.c
@@ -369,6 +369,10 @@ struct fmt_main fmt_opencl_keychain = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		keychain_tests
 	}, {
 		init,
@@ -379,6 +383,10 @@ struct fmt_main fmt_opencl_keychain = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_keyring_fmt.c
+++ b/src/opencl_keyring_fmt.c
@@ -389,6 +389,10 @@ struct fmt_main fmt_opencl_keyring = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		keyring_tests
 	}, {
 		init,
@@ -399,6 +403,10 @@ struct fmt_main fmt_opencl_keyring = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_krb5pa-md5_fmt.c
+++ b/src/opencl_krb5pa-md5_fmt.c
@@ -735,6 +735,10 @@ struct fmt_main fmt_opencl_krb5pa_md5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -745,6 +749,10 @@ struct fmt_main fmt_opencl_krb5pa_md5 = {
 		split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_krb5pa-sha1_fmt.c
+++ b/src/opencl_krb5pa-sha1_fmt.c
@@ -925,6 +925,10 @@ struct fmt_main fmt_opencl_krb5pa_sha1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -935,6 +939,10 @@ struct fmt_main fmt_opencl_krb5pa_sha1 = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_mscash2_fmt.c
+++ b/src/opencl_mscash2_fmt.c
@@ -400,6 +400,10 @@ struct fmt_main fmt_opencl_mscash2 = {
 		MAX_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	},{
 		init,
@@ -410,6 +414,10 @@ struct fmt_main fmt_opencl_mscash2 = {
 		mscash2_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/opencl_mysqlsha1_fmt.c
+++ b/src/opencl_mysqlsha1_fmt.c
@@ -496,6 +496,10 @@ struct fmt_main fmt_opencl_mysqlsha1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -506,6 +510,10 @@ struct fmt_main fmt_opencl_mysqlsha1 = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_nsldaps_fmt.c
+++ b/src/opencl_nsldaps_fmt.c
@@ -418,6 +418,10 @@ struct fmt_main fmt_opencl_NSLDAPS = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_ssha_init,
@@ -428,6 +432,10 @@ struct fmt_main fmt_opencl_NSLDAPS = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_nt_fmt.c
+++ b/src/opencl_nt_fmt.c
@@ -406,6 +406,10 @@ struct fmt_main fmt_opencl_NT = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -416,6 +420,10 @@ struct fmt_main fmt_opencl_NT = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/opencl_ntlmv2_fmt.c
+++ b/src/opencl_ntlmv2_fmt.c
@@ -778,6 +778,10 @@ struct fmt_main fmt_opencl_NTLMv2 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -788,6 +792,10 @@ struct fmt_main fmt_opencl_NTLMv2 = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_o5logon_fmt.c
+++ b/src/opencl_o5logon_fmt.c
@@ -434,6 +434,10 @@ struct fmt_main fmt_opencl_o5logon = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT, // Changed for OpenCL
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		o5logon_tests
 	}, {
 		init,
@@ -444,6 +448,10 @@ struct fmt_main fmt_opencl_o5logon = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_odf_aes_fmt.c
+++ b/src/opencl_odf_aes_fmt.c
@@ -447,6 +447,10 @@ struct fmt_main fmt_opencl_odf_aes = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -457,6 +461,10 @@ struct fmt_main fmt_opencl_odf_aes = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_odf_fmt.c
+++ b/src/opencl_odf_fmt.c
@@ -450,6 +450,10 @@ struct fmt_main fmt_opencl_odf = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		odf_tests
 	}, {
 		init,
@@ -460,6 +464,10 @@ struct fmt_main fmt_opencl_odf = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_office2007_fmt.c
+++ b/src/opencl_office2007_fmt.c
@@ -662,6 +662,10 @@ struct fmt_main fmt_opencl_office2007 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_UTF8 | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -672,6 +676,10 @@ struct fmt_main fmt_opencl_office2007 = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_office2010_fmt.c
+++ b/src/opencl_office2010_fmt.c
@@ -660,6 +660,10 @@ struct fmt_main fmt_opencl_office2010 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_UTF8 | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -670,6 +674,10 @@ struct fmt_main fmt_opencl_office2010 = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_office2013_fmt.c
+++ b/src/opencl_office2013_fmt.c
@@ -653,6 +653,10 @@ struct fmt_main fmt_opencl_office2013 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_UTF8 | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -663,6 +667,10 @@ struct fmt_main fmt_opencl_office2013 = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_pbkdf2_hmac_sha256_fmt.c
+++ b/src/opencl_pbkdf2_hmac_sha256_fmt.c
@@ -486,6 +486,10 @@ struct fmt_main fmt_opencl_pbkdf2_hmac_sha256 = {
 	1,
 	1,
 	FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 	tests
 }, {
 	init,
@@ -496,6 +500,10 @@ struct fmt_main fmt_opencl_pbkdf2_hmac_sha256 = {
 	fmt_default_split,
 	binary,
 	get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 	fmt_default_source,
 	{
 		binary_hash_0,

--- a/src/opencl_pbkdf2_hmac_sha512_fmt.c
+++ b/src/opencl_pbkdf2_hmac_sha512_fmt.c
@@ -407,6 +407,10 @@ struct fmt_main fmt_opencl_pbkdf2_hmac_sha512 = {
 		    1,
 		    1,
 		    FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 	            tests}, {
 		    init,
 		    done,
@@ -416,6 +420,10 @@ struct fmt_main fmt_opencl_pbkdf2_hmac_sha512 = {
 		    fmt_default_split,
 		    binary,
 		    get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		    fmt_default_source,
 		    {
 				binary_hash_0,

--- a/src/opencl_phpass_fmt.c
+++ b/src/opencl_phpass_fmt.c
@@ -433,6 +433,10 @@ struct fmt_main fmt_opencl_phpass = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -443,6 +447,10 @@ struct fmt_main fmt_opencl_phpass = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/opencl_pwsafe_fmt.c
+++ b/src/opencl_pwsafe_fmt.c
@@ -406,6 +406,10 @@ struct fmt_main fmt_opencl_pwsafe = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		pwsafe_tests
 	}, {
 		init,
@@ -416,6 +420,10 @@ struct fmt_main fmt_opencl_pwsafe = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_rakp_fmt.c
+++ b/src/opencl_rakp_fmt.c
@@ -432,6 +432,10 @@ struct fmt_main fmt_opencl_rakp = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -442,6 +446,10 @@ struct fmt_main fmt_opencl_rakp = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_rar_fmt.c
+++ b/src/opencl_rar_fmt.c
@@ -1083,6 +1083,10 @@ struct fmt_main fmt_opencl_rar = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_UTF8 | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		cpu_tests // Changed in init if GPU
 	},{
 		init,
@@ -1093,6 +1097,10 @@ struct fmt_main fmt_opencl_rar = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_rawmd4_fmt.c
+++ b/src/opencl_rawmd4_fmt.c
@@ -339,6 +339,10 @@ struct fmt_main fmt_opencl_rawMD4 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -349,6 +353,10 @@ struct fmt_main fmt_opencl_rawMD4 = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_rawmd5_fmt.c
+++ b/src/opencl_rawmd5_fmt.c
@@ -336,6 +336,10 @@ struct fmt_main fmt_opencl_rawMD5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -346,6 +350,10 @@ struct fmt_main fmt_opencl_rawMD5 = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_rawsha1_fmt.c
+++ b/src/opencl_rawsha1_fmt.c
@@ -367,6 +367,10 @@ struct fmt_main fmt_opencl_rawSHA1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -377,6 +381,10 @@ struct fmt_main fmt_opencl_rawSHA1 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_rawsha256_fmt.c
+++ b/src/opencl_rawsha256_fmt.c
@@ -500,6 +500,10 @@ struct fmt_main fmt_opencl_rawsha256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -510,6 +514,10 @@ struct fmt_main fmt_opencl_rawsha256 = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/opencl_rawsha512-ng_fmt.c
+++ b/src/opencl_rawsha512-ng_fmt.c
@@ -659,6 +659,10 @@ struct fmt_main fmt_opencl_rawsha512_ng = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		raw_tests
 	}, {
 		init,
@@ -669,6 +673,10 @@ struct fmt_main fmt_opencl_rawsha512_ng = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,
@@ -715,6 +723,10 @@ struct fmt_main fmt_opencl_xsha512_ng = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		x_tests
 	}, {
 		init_x,
@@ -725,6 +737,10 @@ struct fmt_main fmt_opencl_xsha512_ng = {
 		split_x,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/opencl_rawsha512_fmt.c
+++ b/src/opencl_rawsha512_fmt.c
@@ -435,6 +435,10 @@ struct fmt_main fmt_opencl_rawsha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -445,6 +449,10 @@ struct fmt_main fmt_opencl_rawsha512 = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/opencl_strip_fmt.c
+++ b/src/opencl_strip_fmt.c
@@ -379,6 +379,10 @@ struct fmt_main fmt_opencl_strip = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		strip_tests
 	}, {
 		init,
@@ -389,6 +393,10 @@ struct fmt_main fmt_opencl_strip = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/opencl_sxc_fmt.c
+++ b/src/opencl_sxc_fmt.c
@@ -464,6 +464,10 @@ struct fmt_main fmt_opencl_sxc = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		sxc_tests
 	}, {
 		init,
@@ -474,6 +478,10 @@ struct fmt_main fmt_opencl_sxc = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/opencl_wpapsk_fmt.c
+++ b/src/opencl_wpapsk_fmt.c
@@ -507,6 +507,10 @@ struct fmt_main fmt_opencl_wpapsk = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -517,6 +521,10 @@ struct fmt_main fmt_opencl_wpapsk = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/opencl_xsha512_fmt.c
+++ b/src/opencl_xsha512_fmt.c
@@ -513,6 +513,10 @@ struct fmt_main fmt_opencl_xsha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 	    tests
 	}, {
 		init,
@@ -523,6 +527,10 @@ struct fmt_main fmt_opencl_xsha512 = {
 		fmt_default_split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/opencl_zip_fmt.c
+++ b/src/opencl_zip_fmt.c
@@ -367,6 +367,10 @@ struct fmt_main fmt_opencl_zip = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		zip_tests
 	}, {
 		init,
@@ -377,6 +381,10 @@ struct fmt_main fmt_opencl_zip = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/openssl_enc_fmt_plug.c
+++ b/src/openssl_enc_fmt_plug.c
@@ -406,6 +406,10 @@ struct fmt_main fmt_openssl = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		openssl_tests
 	}, {
 		init,
@@ -416,6 +420,10 @@ struct fmt_main fmt_openssl = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/options.h
+++ b/src/options.h
@@ -158,7 +158,7 @@
 #define FLG_DEVICE			0x2000000000000000ULL
 
 /* Tunable cost ranges requested */
-#define FLG_COST			0x4000000000000000ULL
+#define FLG_COSTS			0x4000000000000000ULL
 
 /*
  * Structure with option flags and all the parameters.

--- a/src/oracle11_fmt_plug.c
+++ b/src/oracle11_fmt_plug.c
@@ -428,6 +428,10 @@ struct fmt_main fmt_oracle11 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -438,6 +442,10 @@ struct fmt_main fmt_oracle11 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/oracle_fmt_plug.c
+++ b/src/oracle_fmt_plug.c
@@ -343,6 +343,10 @@ struct fmt_main fmt_oracle = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_8_BIT | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -353,6 +357,10 @@ struct fmt_main fmt_oracle = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash0,

--- a/src/osc_fmt_plug.c
+++ b/src/osc_fmt_plug.c
@@ -141,7 +141,11 @@ struct fmt_main fmt_OSC =
 		// setup the labeling and stuff. NOTE the max and min crypts are set to 1
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
-		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT, osc_tests
+		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{ },
+#endif
+		osc_tests
 	},
 	{
 		/*  All we setup here, is the pointer to valid, and the pointer to init */

--- a/src/panama_fmt_plug.c
+++ b/src/panama_fmt_plug.c
@@ -177,6 +177,10 @@ struct fmt_main fmt_panama_ = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		panama__tests
 	}, {
 		init,
@@ -187,6 +191,10 @@ struct fmt_main fmt_panama_ = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/pbkdf2-hmac-sha1_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha1_fmt_plug.c
@@ -326,6 +326,10 @@ struct fmt_main fmt_pbkdf2_hmac_sha1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -336,6 +340,10 @@ struct fmt_main fmt_pbkdf2_hmac_sha1 = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/pbkdf2-hmac-sha512_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha512_fmt_plug.c
@@ -377,6 +377,10 @@ struct fmt_main fmt_pbkdf2_hmac_sha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -387,6 +391,10 @@ struct fmt_main fmt_pbkdf2_hmac_sha512 = {
 		split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/pbkdf2_hmac_sha256_fmt_plug.c
@@ -619,6 +619,10 @@ struct fmt_main fmt_pbkdf2_hmac_sha256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	},{
 		init,
@@ -629,6 +633,10 @@ struct fmt_main fmt_pbkdf2_hmac_sha256 = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/pdf_fmt_plug.c
+++ b/src/pdf_fmt_plug.c
@@ -632,6 +632,10 @@ struct fmt_main fmt_pdf = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		pdf_tests
 	},
 	{
@@ -643,6 +647,10 @@ struct fmt_main fmt_pdf = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/pfx_fmt.c
+++ b/src/pfx_fmt.c
@@ -241,6 +241,10 @@ struct fmt_main fmt_pfx = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		pfx_tests
 	}, {
 		init,
@@ -251,6 +255,10 @@ struct fmt_main fmt_pfx = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/phpassMD5_fmt_plug.c
+++ b/src/phpassMD5_fmt_plug.c
@@ -135,7 +135,11 @@ struct fmt_main fmt_phpassmd5 =
 		// setup the labeling and stuff. NOTE the max and min crypts are set to 1
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
-		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT, phpassmd5_tests
+		PLAINTEXT_LENGTH, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE+1, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{ },
+#endif
+		phpassmd5_tests
 	},
 	{
 		/*  All we setup here, is the pointer to valid, and the pointer to init */

--- a/src/pixMD5_fmt_plug.c
+++ b/src/pixMD5_fmt_plug.c
@@ -85,7 +85,11 @@ struct fmt_main fmt_pixMD5 = {
 		// setup the labeling and stuff. NOTE the max and min crypts are set to 1
 		// here, but will be reset within our init() function.
 		FORMAT_LABEL, FORMAT_NAME, ALGORITHM_NAME, BENCHMARK_COMMENT, BENCHMARK_LENGTH,
-		16, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT, pixmd5_tests
+		16, BINARY_SIZE, DEFAULT_ALIGN, SALT_SIZE, DEFAULT_ALIGN, 1, 1, FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{ },
+#endif
+		pixmd5_tests
 	},
 	{
 		/*  All we setup here, is the pointer to valid, and the pointer to init */

--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -1633,6 +1633,10 @@ struct fmt_main fmt_pkzip = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -1643,6 +1647,10 @@ struct fmt_main fmt_pkzip = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash0,

--- a/src/postgres_fmt_plug.c
+++ b/src/postgres_fmt_plug.c
@@ -264,6 +264,10 @@ struct fmt_main fmt_postgres = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		postgres_tests
 	}, {
 		init,
@@ -274,6 +278,10 @@ struct fmt_main fmt_postgres = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/pst_fmt_plug.c
+++ b/src/pst_fmt_plug.c
@@ -159,6 +159,10 @@ struct fmt_main fmt_pst = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_NOT_EXACT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -169,6 +173,10 @@ struct fmt_main fmt_pst = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/putty_fmt_plug.c
+++ b/src/putty_fmt_plug.c
@@ -385,6 +385,10 @@ struct fmt_main fmt_putty = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		putty_tests
 	},
 	{
@@ -396,6 +400,10 @@ struct fmt_main fmt_putty = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/pwsafe_fmt_plug.c
+++ b/src/pwsafe_fmt_plug.c
@@ -560,6 +560,10 @@ struct fmt_main fmt_pwsafe = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		pwsafe_tests
 	}, {
 		init,
@@ -570,6 +574,10 @@ struct fmt_main fmt_pwsafe = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/racf_fmt_plug.c
+++ b/src/racf_fmt_plug.c
@@ -313,6 +313,10 @@ struct fmt_main fmt_racf = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		racf_tests
 	}, {
 		init,
@@ -323,6 +327,10 @@ struct fmt_main fmt_racf = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/radmin_fmt_plug.c
+++ b/src/radmin_fmt_plug.c
@@ -180,6 +180,10 @@ struct fmt_main fmt_radmin = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		radmin_tests
 	}, {
 		init,
@@ -190,6 +194,10 @@ struct fmt_main fmt_radmin = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rakp_fmt_plug.c
+++ b/src/rakp_fmt_plug.c
@@ -469,6 +469,10 @@ struct fmt_main fmt_rakp = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -479,6 +483,10 @@ struct fmt_main fmt_rakp = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rar5_fmt_plug.c
+++ b/src/rar5_fmt_plug.c
@@ -327,6 +327,10 @@ struct fmt_main fmt_rar5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		rar5_tests
 	}, {
 		init,
@@ -337,6 +341,10 @@ struct fmt_main fmt_rar5 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rar_fmt.c
+++ b/src/rar_fmt.c
@@ -806,6 +806,10 @@ struct fmt_main fmt_rar = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_UTF8 | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		cpu_tests
 	},{
 		init,
@@ -816,6 +820,10 @@ struct fmt_main fmt_rar = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/rawBLAKE2_512_fmt_plug.c
+++ b/src/rawBLAKE2_512_fmt_plug.c
@@ -228,6 +228,10 @@ struct fmt_main fmt_rawBLAKE2 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -238,6 +242,10 @@ struct fmt_main fmt_rawBLAKE2 = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawKeccak_256_fmt_plug.c
+++ b/src/rawKeccak_256_fmt_plug.c
@@ -233,6 +233,10 @@ struct fmt_main fmt_rawKeccak_256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -243,6 +247,10 @@ struct fmt_main fmt_rawKeccak_256 = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawKeccak_512_fmt_plug.c
+++ b/src/rawKeccak_512_fmt_plug.c
@@ -228,6 +228,10 @@ struct fmt_main fmt_rawKeccak = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -238,6 +242,10 @@ struct fmt_main fmt_rawKeccak = {
 		split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -371,6 +371,10 @@ struct fmt_main fmt_rawMD4 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_OMP_BAD,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -381,6 +385,10 @@ struct fmt_main fmt_rawMD4 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -340,6 +340,10 @@ struct fmt_main fmt_rawMD5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_OMP_BAD,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -350,6 +354,10 @@ struct fmt_main fmt_rawMD5 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawSHA0_fmt.c
+++ b/src/rawSHA0_fmt.c
@@ -152,6 +152,10 @@ struct fmt_main fmt_rawSHA0 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_default_init,
@@ -162,6 +166,10 @@ struct fmt_main fmt_rawSHA0 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawSHA1_fmt_plug.c
+++ b/src/rawSHA1_fmt_plug.c
@@ -345,6 +345,10 @@ struct fmt_main fmt_rawSHA1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -355,6 +359,10 @@ struct fmt_main fmt_rawSHA1 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawSHA1_linkedIn_fmt_plug.c
+++ b/src/rawSHA1_linkedIn_fmt_plug.c
@@ -377,6 +377,10 @@ struct fmt_main fmt_rawSHA1_LI = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_default_init,
@@ -387,6 +391,10 @@ struct fmt_main fmt_rawSHA1_LI = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		source,
 		{
 			binary_hash_0,

--- a/src/rawSHA1_ng_fmt.c
+++ b/src/rawSHA1_ng_fmt.c
@@ -728,6 +728,10 @@ struct fmt_main fmt_sha1_ng = {
         .min_keys_per_crypt = 4,
         .max_keys_per_crypt = SHA1_PARALLEL_HASH,
         .flags              = FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+	.tunable_cost_name  = {
+	},
+#endif
         .tests              = sha1_fmt_tests,
     },
     .methods                = {
@@ -739,6 +743,10 @@ struct fmt_main fmt_sha1_ng = {
         .split              = sha1_fmt_split,
         .binary             = sha1_fmt_binary,
         .salt               = fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+	.tunable_cost_value = {
+	},
+#endif
         .source             = fmt_default_source,
         .salt_hash          = fmt_default_salt_hash,
         .set_salt           = fmt_default_set_salt,

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -314,6 +314,10 @@ struct fmt_main fmt_rawSHA224 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -324,6 +328,10 @@ struct fmt_main fmt_rawSHA224 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -288,6 +288,10 @@ struct fmt_main fmt_rawSHA256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -298,6 +302,10 @@ struct fmt_main fmt_rawSHA256 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawSHA256_ng_fmt.c
+++ b/src/rawSHA256_ng_fmt.c
@@ -532,6 +532,10 @@ struct fmt_main fmt_rawSHA256_ng = {
         MIN_KEYS_PER_CRYPT,
         MAX_KEYS_PER_CRYPT,
         FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         tests
     }, {
         init,
@@ -545,6 +549,10 @@ struct fmt_main fmt_rawSHA256_ng = {
         get_binary,
         fmt_default_salt,
 #if FMT_MAIN_VERSION > 9
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         fmt_default_source,
 #endif
         {

--- a/src/rawSHA256_ng_i_fmt.c
+++ b/src/rawSHA256_ng_i_fmt.c
@@ -410,6 +410,10 @@ struct fmt_main fmt_rawSHA256_ng_i = {
         MIN_KEYS_PER_CRYPT,
         MAX_KEYS_PER_CRYPT,
         FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         tests
     }, {
         init,
@@ -423,6 +427,10 @@ struct fmt_main fmt_rawSHA256_ng_i = {
         get_binary,
         fmt_default_salt,
 #if FMT_MAIN_VERSION > 9
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         fmt_default_source,
 #endif
         {

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -338,6 +338,10 @@ struct fmt_main fmt_rawSHA384 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -348,6 +352,10 @@ struct fmt_main fmt_rawSHA384 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -344,6 +344,10 @@ struct fmt_main fmt_raw0_SHA512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -354,6 +358,10 @@ struct fmt_main fmt_raw0_SHA512 = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/rawSHA512_ng_fmt.c
+++ b/src/rawSHA512_ng_fmt.c
@@ -545,6 +545,10 @@ struct fmt_main fmt_rawSHA512_ng = {
         MIN_KEYS_PER_CRYPT,
         MAX_KEYS_PER_CRYPT,
         FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         tests
     }, {
         init,
@@ -558,6 +562,10 @@ struct fmt_main fmt_rawSHA512_ng = {
         get_binary,
         fmt_default_salt,
 #if FMT_MAIN_VERSION > 9
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         fmt_default_source,
 #endif
         {

--- a/src/rawSHA512_ng_i_fmt.c
+++ b/src/rawSHA512_ng_i_fmt.c
@@ -427,6 +427,10 @@ struct fmt_main fmt_rawSHA512_ng_i = {
         MIN_KEYS_PER_CRYPT,
         MAX_KEYS_PER_CRYPT,
         FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         tests
     }, {
         init,
@@ -440,6 +444,10 @@ struct fmt_main fmt_rawSHA512_ng_i = {
         get_binary,
         fmt_default_salt,
 #if FMT_MAIN_VERSION > 9
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
         fmt_default_source,
 #endif
         {

--- a/src/rawmd5u_fmt_plug.c
+++ b/src/rawmd5u_fmt_plug.c
@@ -575,6 +575,10 @@ struct fmt_main fmt_rawmd5uthick = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -585,6 +589,10 @@ struct fmt_main fmt_rawmd5uthick = {
 		split,
 		binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/ripemd_fmt_plug.c
+++ b/src/ripemd_fmt_plug.c
@@ -226,6 +226,10 @@ struct fmt_main fmt_ripemd_160 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		ripemd_160_tests
 	}, {
 		init,
@@ -236,6 +240,10 @@ struct fmt_main fmt_ripemd_160 = {
 		fmt_default_split,
 		get_binary_160,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -283,6 +291,10 @@ struct fmt_main fmt_ripemd_128 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		ripemd_128_tests
 	}, {
 		init,
@@ -293,6 +305,10 @@ struct fmt_main fmt_ripemd_128 = {
 		fmt_default_split,
 		get_binary_128,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/salted_sha1_fmt_plug.c
+++ b/src/salted_sha1_fmt_plug.c
@@ -370,6 +370,10 @@ struct fmt_main fmt_saltedsha = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_default_init,
@@ -380,6 +384,10 @@ struct fmt_main fmt_saltedsha = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/sapB_fmt_plug.c
+++ b/src/sapB_fmt_plug.c
@@ -683,6 +683,10 @@ struct fmt_main fmt_sapB = {
 		FMT_OMP |
 #endif
 		FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -693,6 +697,10 @@ struct fmt_main fmt_sapB = {
 		split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/sapG_fmt_plug.c
+++ b/src/sapG_fmt_plug.c
@@ -744,6 +744,10 @@ struct fmt_main fmt_sapG = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT | FMT_UTF8,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -754,6 +758,10 @@ struct fmt_main fmt_sapG = {
 		split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/scrypt_fmt.c
+++ b/src/scrypt_fmt.c
@@ -338,6 +338,10 @@ struct fmt_main fmt_scrypt = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -348,6 +352,10 @@ struct fmt_main fmt_scrypt = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/sha1_gen_fmt_plug.c
+++ b/src/sha1_gen_fmt_plug.c
@@ -217,6 +217,10 @@ struct fmt_main fmt_sha1_gen = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_default_init,
@@ -227,6 +231,10 @@ struct fmt_main fmt_sha1_gen = {
 		fmt_default_split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -227,6 +227,10 @@ struct fmt_main fmt_s7 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		s7_tests
 	}, {
 		init,
@@ -237,6 +241,10 @@ struct fmt_main fmt_s7 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/sip_fmt_plug.c
+++ b/src/sip_fmt_plug.c
@@ -335,6 +335,10 @@ struct fmt_main fmt_sip = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		sip_tests
 	}, {
 		init,
@@ -345,6 +349,10 @@ struct fmt_main fmt_sip = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/skein_fmt_plug.c
+++ b/src/skein_fmt_plug.c
@@ -226,6 +226,10 @@ struct fmt_main fmt_skein_256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		skein_256_tests
 	}, {
 		init,
@@ -236,6 +240,10 @@ struct fmt_main fmt_skein_256 = {
 		fmt_default_split,
 		get_binary_256,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -283,6 +291,10 @@ struct fmt_main fmt_skein_512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		skein_512_tests
 	}, {
 		init,
@@ -293,6 +305,10 @@ struct fmt_main fmt_skein_512 = {
 		fmt_default_split,
 		get_binary_512,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/snefru_fmt_plug.c
+++ b/src/snefru_fmt_plug.c
@@ -226,6 +226,10 @@ struct fmt_main fmt_snefru_256 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		snefru_256_tests
 	}, {
 		init,
@@ -236,6 +240,10 @@ struct fmt_main fmt_snefru_256 = {
 		fmt_default_split,
 		get_binary_256,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -283,6 +291,10 @@ struct fmt_main fmt_snefru_128 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		snefru_128_tests
 	}, {
 		init,
@@ -293,6 +305,10 @@ struct fmt_main fmt_snefru_128 = {
 		fmt_default_split,
 		get_binary_128,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/ssh_fmt.c
+++ b/src/ssh_fmt.c
@@ -423,6 +423,10 @@ struct fmt_main fmt_ssh = {
 		FMT_OMP |
 #endif
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		ssh_tests
 	}, {
 		init,
@@ -433,6 +437,10 @@ struct fmt_main fmt_ssh = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/ssh_ng_fmt_plug.c
+++ b/src/ssh_ng_fmt_plug.c
@@ -409,6 +409,10 @@ struct fmt_main fmt_sshng = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		sshng_tests
 	}, {
 		init,
@@ -419,6 +423,10 @@ struct fmt_main fmt_sshng = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -222,6 +222,10 @@ struct fmt_main fmt_saltedsha2 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -232,6 +236,10 @@ struct fmt_main fmt_saltedsha2 = {
 		fmt_default_split,
 		binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/strip_fmt_plug.c
+++ b/src/strip_fmt_plug.c
@@ -272,6 +272,10 @@ struct fmt_main fmt_strip = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		strip_tests
 	}, {
 		init,
@@ -282,6 +286,10 @@ struct fmt_main fmt_strip = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/sunmd5_fmt_plug.c
+++ b/src/sunmd5_fmt_plug.c
@@ -886,6 +886,10 @@ struct fmt_main fmt_sunmd5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -896,6 +900,10 @@ struct fmt_main fmt_sunmd5 = {
 		fmt_default_split,
 		binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/sxc_fmt_plug.c
+++ b/src/sxc_fmt_plug.c
@@ -363,6 +363,10 @@ struct fmt_main fmt_sxc = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		sxc_tests
 	}, {
 		init,
@@ -373,6 +377,10 @@ struct fmt_main fmt_sxc = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/tcp_md5_fmt_plug.c
+++ b/src/tcp_md5_fmt_plug.c
@@ -223,6 +223,10 @@ struct fmt_main fmt_tcpmd5 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -233,6 +237,10 @@ struct fmt_main fmt_tcpmd5 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/tiger_fmt_plug.c
+++ b/src/tiger_fmt_plug.c
@@ -178,6 +178,10 @@ struct fmt_main fmt_tiger = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tiger_tests
 	}, {
 		init,
@@ -188,6 +192,10 @@ struct fmt_main fmt_tiger = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/trip_fmt.c
+++ b/src/trip_fmt.c
@@ -596,6 +596,10 @@ struct fmt_main fmt_trip = {
 #else
 		FMT_CASE,
 #endif
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -606,6 +610,10 @@ struct fmt_main fmt_trip = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash_0,

--- a/src/truecrypt_fmt.c
+++ b/src/truecrypt_fmt.c
@@ -319,6 +319,10 @@ struct fmt_main fmt_truecrypt = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests_ripemd160
 	}, {
 		init_ripemd160,
@@ -329,6 +333,10 @@ struct fmt_main fmt_truecrypt = {
 		ms_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash,
@@ -375,6 +383,10 @@ struct fmt_main fmt_truecrypt_sha512 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests_sha512
 	}, {
 		init_sha512,
@@ -385,6 +397,10 @@ struct fmt_main fmt_truecrypt_sha512 = {
 		ms_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash,
@@ -431,6 +447,10 @@ struct fmt_main fmt_truecrypt_whirlpool = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests_whirlpool
 	}, {
 		init_whirlpool,
@@ -441,6 +461,10 @@ struct fmt_main fmt_truecrypt_whirlpool = {
 		ms_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			binary_hash,

--- a/src/vms_fmt_plug.c
+++ b/src/vms_fmt_plug.c
@@ -233,6 +233,10 @@ struct fmt_main fmt_VMS = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		fmt_vms_init,			/* changed for jumbo */
@@ -243,6 +247,10 @@ struct fmt_main fmt_VMS = {
 		fmt_vms_split,
 		(void *(*)(char *))VMS_std_get_binary,
 		(void *(*)(char *))VMS_std_get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/vnc_fmt_plug.c
+++ b/src/vnc_fmt_plug.c
@@ -280,6 +280,10 @@ struct fmt_main fmt_vnc = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		vnc_tests
 	}, {
 		init,
@@ -290,6 +294,10 @@ struct fmt_main fmt_vnc = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/wbb3_fmt_plug.c
+++ b/src/wbb3_fmt_plug.c
@@ -266,6 +266,10 @@ struct fmt_main fmt_wbb3 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		wbb3_tests
 	}, {
 		init,
@@ -276,6 +280,10 @@ struct fmt_main fmt_wbb3 = {
 		fmt_default_split,
 		get_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/whirlpool_fmt_plug.c
+++ b/src/whirlpool_fmt_plug.c
@@ -233,6 +233,10 @@ struct fmt_main fmt_whirlpool_0 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		whirlpool_0_tests
 	}, {
 		init,
@@ -243,6 +247,10 @@ struct fmt_main fmt_whirlpool_0 = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -290,6 +298,10 @@ struct fmt_main fmt_whirlpool_1 = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		whirlpool_1_tests
 	}, {
 		init,
@@ -300,6 +312,10 @@ struct fmt_main fmt_whirlpool_1 = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,
@@ -346,6 +362,10 @@ struct fmt_main fmt_whirlpool = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		whirlpool_tests
 	}, {
 		init,
@@ -356,6 +376,10 @@ struct fmt_main fmt_whirlpool = {
 		fmt_default_split,
 		get_binary,
 		fmt_default_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/wow_srp_fmt_plug.c
+++ b/src/wow_srp_fmt_plug.c
@@ -420,6 +420,10 @@ struct fmt_main fmt_blizzard = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		tests
 	}, {
 		init,
@@ -430,6 +434,10 @@ struct fmt_main fmt_blizzard = {
 		split,
 		get_binary,
 		salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash_0,

--- a/src/wpapsk_fmt.c
+++ b/src/wpapsk_fmt.c
@@ -398,6 +398,10 @@ struct fmt_main fmt_wpapsk = {
 		    MIN_KEYS_PER_CRYPT,
 		    MAX_KEYS_PER_CRYPT,
 		    FMT_CASE | FMT_OMP,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		    tests
 	},
 	{
@@ -409,6 +413,10 @@ struct fmt_main fmt_wpapsk = {
 		    fmt_default_split,
 		    binary,
 		    salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		    fmt_default_source,
 		    {
 				binary_hash_0,

--- a/src/zip_fmt.c
+++ b/src/zip_fmt.c
@@ -256,6 +256,10 @@ struct fmt_main fmt_zip = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT*BASE_SCALE,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT,   /*ldr_remove_hash(crk_db, salt, pw);*/
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		zip_tests
 	}, {
 		init,
@@ -266,6 +270,10 @@ struct fmt_main fmt_zip = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
+#if FMT_MAIN_VERSION > 11
+		{
+		},
+#endif
 		fmt_default_source,
 		{
 			fmt_default_binary_hash


### PR DESCRIPTION
The following functionality is supported:
-listing format specific tunable cost parameters
 in --list=format-details and --list=format-all-details
-format specific functions to calculate tunable costs per salt
-check loaded hashes for differences in tunable cost values,
 print warning messages to stdout and to log file if such
 differences are found
-filter salts based on --costs= (works similar to --salts=,
 except that values or ranges for cost parameters can be
 specified in a comma separated list:
 --cost=-2 (cost of first cost parameter must be smaller than 2)
 --cost=2,10:20 (cost of 1st parameter is >= 2, of 2nd between 10 and 20)
 --cost=:,10:20 (first cost parameter ignored, 2nd between 10 and 20)
 --cost=:,-3 (first cost parameter ignored, 2nd smaller than 3)

Currently, up to 2 tunable cost parameters are supported.
This can easily be adjusted by increasing FMT_TUNABLE_COSTS.
Cost values are unsigned int.

Format version bumped to 12, but just reverting it to 11
disables all the changes.

All formats have been adjusted so that they work with
FMT_MAIN_VERSION 11 and with FMT_MAIN_VERSION 12.

But most formats don't yet report tunable cost parameter and their
values per salt.
The only exceptions so far are:
Format label                         bcrypt
Tunable cost parameters              iteration count

Format label                         crypt
Tunable cost parameters              algorithm [1:descrypt/2:md5crypt/3:sunmd5/4:bcrypt/5:sha256crypt/6:sha512crypt]
                                     algorithm specific tunable cost

So, since --format=crypt --subformat=... only works for --test,
you an use --format=crypt --costs=2 to pick md5crypt hashes.
The 2nd tunable cost for --format=crypt currently is a dummy,
always returning exactly the same ost as the 1st parameter.
My intension is to return the subformat specific tunable cost parameter
(i.e., iteration count) in a later revision.

$ ./john --format=bcrypt bcrypt.hashes
Loaded 13 password hashes with 9 different salts (bcrypt [Blowfish 32/64 X2])
Remaining 12 password hashes with 8 different salts
Loaded hashes with cost 1 (iteration count) varying from 16 to 256
Press 'q' or Ctrl-C to abort, almost any other key for status
0g 0:00:00:05 70.79% 1/3 (ETA: 16:35:21) 0g/s 553.5p/s 553.5c/s 1203C/s #3#..$3$
Session aborted

The "Loaded hashes with cost 1 (iteration count) varying from 16 to 256" line
appears only if the remaining loaded hashes differ in their tunable cost.
E.g., if there are only 2 different cost values, and all hashes of the lower
cost value have already been cracked, the line doesn't appear.
