### PR TITLE
Add functions to query host's physical memory

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -40,6 +40,11 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Added --length=N which is a shortcut for --min-length=N --max-length=N
   [magnum; 2019]
 
+- Add a function for querying host's total or available physical memory, if
+  possible.  Among other things, this will be used for detecting when an OpenCL
+  buffer that is backed by an equal size host buffer gets too big.
+  [magnum; 2019]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -45,6 +45,11 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   buffer that is backed by an equal size host buffer gets too big.
   [magnum; 2019]
 
+- Single mode: Add new config option SingleMaxBufferAvailMem. If true, actual
+  amount of physical memory will override SingleMaxBufferSize (it may increase
+  or decrease). If that option isn't set but SingleMaxBufferSize is explicitly
+  set to zero, no limit will be applied!  [magnum; 2019]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/run/john.conf
+++ b/run/john.conf
@@ -176,10 +176,16 @@ SingleRetestGuessed = Y
 SingleMaxRecursionDepth = 10000
 
 # Set the maximum word buffer size used by Single mode. The default is
-# 4 GB. If running fork this is the *total* used by a session (size is
-# divided by number of forks). If running MPI, we try to determine the
-# number of local processes on each node and divide it accordingly.
+# 4 GB.  Note that you may want to set SingleMaxBufferAvailMem (below) to
+# true instead.
+#
+# If this figure is explicitly set to zero, and SingleMaxBufferAvailMem
+# is false, there will be NO LIMIT!
 SingleMaxBufferSize = 4
+
+# If true, the actual amount of physical memory at runtime, if known, will
+# override the figure from SingleMaxBufferSize (may increase or decrease!).
+SingleMaxBufferAvailMem = N
 
 # When running single mode with a GPU or accelerator, we prioritize speed
 # (saturating buffers) over resume ability:  When resuming such a session

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -325,7 +325,7 @@ static void listconf_list_build_info(void)
 #if defined (__MINGW32__) || defined (_MSC_VER)
 	printf("Using clock(3) for timers, claimed resolution %ss, observed %ss\n",
 	       human_prefix_small(1.0 / CLOCKS_PER_SEC),
-	       human_prefix_small(sm_cPrecision));
+	       human_prefix_small(1.0 / sm_cPrecision));
 #else
 	printf("Using times(2) for timers, resolution %ss\n", human_prefix_small(1.0 / clk_tck));
 #endif

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -315,7 +315,6 @@ static void listconf_list_build_info(void)
 #endif
 	printf("memmem(): " memmem_func "\n");
 
-	printf("clock(3) CLOCKS_PER_SEC: %u\n", (uint32_t)CLOCKS_PER_SEC);
 	clk_tck_init();
 #if defined(_SC_CLK_TCK) || !defined(CLK_TCK)
 	printf("times(2) sysconf(_SC_CLK_TCK) is %ld\n", clk_tck);
@@ -330,6 +329,20 @@ static void listconf_list_build_info(void)
 	printf("Using times(2) for timers, resolution %ss\n", human_prefix_small(1.0 / clk_tck));
 #endif
 	printf("HR timer claimed resolution %ss, observed %ss\n", human_prefix_small(1.0 / sm_HRTicksPerSec), human_prefix_small(1.0 / sm_hrPrecision));
+
+	int64_t total_mem = host_total_mem();
+
+	if (total_mem >= 0)
+		printf("Total physical host memory: %sB\n", human_prefix(total_mem));
+	else
+		puts("Total physical host memory: unknown");
+
+	int64_t avail_mem = host_avail_mem();
+
+	if (avail_mem >= 0)
+		printf("Available physical host memory: %sB\n", human_prefix(avail_mem));
+	else
+		puts("Available physical host memory: unknown");
 
 // OK, now append debugging options, BUT only output  something if
 // one or more of them is set. IF none set, be silent.

--- a/src/memory.h
+++ b/src/memory.h
@@ -94,9 +94,9 @@ extern void *mem_calloc(size_t nmemb, size_t size);
 extern void *mem_realloc(void *old_ptr, size_t size);
 
 /* These allow alignment and are wrappers to system-specific functions */
-void *mem_alloc_align(size_t size, size_t align);
+extern void *mem_alloc_align(size_t size, size_t align);
 
