### PR TITLE
Fix AES-NI support for 32 bit Linux builds

### DIFF
--- a/src/Makefile.orig
+++ b/src/Makefile.orig
@@ -416,7 +416,7 @@ linux-x86-64-avx:
 		CFLAGS="$(CFLAGS) -mavx -DHAVE_CRYPT -DHAVE_LIBDL" \
 		ASFLAGS="$(ASFLAGS) -mavx" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -430,7 +430,7 @@ linux-x86-64-xop:
 		CFLAGS="$(CFLAGS) -mxop -DHAVE_CRYPT -DHAVE_LIBDL" \
 		ASFLAGS="$(ASFLAGS) -mxop" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -443,7 +443,7 @@ linux-x86-64-gpu:
 		CFLAGS="$(CFLAGS) -I$(OCLROOT)/include -I$(CUDAPATH)/include -DHAVE_CRYPT -DHAVE_OPENCL -DHAVE_CUDA -DHAVE_LIBDL -march=native" \
 		ASFLAGS="$(ASFLAGS) -march=native" \
 		LDFLAGS="$(LDFLAGS) -L$(OCLROOT)/lib/x86_64 -L$(OCLROOT)/lib64 -L$(CUDAPATH)/lib64 -lcrypt -lOpenCL -ldl -lcudart -march=native" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	$(MKDIR) ../run/kernels/
 	$(CP_PRESERVE) opencl/*.cl ../run/kernels/
 	$(CP_PRESERVE) opencl_*.h ../run/kernels/
@@ -459,7 +459,7 @@ linux-x86-64-opencl:
 		CFLAGS="$(CFLAGS) -I$(OCLROOT)/include -DHAVE_CRYPT -DHAVE_OPENCL -DHAVE_LIBDL -march=native" \
 		ASFLAGS="$(ASFLAGS) -march=native" \
 		LDFLAGS="$(LDFLAGS) -L$(OCLROOT)/lib/x86_64 -L$(OCLROOT)/lib64 -lcrypt -lOpenCL -ldl -march=native" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	$(MKDIR) ../run/kernels/
 	$(CP_PRESERVE) opencl/*.cl ../run/kernels/
 	$(CP_PRESERVE) opencl_*.h ../run/kernels/
@@ -475,7 +475,7 @@ linux-x86-64-cuda:
 		CFLAGS="$(CFLAGS) -I$(CUDAPATH)/include -DHAVE_CRYPT -DHAVE_LIBDL -DHAVE_CUDA -march=native" \
 		ASFLAGS="$(ASFLAGS) -march=native" \
 		LDFLAGS="$(LDFLAGS) -L$(CUDAPATH)/lib64 -lcrypt -ldl -lcudart -march=native" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -488,7 +488,7 @@ linux-x86-64-native:
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT -DHAVE_LIBDL -march=native" \
 		ASFLAGS="$(ASFLAGS) -march=native" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl -march=native" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -501,7 +501,8 @@ linux-X32-native:
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT -DHAVE_LIBDL -march=native -mx32" \
 		ASFLAGS="$(ASFLAGS) -march=native -mx32" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl -march=native -mx32" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
+#		not sure if elf32 is the right format here, but elf86 was definitely wrong
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -514,7 +515,8 @@ linux-X32:
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT -DHAVE_LIBDL -mx32" \
 		ASFLAGS="$(ASFLAGS) -mx32" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl -mx32" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
+#		not sure if elf32 is the right format here, but elf86 was definitely wrong
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -526,7 +528,7 @@ linux-x86-64:
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o sse-intrinsics.o" \
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT -DHAVE_LIBDL" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -538,7 +540,7 @@ linux-x86-64i:
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o sse-intrinsics-64.o" \
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT -DHAVE_LIBDL -DUSING_ICC_S_FILE" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -551,7 +553,7 @@ linux-x86-64-clang:
 		CFLAGS="-Wall -c -O2 -I/usr/include -msse2 -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_NSS) $(HAVE_LIBGMP) $(HAVE_LIBKRB5) $(JOHN_CFLAGS)" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CC="clang"
 	@echo "All done"
@@ -564,7 +566,7 @@ linux-x86-64-clang-debug:
 		CFLAGS="-Wall -Wdeclaration-after-statement -c -g -O1 -faddress-sanitizer -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_NSS) $(HAVE_LIBGMP) $(HAVE_LIBKRB5) $(JOHN_CFLAGS)" \
 		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -faddress-sanitizer $(NSS_LDFLAGS) $(GMP_LDFLAGS) $(KRB5_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) \
 		CFLAGS="-Wall -Wdeclaration-after-statement -c -g -O1 -faddress-sanitizer -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_NSS) $(HAVE_LIBGMP) $(HAVE_LIBKRB5) $(JOHN_CFLAGS)" \
@@ -579,7 +581,7 @@ linux-x86-64-newgcc-debug:
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o sse-intrinsics.o" \
 		CFLAGS="-Wall -Wdeclaration-after-statement -c -g -O1 -fsanitize=address -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_NSS) $(HAVE_LIBGMP) $(HAVE_LIBKRB5) $(JOHN_CFLAGS)" \
 		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -fsanitize=address $(NSS_LDFLAGS) $(GMP_LDFLAGS) $(KRB5_LDFLAGS) $(JOHN_LDFLAGS)" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) \
 		CFLAGS="-Wall -Wdeclaration-after-statement -c -g -O1 -fsanitize=address -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_NSS) $(HAVE_LIBGMP) $(HAVE_LIBKRB5) $(JOHN_CFLAGS)" \
@@ -595,7 +597,7 @@ linux-x86-64-icc:
 		ASFLAGS="-c -xHost $(JOHN_ASFLAGS)" \
 		LDFLAGS="-lm -lssl -lcrypto -ipo -static-intel -lcrypt -ldl -lz $(ICCOMPFLAGS) -s $(NSS_LDFLAGS) $(GMP_LDFLAGS) $(KRB5_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="icc" CC="icc" AS="icc" LD="icc" \
-		AESNI_ARCH=64
+		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CPP="icc" CC="icc" AS="icc" LD="icc"
 	@echo "All done"
@@ -608,7 +610,7 @@ linux-x86-64-32-native:
 		CFLAGS="$(CFLAGS) -m32 -msse2 -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE -march=native" \
 		ASFLAGS="$(ASFLAGS) -m32 -msse2 -march=native" \
 		LDFLAGS="$(LDFLAGS) -m32 -lcrypt -ldl -march=native" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CFLAGS="$(CFLAGS) -m32"
 	@echo "All done"
@@ -621,7 +623,7 @@ linux-x86-64-32-sse2:
 		CFLAGS="$(CFLAGS) -m32 -msse2 -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE" \
 		ASFLAGS="$(ASFLAGS) -m32 -msse2" \
 		LDFLAGS="$(LDFLAGS) -m32 -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CFLAGS="$(CFLAGS) -m32"
 	@echo "All done"
@@ -634,7 +636,7 @@ linux-x86-64-32-sse2asm:
 		CFLAGS="$(CFLAGS) -m32 -msse2 -DHAVE_CRYPT -DHAVE_LIBDL -DJOHN_DISABLE_INTRINSICS -D_LARGEFILE64_SOURCE" \
 		ASFLAGS="$(ASFLAGS) -m32 -msse2" \
 		LDFLAGS="$(LDFLAGS) -m32 -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CFLAGS="$(CFLAGS) -m32"
 	@echo "All done"
@@ -647,7 +649,7 @@ linux-x86-64-32-sse2i:
 		CFLAGS="$(CFLAGS) -m32 -msse2 -DHAVE_CRYPT -DHAVE_LIBDL -DUSING_ICC_S_FILE -D_LARGEFILE64_SOURCE" \
 		ASFLAGS="$(ASFLAGS) -m32 -msse2" \
 		LDFLAGS="$(LDFLAGS) -m32 -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CFLAGS="$(CFLAGS) -m32"
 	@echo "All done"
@@ -660,7 +662,7 @@ linux-x86-64-32-mmx:
 		CFLAGS="$(CFLAGS) -m32 -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE" \
 		ASFLAGS="$(ASFLAGS) -m32" \
 		LDFLAGS="$(LDFLAGS) -m32 -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CFLAGS="$(CFLAGS) -m32"
 	@echo "All done"
@@ -673,7 +675,7 @@ linux-x86-64-32-any:
 		CFLAGS="$(CFLAGS) -m32 -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE" \
 		ASFLAGS="$(ASFLAGS) -m32" \
 		LDFLAGS="$(LDFLAGS) -m32 -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CFLAGS="$(CFLAGS) -m32"
 	@echo "All done"
@@ -687,7 +689,7 @@ linux-x86-avx:
 		CFLAGS="$(CFLAGS) -m32 -mavx -DHAVE_CRYPT" \
 		ASFLAGS="$(ASFLAGS) -m32 -mavx" \
 		LDFLAGS="$(LDFLAGS) -m32 -lcrypt" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CFLAGS="$(CFLAGS) -m32"
 	@echo "All done"
@@ -701,7 +703,7 @@ linux-x86-xop:
 		CFLAGS="$(CFLAGS) -m32 -mxop -DHAVE_CRYPT -D_LARGEFILE64_SOURCE" \
 		ASFLAGS="$(ASFLAGS) -m32 -mxop" \
 		LDFLAGS="$(LDFLAGS) -m32 -lcrypt" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CFLAGS="$(CFLAGS) -m32"
 	@echo "All done"
@@ -714,7 +716,7 @@ linux-x86-gpu:
 		CFLAGS="$(CFLAGS) -I$(OCLROOT)/include -I$(CUDAPATH)/include -DHAVE_CRYPT -DHAVE_OPENCL -DHAVE_CUDA -DHAVE_LIBDL -DUSING_ICC_S_FILE -D_LARGEFILE64_SOURCE -march=native" \
 		ASFLAGS="$(ASFLAGS) -march=native" \
 		LDFLAGS="$(LDFLAGS) -L$(OCLROOT)/lib/x86 -L$(OCLROOT)/lib -L$(CUDAPATH)/lib -lcrypt -lOpenCL -ldl -lcudart -march=native" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	$(MKDIR) ../run/kernels/
 	$(CP_PRESERVE) opencl/*.cl ../run/kernels/
 	$(CP_PRESERVE) opencl_*.h ../run/kernels/
@@ -730,7 +732,7 @@ linux-x86-opencl:
 		CFLAGS="$(CFLAGS) -I$(OCLROOT)/include -DHAVE_CRYPT -DHAVE_OPENCL -DHAVE_LIBDL -DUSING_ICC_S_FILE -D_LARGEFILE64_SOURCE -march=native" \
 		ASFLAGS="$(ASFLAGS) -march=native" \
 		LDFLAGS="$(LDFLAGS) -L$(OCLROOT)/lib/x86 -L$(OCLROOT)/lib -lcrypt -lOpenCL -ldl -march=native" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	$(MKDIR) ../run/kernels/
 	$(CP_PRESERVE) opencl/*.cl ../run/kernels/
 	$(CP_PRESERVE) opencl_*.h ../run/kernels/
@@ -746,7 +748,7 @@ linux-x86-cuda:
 		CFLAGS="$(CFLAGS) -I$(CUDAPATH)/include -DHAVE_CRYPT -DHAVE_LIBDL -DHAVE_CUDA -DUSING_ICC_S_FILE -D_LARGEFILE64_SOURCE -march=native" \
 		ASFLAGS="$(ASFLAGS) -march=native" \
 		LDFLAGS="$(LDFLAGS) -L$(CUDAPATH)/lib -lcrypt -ldl -lcudart -march=native" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -759,7 +761,7 @@ linux-x86-native:
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE -march=native" \
 		ASFLAGS="$(ASFLAGS) -march=native" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl -march=native" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -772,7 +774,7 @@ linux-x86-sse2:
 		CFLAGS="$(CFLAGS) -msse2 -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE" \
 		ASFLAGS="$(ASFLAGS) -msse2" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -785,7 +787,7 @@ linux-x86-sse2i:
 		CFLAGS="$(CFLAGS) -msse2 -DHAVE_CRYPT -DHAVE_LIBDL -DUSING_ICC_S_FILE -D_LARGEFILE64_SOURCE" \
 		ASFLAGS="$(ASFLAGS) -msse2" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -797,7 +799,7 @@ linux-x86-mmx:
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86.o x86-mmx.o sha1-mmx.o md4-mmx.o md5-mmx.o" \
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -809,7 +811,7 @@ linux-x86-any:
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86.o" \
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -822,7 +824,7 @@ linux-x86-clang:
 		CFLAGS="-Wall -c -O2 -I/usr/include -msse2 -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE $(HAVE_NSS) $(HAVE_LIBGMP) $(HAVE_LIBKRB5) $(OMPFLAGS) $(JOHN_CFLAGS)" \
 		LDFLAGS="$(LDFLAGS) -lcrypt -ldl" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) CC="clang"
 	@echo "All done"
@@ -835,7 +837,7 @@ linux-x86-clang-debug:
 		CFLAGS="-Wall -Wdeclaration-after-statement -c -g -O1 -faddress-sanitizer -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE $(HAVE_NSS) $(HAVE_LIBGMP) $(HAVE_LIBKRB5) $(OMPFLAGS) $(JOHN_CFLAGS)" \
 		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -faddress-sanitizer $(NSS_LDFLAGS) $(GMP_LDFLAGS) $(KRB5_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++" \
-		AESNI_ARCH=86
+		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) \
 		CFLAGS="-Wall -Wdeclaration-after-statement -c -g -O1 -faddress-sanitizer -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_NSS) $(HAVE_LIBGMP) $(HAVE_LIBKRB5) $(OMPFLAGS) $(JOHN_CFLAGS)" \

--- a/src/aes/aesni/Makefile.orig
+++ b/src/aes/aesni/Makefile.orig
@@ -3,10 +3,10 @@ IAES = $(ASM_DIR)/iaesx$(AESNI_ARCH).s
 RDTSC = $(ASM_DIR)/do_rdtsc.s
 
 iaesx.o: $(IAES)
-	yasm -D__linux__ -g dwarf2 -f elf$(AESNI_ARCH) $(IAES) -o $@
+	yasm -D__linux__ -g dwarf2 -f $(YASM_FORMAT) $(IAES) -o $@
 
 rdtsc.o: $(RDTSC)
-	yasm -D__linux__ -g dwarf2 -f elf$(AESNI_ARCH) $(RDTSC) -o $@
+	yasm -D__linux__ -g dwarf2 -f $(YASM_FORMAT) $(RDTSC) -o $@
 
 aesni.o: iaes_asm_interface.h  iaesni.h  intel_aes.c
 	$(CC) $(CFLAGS) -c intel_aes.c -o $@


### PR DESCRIPTION
This did never work, due to using yasm -f elf86 instead of yasm -f elf32.
I had to rename some subdirectories and files under src/aes/aesni/asm/.
