### PR TITLE
benchmark-unify: map krb5-23 format to NT

### DIFF
--- a/run/benchmark-unify
+++ b/run/benchmark-unify
@@ -107,9 +107,10 @@ generic crypt(3)	generic crypt(3) DES
 hmailserver	hMailServer salted SHA-256
 HTTP Digest access authentication	HTTP Digest access authentication MD5
 IPB2 MD5	Invision Power Board 2.x salted MD5
+Kerberos 5 db etype 18 aes256-cts-hmac-sha1-96	NT MD4
 Kerberos v4 TGT	Kerberos v4 TGT DES
 Kerberos v5 TGT	Kerberos v5 TGT 3DES
-KRB5 aes256-cts-hmac-sha1-96	Kerberos 5 db etype 18 aes256-cts-hmac-sha1-96
+KRB5 aes256-cts-hmac-sha1-96	NT MD4
 KRB5 arcfour-hmac	Kerberos 5 db etype 23 rc4-hmac
 Lotus5	Lotus Notes/Domino 5
 M$ Cache Hash 2 (DCC2)	M$ Cache Hash 2 (DCC2) PBKDF2-HMAC-SHA-1


### PR DESCRIPTION
Since krb5-23 is the same as NT, krb5-23 hat been removed.
The other implementations (nt and nt2) had been much faster anyway.

That's why, benchmark-unify maps krb5-23 to nt, to avoid relbench's
"Only in file 1: " or "Only in file 2: " output, and possibly even the
"Converting the two benchmark files using benchmark-unify might\n"
"increase the number of benchmarks which can be compared\n"
output in relbench.