-void *mem_calloc_align(size_t count, size_t size, size_t align);
+extern void *mem_calloc_align(size_t count, size_t size, size_t align);
 
 /*
  * Frees memory allocated with mem_alloc() and sets the pointer to NULL.
@@ -110,7 +110,7 @@ void *mem_calloc_align(size_t count, size_t size, size_t align);
 #define calloc(a,b) memset(_aligned_malloc(a*b,16),0,a*b)
 #define free(a) _aligned_free(a)
 #define strdup(a) strdup_MSVC(a)
-char *strdup_MSVC(const char *str);
+extern char *strdup_MSVC(const char *str);
 #define MEM_FREE(ptr) \
 { \
 	if ((ptr)) { \
@@ -125,7 +125,7 @@ char *strdup_MSVC(const char *str);
 #define calloc(a,b) memset(__mingw_aligned_malloc(a*b,(sizeof(long long))),0,a*b)
 #define free(a) __mingw_aligned_free(a)
 #define strdup(a) strdup_MSVC(a)
-char *strdup_MSVC(const char *str);
+extern char *strdup_MSVC(const char *str);
 
 #define MEM_FREE(ptr) \
 { \
@@ -202,27 +202,27 @@ extern void cleanup_tiny_memory();
 /* Dump memory as text (non-printables as dots) */
 #define dump_text(d, sz) dump_text_msg(STRINGIZE(d), d, sz)
 
-void dump_text_msg(const void *msg, const void *in, int len);
+extern void dump_text_msg(const void *msg, const void *in, int len);
 
-void dump_stuff_msg(const void *msg, const void *x, unsigned int size);
-void dump_stuff_be_msg(const void *msg, const void *x, unsigned int size);
+extern void dump_stuff_msg(const void *msg, const void *x, unsigned int size);
+extern void dump_stuff_be_msg(const void *msg, const void *x, unsigned int size);
 
 #if defined (SIMD_COEF_32) || defined(NT_X86_64) || defined (SIMD_PARA_MD5) || defined (SIMD_PARA_MD4) || defined (SIMD_PARA_SHA1)
-void dump_stuff_mmx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
+extern void dump_stuff_mmx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
 // for flat input, we do want to see SHA512 without byte swapping.
-void dump_stuff_mmx64_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
-void dump_out_mmx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
-void dump_stuff_shammx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
-void dump_out_shammx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
-void dump_stuff_shammx64_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
-void dump_out_shammx64_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
+extern void dump_stuff_mmx64_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
+extern void dump_out_mmx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
+extern void dump_stuff_shammx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
+extern void dump_out_shammx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
+extern void dump_stuff_shammx64_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
+extern void dump_out_shammx64_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
 #endif
 
 #if defined (SIMD_PARA_MD5)
 // these functions help debug arrays of contigious MD5 prepared PARA buffers. Seen in sunmd5 at the current time.
-void dump_stuff_mpara_mmx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
+extern void dump_stuff_mpara_mmx_msg(const void *msg, const void *buf, unsigned int size, unsigned int index);
 // a 'getter' to help debugging.  Returns a flat buffer, vs printing it out.
-void getbuf_stuff_mpara_mmx(unsigned char *oBuf, const void *buf, unsigned int size, unsigned int index);
+extern void getbuf_stuff_mpara_mmx(unsigned char *oBuf, const void *buf, unsigned int size, unsigned int index);
 #endif
 
 /*
@@ -240,19 +240,19 @@ void getbuf_stuff_mpara_mmx(unsigned char *oBuf, const void *buf, unsigned int s
  * be a multiple of 2). From now on, this function may be used on any arch.
  * this is needed for some swapping of things like UTF16LE to UTF16BE, etc.
  */
-void alter_endianity_w16(void * x, unsigned int size);
+extern void alter_endianity_w16(void * x, unsigned int size);
 
 /*
  * 32-bit endian-swap a memory buffer in place. Size is in octets (so should
  * be a multiple of 4). From now on, this function may be used on any arch.
  */
-void alter_endianity(void * x, unsigned int size);
+extern void alter_endianity(void * x, unsigned int size);
 
 /* 32-bit endian-swap a memory buffer in place. Count is in 32-bit words */
-void alter_endianity_w(void *x, unsigned int count);
+extern void alter_endianity_w(void *x, unsigned int count);
 
 /* 64-bit endian-swap a memory buffer in place. Count is in 64-bit words */
-void alter_endianity_w64(void *x, unsigned int count);
+extern void alter_endianity_w64(void *x, unsigned int count);
 
 #if ARCH_ALLOWS_UNALIGNED
 // we can inline these, to always use JOHNSWAP/JOHNSWAP64
@@ -303,9 +303,8 @@ typedef struct {
 	size_t base_size, aligned_size;
 } region_t;
 
-
-void * alloc_region_t(region_t * region, size_t size);
-void init_region_t(region_t * region);
-int free_region_t(region_t * region);
+extern void* alloc_region_t(region_t * region, size_t size);
+extern void init_region_t(region_t * region);
+extern int free_region_t(region_t * region);
 
 #endif

--- a/src/misc.c
+++ b/src/misc.c
@@ -16,7 +16,9 @@
 #if (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER
 #include <unistd.h>
 #endif
-#ifdef _MSC_VER
+#ifdef __APPLE__
+#include <mach/mach.h>
+#elif _MSC_VER
 #include <io.h>
 #pragma warning ( disable : 4996 )
 #endif
