### PR TITLE
Add FMT_NOT_EXACT to ssh-opencl

### DIFF
--- a/src/opencl_ssh_fmt_plug.c
+++ b/src/opencl_ssh_fmt_plug.c
@@ -274,7 +274,7 @@ struct fmt_main fmt_opencl_ssh = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_HUGE_INPUT,
+		FMT_CASE | FMT_8_BIT | FMT_NOT_EXACT | FMT_HUGE_INPUT,
 		{
 			"KDF/cipher [0=MD5/AES 1=MD5/3DES 2=Bcrypt/AES]",
 			"iteration count",


### PR DESCRIPTION
See https://www.openwall.com/lists/john-users/2019/06/10/1

Another issue is that ssh_fmt_plug.c has custom `split` that converts the "hashes" to all-lowercase, and (correctly for it) sets `FMT_SPLIT_UNIFIES_CASE`. opencl_ssh_fmt_plug.c does neither. I see no reason for the lowercasing there - those are our own custom format "hashes", so we can enforce a particular case - but maybe it changed during our development? Since I don't know the history of this and have no time anyway, I'm not fixing it with this PR. But this inconsistency between the two formats is probably wrong.