### PR TITLE
reorder ripemd-128 tests (untagged hash first)

### DIFF
--- a/src/ripemd_fmt_plug.c
+++ b/src/ripemd_fmt_plug.c
@@ -52,8 +52,8 @@ static struct fmt_tests ripemd_160_tests[] = {
 };
 
 static struct fmt_tests ripemd_128_tests[] = {
-	{"$ripemd$cdf26213a150dc3ecb610f18f6b38b46", ""},
 	{"cdf26213a150dc3ecb610f18f6b38b46", ""},
+	{"$ripemd$cdf26213a150dc3ecb610f18f6b38b46", ""},
 	{NULL}
 };
 


### PR DESCRIPTION
5bd568d1 reordered test vectors (untagged hashes first), but missed
ripemd-128 hashes and only reordered ripemd-160 hashes.