@@ -633,3 +635,93 @@ char *rtrim(char *str)
 	*(out+1) = '\0';
 	return str;
 }
+
+#ifndef _JOHN_MISC_NO_LOG
+int64_t host_total_mem(void)
+{
+	int64_t tot_mem = -1;
+
+#if (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER && defined _SC_PAGESIZE && defined _SC_PHYS_PAGES
+
+	long pagesize = sysconf(_SC_PAGESIZE);
+	if (pagesize < 0)
+		return -1;
+
+	long totmem = sysconf(_SC_PHYS_PAGES);
+	if (totmem < 0)
+		return -1;
+
+	tot_mem = (int64_t)totmem * pagesize;
+
+#endif
+
+	return tot_mem;
+}
+
+int64_t host_avail_mem(void)
+{
+	int64_t avail_mem = -1;
+
+#if __linux__
+
+	FILE *fp;
+	char buf[LINE_BUFFER_SIZE];
+
+	if ((fp = fopen("/proc/meminfo", "r"))) {
+		while (fgets(buf, LINE_BUFFER_SIZE, fp)) {
+			if (strstr(buf, "MemAvailable")) {
+				char *p = strchr(buf, ':');
+				if (p++)
+					avail_mem = strtoull(p, NULL, 10) << 10;
+				break;
+			}
+		}
+	}
+
+#elif __APPLE__
+
+	vm_statistics64_data_t vm_stat;
+	unsigned int count = HOST_VM_INFO64_COUNT;
+	kern_return_t ret;
+	mach_port_t myHost = mach_host_self();
+	vm_size_t pageSize;
+
+	if (host_page_size(mach_host_self(), &pageSize) != KERN_SUCCESS)
+		return -1;
+
+	if ((ret = host_statistics64(myHost, HOST_VM_INFO64, (host_info64_t)&vm_stat, &count) != KERN_SUCCESS))
+		return -1;
+
+	avail_mem = (vm_stat.free_count + vm_stat.inactive_count + vm_stat.purgeable_count) * pageSize;
+
+#elif (!AC_BUILT || HAVE_UNISTD_H) && !_MSC_VER && defined _SC_PAGESIZE
+#if defined _SC_AVPHYS_PAGES
+
+	long pagesize = sysconf(_SC_PAGESIZE);
+	if (pagesize < 0)
+		return -1;
+
+	long availmem = sysconf(_SC_AVPHYS_PAGES);
+	if (availmem < 0)
+		return -1;
+
+	avail_mem = (int64_t)availmem * pagesize;
+
+#elif defined _SC_PHYS_PAGES
+
+	long pagesize = sysconf(_SC_PAGESIZE);
+	if (pagesize < 0)
+		return -1;
+
+	long totmem = sysconf(_SC_PHYS_PAGES);
+	if (totmem < 0)
+		return -1;
+
+	avail_mem = (int64_t)totmem * pagesize;
+
+#endif
+#endif
+
+	return avail_mem;
+}
+#endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -218,4 +218,18 @@ extern char *ltrim(char *str);
  */
 extern char *rtrim(char *str);
 
+/*
+ * Return total physical host memory, in bytes. A return of -1 means we don't
+ * know.
+ */
+extern int64_t host_total_mem(void);
+
+/*
+ * Return available physical host memory, in bytes. A return of -1 means we
+ * don't know.
+ * Note that if we're running several forks or MPI processes on same host, the
+ * figure needs to be divided by that number to be used per process.
+ */
+extern int64_t host_avail_mem(void);
+
 #endif

--- a/src/misc.h
+++ b/src/misc.h
@@ -156,7 +156,7 @@ extern unsigned int atou(const char *src);
  * for any leading or trailing delims. strtok() strips those off
  * also.
  */
-char *strtokm(char *s1, const char *delimit);
+extern char *strtokm(char *s1, const char *delimit);
 
 #ifndef __has_feature
  #define __has_feature(x) 0
@@ -206,16 +206,16 @@ extern char *human_prefix_small(double num);
  * common multiple of two integers x and y, usually denoted by LCM(x, y),
  * is the smallest positive integer that is divisible by both x and y.
  */
-unsigned int lcm(unsigned int x, unsigned int y);
+extern unsigned int lcm(unsigned int x, unsigned int y);
 
 /*
  * Remove leading spaces from a string.
  */
-char *ltrim(char *str);
+extern char *ltrim(char *str);
 
 /*
  * Remove trailing spaces from a string.
  */
-char *rtrim(char *str);
+extern char *rtrim(char *str);
 
 #endif


### PR DESCRIPTION
Perhaps in the end we only want to use the total memory figure, I'm not quite sure.

The last commit uses this for (optionally) automagically increase or decrease the max. buffer size for single mode.

Future code may also use this for knowing beforehand when host-backed GPU buffers will be too big (see #4056).