### PR TITLE
korelogic.conf: split some rule definitions for dupe suppression

### DIFF
--- a/run/korelogic.conf
+++ b/run/korelogic.conf
@@ -149,7 +149,8 @@ A0"[A-Z][A-Z]" <* $[^&()_+\-={}|[\]\\;'":,/<>?`~*]
 
 [List.Rules:AppendNumbers_and_Specials_Simple]
 # cap first letter then add a 0  2 6 9 ! *  to the end
--[c:] <* \p[c:] $[0-9!$@#%.^&()_+\-={}|[\]\\;'":,/<>?`~*]
+-[c:] <* \p[c:] $[0-9]
+-[c:] <* \p[c:] $[!$@#%.^&()_+\-={}|[\]\\;'":,/<>?`~*]
 # cap first letter then add a special char - THEN a number  !0 %9 !9 etc
 -[c:] <- \p[c:] Azq[!$@#%.^&()_+\-={}|[\]\\;'":,/<>?`~*][0-9]q
 # Cap the first letter - then add 0? 0! 5_ .. 9!
@@ -505,7 +506,8 @@ A0"[Ss][uU][nN][dD][aA4@][yY]"
 .include [List.Rules:AppendJustNumbers]
 # This is split for better order:
 # First part of AppendNumbers_and_Specials_Simple
--[c:] <* \p[c:] $[0-9!$@#%.^&()_+\-={}|[\]\\;'":,/<>?`~*]
+-[c:] <* \p[c:] $[0-9]
+-[c:] <* \p[c:] $[!$@#%.^&()_+\-={}|[\]\\;'":,/<>?`~*]
 -[c:] <- \p[c:] Azq[!$@#%.^&()_+\-={}|[\]\\;'":,/<>?`~*][0-9]q
 -[c:] <- \p[c:] Azq[0-9][!$@#%.^&()_+\-={}|[\]\\;'":,/<>?`~*]q
 .include [List.Rules:AppendJustSpecials]


### PR DESCRIPTION
John's suppression of duplicate rules will only work
if it finds identical lines.
Thiese changes will reduce the total number of rules to be
processed for --rules=korelogic and --rules=all.

Unfortunately, it can also cause interrupted --rules=korelogic
or --rules=all sessions started prior to this change to skip some rules
if they are resumed after this change.
