### PR TITLE
Fixes for Mac OS X and parallel compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -105,7 +105,7 @@ CFLAGS = -c -Wall -Wdeclaration-after-statement -O2 -fomit-frame-pointer -I/usr/
 CFLAGS_MAIN = $(CFLAGS)
 ASFLAGS = -c $(OMPFLAGS) $(JOHN_ASFLAGS)
 LDFLAGS = -s -L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz \
-	$(OMPFLAGS) $(NSS_LDFLAGS) $(GMP_LDFLAGS) $(KRB5_LDFLAGS) $(JOHN_LDFLAGS) $(REXGEN_LDFLAGS) aes/aes.a
+	$(OMPFLAGS) $(NSS_LDFLAGS) $(GMP_LDFLAGS) $(KRB5_LDFLAGS) $(JOHN_LDFLAGS) $(REXGEN_LDFLAGS)
 # -lskey
 LDFLAGS_SOLARIS = -lrt -lnsl -lsocket -lm -lz -lcrypto -lssl
 LDFLAGS_MKV = -s -lm
@@ -2072,7 +2072,7 @@ $(SUBDIRS):
 	$(MAKE) -C $@ all
 
 ../run/john: $(JOHN_OBJS) $(SUBDIRS)
-	$(LD) $(JOHN_OBJS) $(LDFLAGS) -o ../run/john
+	$(LD) $(JOHN_OBJS) $(LDFLAGS) aes/aes.a -o ../run/john
 
 ../run/unshadow: ../run/john
 	$(RM) ../run/unshadow

--- a/src/aes/openssl/ossl_aes.c
+++ b/src/aes/openssl/ossl_aes.c
@@ -1,4 +1,5 @@
 #include <openssl/aes.h>
+#include <stddef.h>
 
 static inline void aes_key_mgmt(AES_KEY *akey, unsigned char *key, unsigned int key_length, int direction) {
 	if (direction == AES_ENCRYPT) {


### PR DESCRIPTION
I think the issue you encountered on OS X could happen on any platform with parallel compilation - I added aes.a to LDFLAGS, and I only marked the john executable as requiring the AES folder to actually be built, so I suspect it was one of the other executables being linked that threw the error for you. Simple fix - move aes.a from LDFLAGS to the line specific for building the john executable.

That said, I don't have access to an OS X machine with more than two processor cores, and I couldn’t replicate that particular issue. So if you could double check if these changes help on a machine that can actually run eight things in parallel, it'd be appreciated.

Also, while building on a Mac OS X Mavericks machine, I discovered a small problem that could occur while building part of the wrapper, so that's been fixed.
