### PR TITLE
Don't parse luks2 files

### DIFF
--- a/run/luks2john.py
+++ b/run/luks2john.py
@@ -70,7 +70,7 @@ def process_file(filename):
 
     myphdr = data = f.read(luks_header_size)
     if len(data) != luks_header_size:
-        sys.stdout.write("%s : parsing failed\n" % filename)
+        sys.stderr.write("%s : parsing failed\n" % filename)
         return -1
 
     data = struct.unpack(luks_header_fmt, data)

--- a/run/luks2john.py
+++ b/run/luks2john.py
@@ -81,6 +81,11 @@ def process_file(filename):
         sys.stderr.write("%s : not a LUKS file / disk\n" % filename)
         return -2
 
+    if version != 1:
+        sys.stderr.write("%s : Only LUKS1 is supported. Used version: %d\n" %
+                         (filename, version))
+        return -2
+
     if not cipherName.startswith(b"aes\x00"):
         sys.stderr.write("%s : Only AES cipher supported. Used cipher: %s\n" %
                          (filename, cipherName))


### PR DESCRIPTION
Prevents output of garbage:

```
juergen@lemmy:~/cxx/JohnTheRipper/run → ./luks2john.py ~/dmcryptv2.img 
/home/juergen/dmcryptv2.img : Only AES cipher supported. Used cipher: @
```

Fixed:

```
juergen@lemmy:~/cxx/JohnTheRipper/run → ./luks2john.py ~/dmcryptv2.img 
/home/juergen/dmcryptv2.img : Only LUKS1 is supported. Used version: 2
```
