### PR TITLE
bench.c: If "Many salts" test exceeded 90% of target, force finish so

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -601,9 +601,10 @@ char *benchmark_format(struct fmt_main *format, int salts,
 		sig_timer_emu_tick();
 #endif
 		salts_done++;
-	} while (benchmark_time && (bench_running ||
-		(salts_done < (wait ? salts : MIN(salts, 2)))) &&
-	         !event_abort);
+	} while (benchmark_time && !event_abort &&
+	         (bench_running ||
+	          (salts_done < (wait ? salts : MIN(salts, 2))) ||
+	          (10 * salts_done > 9 * salts && salts_done < salts)));
 
 #if defined (__MINGW32__) || defined (_MSC_VER)
 	end_real = clock();


### PR DESCRIPTION
not to get annoying/confusing messages like "test limited: 255/256"
Closes #3961.