### PR TITLE
wordlist.c: avoid compiler warnings for debug builds

### DIFF
--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -352,7 +352,7 @@ static double get_progress(void)
 		size = jtr_ftell64(word_file);
 		jtr_fseek64(word_file, pos, SEEK_SET);
 #ifdef DEBUG
-		fprintf (stderr, "pos="LLd"  size="LLd"  percent=%0.4f\n", pos, size, (100.0 * ((rule_number * (double)size) + pos) /(rule_count * (double)size)));
+		fprintf (stderr, "pos="LLd"  size="LLd"  percent=%0.4f\n", (long long)pos, (long long)size, (100.0 * ((rule_number * (double)size) + pos) /(rule_count * (double)size)));
 #endif
 		if (pos < 0) {
 #ifdef __DJGPP__


### PR DESCRIPTION
This fixes issue #659.
