### PR TITLE
Cross platform compatibility for tezos2john.py

### DIFF
--- a/run/test_tezos2john.py
+++ b/run/test_tezos2john.py
@@ -36,7 +36,7 @@ import unittest
 from tezos2john import isICOValidSeed, isValidMnemonic, isValidChecksumForMnemonic, normalize_string
 
 
-bip39WordFileDirectory = "bip-0039\\"
+bip39WordFileDirectory = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])) , "bip-0039")
 
 
 class MockStdErrHandler():
@@ -224,7 +224,7 @@ class TestMethods(unittest.TestCase):
 
         #Translate Valid Seed to the location in the bip39 Word list
         ## Get the english word list
-        f = open(bip39WordFileDirectory + "english.txt", 'r', encoding="utf-8")
+        f = open(os.path.join(bip39WordFileDirectory , "english.txt"), 'r', encoding="utf-8")
         x = f.readlines()
         f.close()
         bip39EnglishList = list(map(lambda s: normalize_string(s.strip()), x))
@@ -235,7 +235,7 @@ class TestMethods(unittest.TestCase):
             locationValidSeeds.append([bip39EnglishList.index(word) for word in myVector[1].split(' ')])
 
         ## ok, we have a list of locations for each valid word, now we are going to go and get all of our languages.
-        languageList = [str(bip39WordFileDirectory + files) for files in os.listdir(bip39WordFileDirectory) if files.endswith(".txt")]
+        languageList = [str(os.path.join(bip39WordFileDirectory , files)) for files in os.listdir(bip39WordFileDirectory) if files.endswith(".txt")]
 
         self.assertTrue(len(languageList) >= 8)
 

--- a/run/tezos2john.py
+++ b/run/tezos2john.py
@@ -92,7 +92,7 @@ code_strings = {
     256: ''.join([chr(x) for x in range(256)])
 }
 
-bip39WordFileDirectory = "bip-0039\\"
+bip39WordFileDirectory = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])) , "bip-0039")
 
 def encode(val, base, minlen=0):
     base, minlen = int(base), int(minlen)
@@ -196,7 +196,7 @@ def isValidMnemonic(seedWords):
     myWords = getSeedWordListFromString(seedWords)
     # Get a list of all avalible languages
     expectedNuberOfFiles = 8
-    languageList = [str(bip39WordFileDirectory + files) for files in os.listdir(bip39WordFileDirectory) if files.endswith(".txt")]
+    languageList = [str(os.path.join(bip39WordFileDirectory , files)) for files in os.listdir(bip39WordFileDirectory) if files.endswith(".txt")]
     if (len(languageList) < expectedNuberOfFiles):
         sys.stderr.write("[WARNING] Language List Error. Language files not detected! Files found=" + str(len(languageList)) + " expecting at least " + str(expectedNuberOfFiles) + "\n")
         return False


### PR DESCRIPTION
The previous version did not account for cross platform execution. macOS was not able to access the bip-0039 directory. To fix this we use python's os.path.join to create proper paths. We also find the current absolute path of the script in the rare case where someone executes it from another directory. 