### PR TITLE
Removed fmt_not_exact

### DIFF
--- a/src/multibit_fmt_plug.c
+++ b/src/multibit_fmt_plug.c
@@ -503,7 +503,7 @@ struct fmt_main fmt_multibit = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT | FMT_UNICODE | FMT_ENC,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_ENC,
 		{
 			"iteration count",
 			"kdf [1:MD5 2:scrypt hd 3:scrypt classic]",


### PR DESCRIPTION
Useless whilst there is a second block check on .key files, which effectively removes false positives. Having this option turned on just reduces overall cracking times by a lot, especially for multiple hashes for no good reason.