### PR TITLE
New scheme for non-hash formats, that can exploit same-salt

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -78,6 +78,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Add option --no-keep-guessing that "turns off" FMT_NOT_EXACT just like the
   old --keep-guessing option "turns it on".
 
+- Worked out a new KISS solution "FMT_BLOB" for non-hash formats, so they can
+  still benefit from same-salt optimizations/exploits.  [magnum; 2019]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -84,6 +84,8 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Converted WPAPSK formats to the new FMT_BLOB scheme, with excellent
   improvement in performance, especially for single mode.  [magnum; 2019]
 
+- Converted Office formats to the new FMT_BLOB scheme.  [magnum; 2019]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -81,6 +81,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Worked out a new KISS solution "FMT_BLOB" for non-hash formats, so they can
   still benefit from same-salt optimizations/exploits.  [magnum; 2019]
 
+- Converted WPAPSK formats to the new FMT_BLOB scheme, with excellent
+  improvement in performance, especially for single mode.  [magnum; 2019]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -89,6 +89,8 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Converted oldOffice CPU format to the new FMT_BLOB scheme.  The GPU version
   uses internal mask so may be hard or impossible to convert.  [magnum; 2019]
 
+- Converted RAR3 formats to the new FMT_BLOB scheme.  [magnum; 2019]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -86,6 +86,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Converted Office formats to the new FMT_BLOB scheme.  [magnum; 2019]
 
+- Converted oldOffice CPU format to the new FMT_BLOB scheme.  The GPU version
+  uses internal mask so may be hard or impossible to convert.  [magnum; 2019]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/bench.c
+++ b/src/bench.c
@@ -433,6 +433,10 @@ char *benchmark_format(struct fmt_main *format, int salts,
 		binary = mem_alloc_tiny(binary_size, MEM_ALIGN_SIMD);
 		memset(binary, 0x55, binary_size);
 	}
+	if (format->params.flags & FMT_BLOB)
+		memcpy(binary,
+		       format->methods.binary(format->params.tests[0].ciphertext),
+		       binary_size);
 
 	for (index = 0; index < 2; index++) {
 		two_salts[index] = mem_alloc_align(format->params.salt_size,
@@ -606,6 +610,8 @@ char *benchmark_format(struct fmt_main *format, int salts,
 	         (bench_running ||
 	          (salts_done < (wait ? salts : MIN(salts, 2))) ||
 	          (10 * salts_done > 9 * salts && salts_done < salts)));
+
+	BLOB_FREE(format, binary);
 
 #if defined (__MINGW32__) || defined (_MSC_VER)
 	end_real = clock();

--- a/src/loader.h
+++ b/src/loader.h
@@ -26,7 +26,9 @@ struct db_password {
 /* Pointer to next password hash with the same salt */
 	struct db_password *next;
 
-/* Hot portion of or full binary ciphertext for fast comparison (aligned) */
+/* Hot portion of or full binary ciphertext for fast comparison (aligned).
+ * Alternatively, for non-hash formats: Non-salt data (that we used to
+ * incorrectly store in a "salt"). */
 	void *binary;
 
 /* After loading is completed: pointer to next password hash with the same salt

--- a/src/office_common.h
+++ b/src/office_common.h
@@ -1,5 +1,11 @@
 /*
- * Office 2007-2013 cracker patch for JtR, common code. 2014 by JimF
+ * Office 2007-2013 cracker patch for JtR, common code. This software is
+ * Copyright (c) 2014 by JimF
+ * Copyright (c) 2012-2019 magnum
+ * and is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
  * This file takes replicated but common code, shared between the CPU
  * office format, and the GPU office formats, and places it into one
  * common location.
@@ -10,16 +16,24 @@
 #define FORMAT_TAG_OFFICE           "$office$*"
 #define FORMAT_TAG_OFFICE_LEN       (sizeof(FORMAT_TAG_OFFICE)-1)
 
+#define BINARY_SIZE              sizeof(fmt_data)
+#define BINARY_ALIGN             sizeof(size_t)
+#define SALT_SIZE                sizeof(*cur_salt)
+#define SALT_ALIGN               sizeof(int)
+
 typedef struct ms_office_custom_salt_t {
-	uint8_t osalt[16];
-	uint8_t encryptedVerifier[16];
-	uint8_t encryptedVerifierHash[32];
-	int version;
+	uint8_t salt[16];
+	unsigned int version;
 	int verifierHashSize;
 	int keySize;
 	int saltSize;
-	int spinCount;
+	unsigned int spinCount;
 } ms_office_custom_salt;
+
+typedef struct ms_office_binary_blob_t {
+	uint8_t encryptedVerifier[16];
+	uint8_t encryptedVerifierHash[32];
+} ms_office_binary_blob;
 
 void *ms_office_common_get_salt(char *ciphertext);
 void *ms_office_common_binary(char *ciphertext);

--- a/src/office_fmt_plug.c
+++ b/src/office_fmt_plug.c
@@ -1,6 +1,10 @@
 /*
- * Office 2007 cracker patch for JtR. Hacked together during March of 2012 by
- * Dhiru Kholia <dhiru.kholia at gmail.com>.
+ * Office 2007 cracker patch for JtR. This software is
+ * Copyright (c) 2012 Dhiru Kholia <dhiru.kholia at gmail.com>.
+ * Copyright (c) 2012-2019 magnum
+ * and is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  */
 
 #if FMT_EXTERNS_H
@@ -37,23 +41,20 @@ john_register_one(&fmt_office);
 #define BENCHMARK_COMMENT        ""
 #define BENCHMARK_LENGTH         0x107
 #define PLAINTEXT_LENGTH         125
-#define BINARY_SIZE              16
-#define SALT_SIZE                sizeof(*cur_salt)
-#define BINARY_ALIGN             4
-#define SALT_ALIGN               sizeof(int)
+
 #ifdef SIMD_COEF_32
-#define GETPOS_512W(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i*8)&(0xffffffff-7))*SIMD_COEF_64 + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#define GETOUTPOS_512W(i, index) ( (index&(SIMD_COEF_64-1))*8 + ((i*8)&(0xffffffff-7))*SIMD_COEF_64 + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
+#define GETPOS_512W(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i*8)&(0xffffffff-7))*SIMD_COEF_64 + (uint32_t)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
+#define GETOUTPOS_512W(i, index) ( (index&(SIMD_COEF_64-1))*8 + ((i*8)&(0xffffffff-7))*SIMD_COEF_64 + (uint32_t)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
 #if ARCH_LITTLE_ENDIAN==1
-#define GETPOS_1(i, index)       ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
-#define GETPOS_512(i, index)     ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#define GETOUTPOS_512(i, index)  ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
+#define GETPOS_1(i, index)       ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + (3-((i)&3)) + (uint32_t)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
+#define GETPOS_512(i, index)     ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (uint32_t)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
+#define GETOUTPOS_512(i, index)  ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (uint32_t)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
 #else
-#define GETPOS_1(i, index)       ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (unsigned int)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
-#define GETPOS_512(i, index)     ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
-#define GETOUTPOS_512(i, index)  ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
+#define GETPOS_1(i, index)       ( (index&(SIMD_COEF_32-1))*4 + ((i)&(0xffffffff-3))*SIMD_COEF_32 + ((i)&3) + (uint32_t)index/SIMD_COEF_32*SHA_BUF_SIZ*SIMD_COEF_32*4 )
+#define GETPOS_512(i, index)     ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (uint32_t)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
+#define GETOUTPOS_512(i, index)  ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (uint32_t)index/SIMD_COEF_64*8*SIMD_COEF_64*8 )
 #endif
-#define SHA1_LOOP_CNT            (SIMD_COEF_32*SIMD_PARA_SHA1)
+#define SHA1_LOOP_CNT            (SIMD_COEF_32 * SIMD_PARA_SHA1)
 #define SHA512_LOOP_CNT          (SIMD_COEF_64 * SIMD_PARA_SHA512)
 #define MIN_KEYS_PER_CRYPT       (SIMD_COEF_32 * SIMD_PARA_SHA1 * SIMD_PARA_SHA512)
 #define MAX_KEYS_PER_CRYPT       (SIMD_COEF_32 * SIMD_PARA_SHA1 * SIMD_PARA_SHA512)
@@ -119,17 +120,51 @@ static ms_office_custom_salt *cur_salt;
 static UTF16 (*saved_key)[PLAINTEXT_LENGTH + 1];
 /* UCS-2 password length, in octets */
 static int *saved_len;
-static uint32_t (*crypt_key)[4];
 static int *cracked;
 
-/* Office 2010/2013 */
-static const unsigned char encryptedVerifierHashInputBlockKey[] = { 0xfe, 0xa7, 0xd2, 0x76, 0x3b, 0x4b, 0x9e, 0x79 };
-static const unsigned char encryptedVerifierHashValueBlockKey[] = { 0xd7, 0xaa, 0x0f, 0x6d, 0x30, 0x61, 0x34, 0x4e };
+static uint8_t (*encryptionKey)[20];
+static uint8_t (*verifierKeys1)[64];
+static uint8_t (*verifierKeys512)[128];
 
-static unsigned char *DeriveKey(unsigned char *hashValue, unsigned char *X1)
+/* Office 2010/2013 */
+static const uint8_t encryptedVerifierHashInputBlockKey[] = {
+	0xfe, 0xa7, 0xd2, 0x76, 0x3b, 0x4b, 0x9e, 0x79
+};
+static const uint8_t encryptedVerifierHashValueBlockKey[] = {
+	0xd7, 0xaa, 0x0f, 0x6d, 0x30, 0x61, 0x34, 0x4e
+};
+
+#define dynalloc(var) var = mem_calloc(sizeof(*var), self->params.max_keys_per_crypt)
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+
+	dynalloc(saved_key);
+	dynalloc(saved_len);
+	dynalloc(cracked);
+	dynalloc(encryptionKey);
+	dynalloc(verifierKeys1);
+	dynalloc(verifierKeys512);
+
+	if (options.target_enc == UTF_8)
+		self->params.plaintext_length = MIN(125, PLAINTEXT_LENGTH * 3);
+}
+
+static void done(void)
+{
+	MEM_FREE(cracked);
+	MEM_FREE(saved_len);
+	MEM_FREE(saved_key);
+	MEM_FREE(encryptionKey);
+	MEM_FREE(verifierKeys1);
+	MEM_FREE(verifierKeys512);
+}
+
+static uint8_t *DeriveKey(uint8_t *hashValue, uint8_t *X1)
 {
 	int i;
-	unsigned char derivedKey[64];
+	uint8_t derivedKey[64];
 	SHA_CTX ctx;
 
 	// This is step 4a in 2.3.4.7 of MS_OFFCRYPT version 1.0
@@ -142,7 +177,7 @@ static unsigned char *DeriveKey(unsigned char *hashValue, unsigned char *X1)
 	SHA1_Update(&ctx, derivedKey, 64);
 	SHA1_Final(X1, &ctx);
 
-	if (cur_salt->verifierHashSize > cur_salt->keySize/8)
+	if (cur_salt->verifierHashSize > cur_salt->keySize / 8)
 		return X1;
 
 	/* TODO: finish up this function */
@@ -157,98 +192,120 @@ static unsigned char *DeriveKey(unsigned char *hashValue, unsigned char *X1)
 }
 
 #ifdef SIMD_COEF_32
-static void GeneratePasswordHashUsingSHA1(int idx, unsigned char final[SHA1_LOOP_CNT][20])
+static void GeneratePasswordHashUsingSHA1(int idx,
+                                          uint8_t final[SHA1_LOOP_CNT][20])
 {
-	unsigned char hashBuf[20];
-	/* H(0) = H(salt, password)
+	uint8_t hashBuf[20];
+	/*
+	 * H(0) = H(salt, password)
 	 * hashBuf = SHA1Hash(salt, password);
-	 * create input buffer for SHA1 from salt and unicode version of password */
-	unsigned char X1[20];
+	 * create input buffer for SHA1 from salt and unicode version of password
+	 */
+	uint8_t X1[20];
 	SHA_CTX ctx;
-	unsigned char _IBuf[64*SHA1_LOOP_CNT+MEM_ALIGN_CACHE], *keys;
+	uint8_t _IBuf[64*SHA1_LOOP_CNT + MEM_ALIGN_CACHE], *keys;
 	uint32_t *keys32;
-	unsigned i, j;
+	uint32_t i, j;
 
-	keys = (unsigned char*)mem_align(_IBuf, MEM_ALIGN_CACHE);
+	keys = (uint8_t*)mem_align(_IBuf, MEM_ALIGN_CACHE);
 	keys32 = (uint32_t*)keys;
-	memset(keys, 0, 64*SHA1_LOOP_CNT);
+	memset(keys, 0, 64 * SHA1_LOOP_CNT);
 
-	for (i = 0; i < SHA1_LOOP_CNT; ++i) {
+	for (i = 0; i < SHA1_LOOP_CNT; i++) {
 		SHA1_Init(&ctx);
-		SHA1_Update(&ctx, cur_salt->osalt, cur_salt->saltSize);
-		SHA1_Update(&ctx, saved_key[idx+i], saved_len[idx+i]);
+		SHA1_Update(&ctx, cur_salt->salt, cur_salt->saltSize);
+		SHA1_Update(&ctx, saved_key[idx + i], saved_len[idx + i]);
 		SHA1_Final(hashBuf, &ctx);
 
-		/* Generate each hash in turn
+		/*
+		 * Generate each hash in turn
 		 * H(n) = H(i, H(n-1))
-		 * hashBuf = SHA1Hash(i, hashBuf); */
+		 * hashBuf = SHA1Hash(i, hashBuf);
+		 */
 
-		// Create a byte array of the integer and put at the front of the input buffer
-		// 1.3.6 says that little-endian byte ordering is expected
-		for (j = 4; j < 24; ++j)
+		/*
+		 * Create a byte array of the integer and put at the front
+		 * of the input buffer.
+		 * 1.3.6 says that little-endian byte ordering is expected.
+		 */
+		for (j = 4; j < 24; j++)
 			keys[GETPOS_1(j, i)] = hashBuf[j-4];
 		keys[GETPOS_1(j, i)] = 0x80;
-		// 24 bytes of crypt data (192 bits).
+		/* 24 bytes of crypt data (192 bits). */
 		keys[GETPOS_1(63, i)] = 192;
 	}
-	// we do 1 less than actual number of iterations here.
-	for (i = 0; i < MS_OFFICE_2007_ITERATIONS-1; i++) {
-		for (j = 0; j < SHA1_LOOP_CNT; ++j) {
-			keys[GETPOS_1(0, j)] = i&0xff;
-			keys[GETPOS_1(1, j)] = i>>8;
+	/* we do 1 less than actual number of iterations here. */
+	for (i = 0; i < MS_OFFICE_2007_ITERATIONS - 1; i++) {
+		for (j = 0; j < SHA1_LOOP_CNT; j++) {
+			keys[GETPOS_1(0, j)] = i & 0xff;
+			keys[GETPOS_1(1, j)] = i >> 8;
 		}
-		// Here we output to 4 bytes past start of input buffer.
-		SIMDSHA1body(keys, &keys32[SIMD_COEF_32], NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+		/* Here we output to 4 bytes past start of input buffer. */
+		SIMDSHA1body(keys, &keys32[SIMD_COEF_32], NULL,
+		             SSEi_MIXED_IN | SSEi_OUTPUT_AS_INP_FMT);
 	}
-	// last iteration is output to start of input buffer, then 32 bit 0 appended.
-	// but this is still ends up being 24 bytes of crypt data.
-	for (j = 0; j < SHA1_LOOP_CNT; ++j) {
-		keys[GETPOS_1(0, j)] = i&0xff;
-		keys[GETPOS_1(1, j)] = i>>8;
+	/*
+	 * Last iteration is output to start of input buffer,
+	 * then 32 bit 0 appended.
+	 * but this is still ends up being 24 bytes of crypt data.
+	 */
+	for (j = 0; j < SHA1_LOOP_CNT; j++) {
+		keys[GETPOS_1(0, j)] = i & 0xff;
+		keys[GETPOS_1(1, j)] = i >> 8;
 	}
-	SIMDSHA1body(keys, keys32, NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+	SIMDSHA1body(keys, keys32, NULL, SSEi_MIXED_IN | SSEi_OUTPUT_AS_INP_FMT);
 
-	// Finally, append "block" (0) to H(n)
-	// hashBuf = SHA1Hash(hashBuf, 0);
-	for (i = 0; i < SHA1_LOOP_CNT; ++i) {
+	/*
+	 * Finally, append "block" (0) to H(n)
+	 * hashBuf = SHA1Hash(hashBuf, 0);
+	 */
+	for (i = 0; i < SHA1_LOOP_CNT; i++) {
 		keys[GETPOS_1(20,i)] = 0;
 		keys[GETPOS_1(21,i)] = 0;
 		keys[GETPOS_1(22,i)] = 0;
 		keys[GETPOS_1(23,i)] = 0;
 	}
 
-	SIMDSHA1body(keys, keys32, NULL, SSEi_MIXED_IN|SSEi_FLAT_OUT);
+	SIMDSHA1body(keys, keys32, NULL, SSEi_MIXED_IN | SSEi_FLAT_OUT);
 
-	// Now convert back into a 'flat' value, which is a flat array.
-	for (i = 0; i < SHA1_LOOP_CNT; ++i)
-		memcpy(final[i], DeriveKey(&keys[20*i], X1), cur_salt->keySize/8);
+	/* Now convert back into a 'flat' value, which is a flat array. */
+	for (i = 0; i < SHA1_LOOP_CNT; i++)
+		memcpy(final[i], DeriveKey(&keys[20 * i], X1), cur_salt->keySize / 8);
 }
 #else
-// for non MMX, SHA1_LOOP_CNT is 1
-static void GeneratePasswordHashUsingSHA1(int idx, unsigned char final[SHA1_LOOP_CNT][20])
+// for non SIMD, SHA1_LOOP_CNT is 1
+static void GeneratePasswordHashUsingSHA1(int idx,
+                                          uint8_t final[SHA1_LOOP_CNT][20])
 {
-	unsigned char hashBuf[20], *key;
-	UTF16 *passwordBuf=saved_key[idx];
-	int passwordBufSize=saved_len[idx];
-	/* H(0) = H(salt, password)
+	uint8_t hashBuf[20], *key;
+	UTF16 *passwordBuf = saved_key[idx];
+	int passwordBufSize = saved_len[idx];
+	/*
+	 * H(0) = H(salt, password)
 	 * hashBuf = SHA1Hash(salt, password);
-	 * create input buffer for SHA1 from salt and unicode version of password */
-	unsigned int inputBuf[(0x14 + 0x04 + 4) / sizeof(int)];
-	unsigned char X1[20];
+	 * create input buffer for SHA1 from salt and unicode version of password
+	 */
+	uint32_t inputBuf[(0x14 + 0x04 + 4) / sizeof(int)];
+	uint8_t X1[20];
 	int i;
 	SHA_CTX ctx;
 
 	SHA1_Init(&ctx);
-	SHA1_Update(&ctx, cur_salt->osalt, cur_salt->saltSize);
+	SHA1_Update(&ctx, cur_salt->salt, cur_salt->saltSize);
 	SHA1_Update(&ctx, passwordBuf, passwordBufSize);
 	SHA1_Final(hashBuf, &ctx);
 
-	/* Generate each hash in turn
+	/*
+	 * Generate each hash in turn
 	 * H(n) = H(i, H(n-1))
-	 * hashBuf = SHA1Hash(i, hashBuf); */
+	 * hashBuf = SHA1Hash(i, hashBuf);
+	 */
 
-	// Create a byte array of the integer and put at the front of the input buffer
-	// 1.3.6 says that little-endian byte ordering is expected
+	/*
+	 * Create a byte array of the integer and put at the front
+	 * of the input buffer.
+	 * 1.3.6 says that little-endian byte ordering is expected.
+	 */
 	memcpy(&inputBuf[1], hashBuf, 20);
 	for (i = 0; i < MS_OFFICE_2007_ITERATIONS; i++) {
 #if ARCH_LITTLE_ENDIAN
@@ -256,13 +313,15 @@ static void GeneratePasswordHashUsingSHA1(int idx, unsigned char final[SHA1_LOOP
 #else
 		*inputBuf = JOHNSWAP(i);
 #endif
-		// 'append' the previously generated hash to the input buffer
+		/* 'append' the previously generated hash to the input buffer. */
 		SHA1_Init(&ctx);
 		SHA1_Update(&ctx, inputBuf, 0x14 + 0x04);
-		SHA1_Final((unsigned char*)&inputBuf[1], &ctx);
+		SHA1_Final((uint8_t*)&inputBuf[1], &ctx);
 	}
-	// Finally, append "block" (0) to H(n)
-	// hashBuf = SHA1Hash(hashBuf, 0);
+	/*
+	 * Finally, append "block" (0) to H(n)
+	 * hashBuf = SHA1Hash(hashBuf, 0);
+	 */
 	memset(&inputBuf[6], 0, 4);
 	SHA1_Init(&ctx);
 	SHA1_Update(&ctx, &inputBuf[1], 0x14 + 0x04);
@@ -270,83 +329,87 @@ static void GeneratePasswordHashUsingSHA1(int idx, unsigned char final[SHA1_LOOP
 
 	key = DeriveKey(hashBuf, X1);
 
-	// Should handle the case of longer key lengths as shown in 2.3.4.9
-	// Grab the key length bytes of the final hash as the encrypytion key
-	memcpy(final[0], key, cur_salt->keySize/8);
+	/*
+	 * Should handle the case of longer key lengths as shown in 2.3.4.9
+	 * Grab the key length bytes of the final hash as the encrypytion key
+	 */
+	memcpy(final[0], key, cur_salt->keySize / 8);
 }
 #endif
 
 #ifdef SIMD_COEF_32
-static void GenerateAgileEncryptionKey(int idx, unsigned char hashBuf[SHA1_LOOP_CNT][64])
+static void GenerateAgileEncryptionKey(int idx,
+                                       uint8_t hashBuf[SHA1_LOOP_CNT][64])
 {
-	unsigned char tmpBuf[20];
+	uint8_t tmpBuf[20], *keys;
 	int hashSize = cur_salt->keySize >> 3;
-	unsigned i, j;
+	uint32_t i, j;
 	SHA_CTX ctx;
-	unsigned char _IBuf[64*SHA1_LOOP_CNT+MEM_ALIGN_CACHE], *keys,
-	              _OBuf[20*SHA1_LOOP_CNT+MEM_ALIGN_CACHE];
-	uint32_t *keys32, (*crypt)[20/4];
+	uint8_t _IBuf[64 * SHA1_LOOP_CNT + MEM_ALIGN_CACHE];
+	uint8_t _OBuf[20 * SHA1_LOOP_CNT + MEM_ALIGN_CACHE];
+	uint32_t *keys32, (*crypt)[20 / 4];
 
 	crypt = (void*)mem_align(_OBuf, MEM_ALIGN_CACHE);
-	keys = (unsigned char*)mem_align(_IBuf, MEM_ALIGN_CACHE);
+	keys = (uint8_t*)mem_align(_IBuf, MEM_ALIGN_CACHE);
 	keys32 = (uint32_t*)keys;
-	memset(keys, 0, 64*SHA1_LOOP_CNT);
+	memset(keys, 0, 64 * SHA1_LOOP_CNT);
 
-	for (i = 0; i < SHA1_LOOP_CNT; ++i) {
+	for (i = 0; i < SHA1_LOOP_CNT; i++) {
 		SHA1_Init(&ctx);
-		SHA1_Update(&ctx, cur_salt->osalt, cur_salt->saltSize);
-		SHA1_Update(&ctx, saved_key[idx+i], saved_len[idx+i]);
+		SHA1_Update(&ctx, cur_salt->salt, cur_salt->saltSize);
+		SHA1_Update(&ctx, saved_key[idx + i], saved_len[idx + i]);
 		SHA1_Final(tmpBuf, &ctx);
-		for (j = 4; j < 24; ++j)
-			keys[GETPOS_1(j, i)] = tmpBuf[j-4];
+		for (j = 4; j < 24; j++)
+			keys[GETPOS_1(j, i)] = tmpBuf[j - 4];
 		keys[GETPOS_1(j, i)] = 0x80;
 		// 24 bytes of crypt data (192 bits).
 		keys[GETPOS_1(63, i)] = 192;
 	}
 
 	// we do 1 less than actual number of iterations here.
-	for (i = 0; i < cur_salt->spinCount-1; i++) {
-		for (j = 0; j < SHA1_LOOP_CNT; ++j) {
-			keys[GETPOS_1(0, j)] = i&0xff;
-			keys[GETPOS_1(1, j)] = (i>>8)&0xff;
-			keys[GETPOS_1(2, j)] = i>>16;
+	for (i = 0; i < cur_salt->spinCount - 1; i++) {
+		for (j = 0; j < SHA1_LOOP_CNT; j++) {
+			keys[GETPOS_1(0, j)] = i & 0xff;
+			keys[GETPOS_1(1, j)] = (i >> 8) & 0xff;
+			keys[GETPOS_1(2, j)] = i >> 16;
 		}
 		// Here we output to 4 bytes past start of input buffer.
-		SIMDSHA1body(keys, &keys32[SIMD_COEF_32], NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+		SIMDSHA1body(keys, &keys32[SIMD_COEF_32], NULL,
+		             SSEi_MIXED_IN | SSEi_OUTPUT_AS_INP_FMT);
 	}
 	// last iteration is output to start of input buffer, then 32 bit 0 appended.
 	// but this is still ends up being 24 bytes of crypt data.
-	for (j = 0; j < SHA1_LOOP_CNT; ++j) {
-		keys[GETPOS_1(0, j)] = i&0xff;
-		keys[GETPOS_1(1, j)] = (i>>8)&0xff;
-		keys[GETPOS_1(2, j)] = i>>16;
+	for (j = 0; j < SHA1_LOOP_CNT; j++) {
+		keys[GETPOS_1(0, j)] = i & 0xff;
+		keys[GETPOS_1(1, j)] = (i >> 8) & 0xff;
+		keys[GETPOS_1(2, j)] = i >> 16;
 	}
-	SIMDSHA1body(keys, keys32, NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+	SIMDSHA1body(keys, keys32, NULL, SSEi_MIXED_IN | SSEi_OUTPUT_AS_INP_FMT);
 
 	// Finally, append "block" (0) to H(n)
-	for (i = 0; i < SHA1_LOOP_CNT; ++i) {
-		for (j = 0; j < 8; ++j)
-			keys[GETPOS_1(20+j, i)] = encryptedVerifierHashInputBlockKey[j];
-		keys[GETPOS_1(20+j, i)] = 0x80;
+	for (i = 0; i < SHA1_LOOP_CNT; i++) {
+		for (j = 0; j < 8; j++)
+			keys[GETPOS_1(20 + j, i)] = encryptedVerifierHashInputBlockKey[j];
+		keys[GETPOS_1(20 + j, i)] = 0x80;
 		// 28 bytes of crypt data (192 bits).
 		keys[GETPOS_1(63, i)] = 224;
 	}
-	SIMDSHA1body(keys, (uint32_t*)crypt, NULL, SSEi_MIXED_IN|SSEi_FLAT_OUT);
-	for (i = 0; i < SHA1_LOOP_CNT; ++i)
+	SIMDSHA1body(keys, (uint32_t*)crypt, NULL, SSEi_MIXED_IN | SSEi_FLAT_OUT);
+	for (i = 0; i < SHA1_LOOP_CNT; i++)
 		memcpy(hashBuf[i], crypt[i], 20);
 
 	// And second "block" (0) to H(n)
-	for (i = 0; i < SHA1_LOOP_CNT; ++i) {
-		for (j = 0; j < 8; ++j)
-			keys[GETPOS_1(20+j, i)] = encryptedVerifierHashValueBlockKey[j];
+	for (i = 0; i < SHA1_LOOP_CNT; i++) {
+		for (j = 0; j < 8; j++)
+			keys[GETPOS_1(20 + j, i)] = encryptedVerifierHashValueBlockKey[j];
 	}
-	SIMDSHA1body(keys, (uint32_t*)crypt, NULL, SSEi_MIXED_IN|SSEi_FLAT_OUT);
-	for (i = 0; i < SHA1_LOOP_CNT; ++i)
+	SIMDSHA1body(keys, (uint32_t*)crypt, NULL, SSEi_MIXED_IN | SSEi_FLAT_OUT);
+	for (i = 0; i < SHA1_LOOP_CNT; i++)
 		memcpy(&hashBuf[i][32], crypt[i], 20);
 
 	// Fix up the size per the spec
-	if (20 < hashSize) { // FIXME: Is this ever true?
-		for (i = 0; i < SHA1_LOOP_CNT; ++i) {
+	if (hashSize > 20) { // FIXME: Is this ever true?
+		for (i = 0; i < SHA1_LOOP_CNT; i++) {
 			for (j = 20; j < hashSize; j++) {
 				hashBuf[i][j] = 0x36;
 				hashBuf[i][32 + j] = 0x36;
@@ -355,20 +418,21 @@ static void GenerateAgileEncryptionKey(int idx, unsigned char hashBuf[SHA1_LOOP_
 	}
 }
 #else
-static void GenerateAgileEncryptionKey(int idx, unsigned char hashBuf[SHA1_LOOP_CNT][64])
+static void GenerateAgileEncryptionKey(int idx,
+                                       uint8_t hashBuf[SHA1_LOOP_CNT][64])
 {
 	/* H(0) = H(salt, password)
 	 * hashBuf = SHA1Hash(salt, password);
 	 * create input buffer for SHA1 from salt and unicode version of password */
-	UTF16 *passwordBuf=saved_key[idx];
-	int passwordBufSize=saved_len[idx];
+	UTF16 *passwordBuf = saved_key[idx];
+	int passwordBufSize = saved_len[idx];
 	int hashSize = cur_salt->keySize >> 3;
-	unsigned int inputBuf[(28 + 4) / sizeof(int)];
-	unsigned int i;
+	uint32_t inputBuf[(28 + 4) / sizeof(int)];
+	uint32_t i;
 	SHA_CTX ctx;
 
 	SHA1_Init(&ctx);
-	SHA1_Update(&ctx, cur_salt->osalt, cur_salt->saltSize);
+	SHA1_Update(&ctx, cur_salt->salt, cur_salt->saltSize);
 	SHA1_Update(&ctx, passwordBuf, passwordBufSize);
 	SHA1_Final(hashBuf[0], &ctx);
 
@@ -388,7 +452,7 @@ static void GenerateAgileEncryptionKey(int idx, unsigned char hashBuf[SHA1_LOOP_
 		// 'append' the previously generated hash to the input buffer
 		SHA1_Init(&ctx);
 		SHA1_Update(&ctx, inputBuf, 0x14 + 0x04);
-		SHA1_Final((unsigned char*)&inputBuf[1], &ctx);
+		SHA1_Final((uint8_t*)&inputBuf[1], &ctx);
 	}
 	// Finally, append "block" (0) to H(n)
 	memcpy(&inputBuf[6], encryptedVerifierHashInputBlockKey, 8);
@@ -403,7 +467,7 @@ static void GenerateAgileEncryptionKey(int idx, unsigned char hashBuf[SHA1_LOOP_
 	SHA1_Final(&hashBuf[0][32], &ctx);
 
 	// Fix up the size per the spec
-	if (20 < hashSize) { // FIXME: Is this ever true?
+	if (hashSize > 20) { // FIXME: Is this ever true?
 		for (i = 20; i < hashSize; i++) {
 			hashBuf[0][i] = 0x36;
 			hashBuf[0][32 + i] = 0x36;
@@ -413,30 +477,31 @@ static void GenerateAgileEncryptionKey(int idx, unsigned char hashBuf[SHA1_LOOP_
 #endif
 
 #ifdef SIMD_COEF_64
-static void GenerateAgileEncryptionKey512(int idx, unsigned char hashBuf[SHA512_LOOP_CNT][128])
+static void GenerateAgileEncryptionKey512(int idx,
+                                          uint8_t hashBuf[SHA512_LOOP_CNT][128])
 {
-	unsigned char tmpBuf[64];
-	unsigned int i, j, k;
+	uint8_t tmpBuf[64], *keys;
+	uint32_t i, j, k;
 	SHA512_CTX ctx;
-	unsigned char _IBuf[128*SHA512_LOOP_CNT+MEM_ALIGN_CACHE], *keys,
-	              _OBuf[64*SHA512_LOOP_CNT+MEM_ALIGN_CACHE];
-	uint64_t *keys64, (*crypt)[64/8];
+	uint8_t _IBuf[128 * SHA512_LOOP_CNT + MEM_ALIGN_CACHE];
+	uint8_t _OBuf[64 * SHA512_LOOP_CNT + MEM_ALIGN_CACHE];
+	uint64_t *keys64, (*crypt)[64 / 8];
 	uint32_t *keys32, *crypt32;
 
 	crypt = (void*)mem_align(_OBuf, MEM_ALIGN_CACHE);
-	keys = (unsigned char*)mem_align(_IBuf, MEM_ALIGN_CACHE);
+	keys = (uint8_t*)mem_align(_IBuf, MEM_ALIGN_CACHE);
 	keys64 = (uint64_t*)keys;
 	keys32 = (uint32_t*)keys;
 	crypt32 = (uint32_t*)crypt;
 
-	memset(keys, 0, 128*SHA512_LOOP_CNT);
-	for (i = 0; i < SHA512_LOOP_CNT; ++i) {
+	memset(keys, 0, 128 * SHA512_LOOP_CNT);
+	for (i = 0; i < SHA512_LOOP_CNT; i++) {
 		SHA512_Init(&ctx);
-		SHA512_Update(&ctx, cur_salt->osalt, cur_salt->saltSize);
-		SHA512_Update(&ctx, saved_key[idx+i], saved_len[idx+i]);
+		SHA512_Update(&ctx, cur_salt->salt, cur_salt->saltSize);
+		SHA512_Update(&ctx, saved_key[idx + i], saved_len[idx + i]);
 		SHA512_Final(tmpBuf, &ctx);
-		for (j = 4; j < 68; ++j)
-			keys[GETPOS_512(j, i)] = tmpBuf[j-4];
+		for (j = 4; j < 68; j++)
+			keys[GETPOS_512(j, i)] = tmpBuf[j - 4];
 		keys[GETPOS_512(j, i)] = 0x80;
 		// 68 bytes of crypt data (0x220 bits).
 		keys[GETPOS_512(127, i)] = 0x20;
@@ -444,116 +509,82 @@ static void GenerateAgileEncryptionKey512(int idx, unsigned char hashBuf[SHA512_
 	}
 
 	// we do 1 less than actual number of iterations here.
-	for (i = 0; i < cur_salt->spinCount-1; i++) {
+	for (i = 0; i < cur_salt->spinCount - 1; i++) {
 
 		// Iteration counter in first 4 bytes
 		for (j = 0; j < SHA512_LOOP_CNT; j++) {
 			keys[GETPOS_512(0, j)] = i & 0xFF;
-			keys[GETPOS_512(1, j)] = (i>>8) & 0xFF;
-			keys[GETPOS_512(2, j)] = (i>>16) & 0xFF;
-			keys[GETPOS_512(3, j)] = (i>>24) & 0xFF;
+			keys[GETPOS_512(1, j)] = (i >> 8) & 0xFF;
+			keys[GETPOS_512(2, j)] = (i >> 16) & 0xFF;
+			keys[GETPOS_512(3, j)] = (i >> 24) & 0xFF;
 		}
 
 		SIMDSHA512body(keys, (uint64_t*)crypt, NULL, SSEi_MIXED_IN);
 
 		// Then we output to 4 bytes past start of input buffer.
-
-		/* Original code to copy in 64 bytes into offset 4.  Not BE compatible.
 		for (j = 0; j < SHA512_LOOP_CNT; j++) {
-			uint32_t *o = keys32 + (j&(SIMD_COEF_64-1))*2 + j/SIMD_COEF_64*2*SHA_BUF_SIZ*SIMD_COEF_64;
-			uint32_t *in = crypt32 + (j&(SIMD_COEF_64-1))*2 + j/SIMD_COEF_64*2*8*SIMD_COEF_64;
-
-			for (k = 0; k < 8; k++) {
-				o[0] = in[1];
-				o += SIMD_COEF_64*2;
-				o[1] = in[0];
-				in += SIMD_COEF_64*2;
-			}
-		}
-		*/
-
-		/* First shot: works good, not endianity bound, but is SLOWER (1/2 speed)
-		for (j = 0; j < SHA512_LOOP_CNT; j++) {
-			for (k = 0; k < 64; k++) {
-				keys[GETPOS_512((k+4), j)] = ((unsigned char*)crypt)[GETOUTPOS_512(k,j)];
-			}
-		}
-		*/
-
-
-		// tweaked original code, swapping uint32_t and this works.
-		// it is very likely this code could be optimized even more, by handling data
-		// in uint64_t items. First and last would still need handled in uint32, but
-		// other 7 elements could be done by reading 2 8 byte values from crypt, shifting
-		// and then placing at one time into input buffer.   I might look into doing that
-		// and see if there is any improvement.  It may also be benefical to look at using
-		// flat buffers here.  Flat buffers would be trivial.  a simple memcpy to move all
-		// 64 bytes at once.  NOTE, in flat model, there is NO way to do this using any
-		// 64 bit assignments. Either the input buffer, or the crypt buffer would not be
-		// properly aligned.  So memcpy would have to be used. BUT it should be trivial
-		// and may in the end be a faster solution, than keeping this code in mixed form.
-		// but for now, it will be left as a task for someone else.
-		for (j = 0; j < SHA512_LOOP_CNT; j++) {
-			uint32_t *o = keys32 + (j&(SIMD_COEF_64-1))*2 + j/SIMD_COEF_64*2*SHA_BUF_SIZ*SIMD_COEF_64;
-			uint32_t *in = crypt32 + (j&(SIMD_COEF_64-1))*2 + j/SIMD_COEF_64*2*8*SIMD_COEF_64;
+			uint32_t *o = keys32 + (j & (SIMD_COEF_64 - 1)) * 2 +
+				j / SIMD_COEF_64 * 2 * SHA_BUF_SIZ * SIMD_COEF_64;
+			uint32_t *in = crypt32 + (j & (SIMD_COEF_64 - 1)) * 2 +
+				j / SIMD_COEF_64 * 2 * 8 * SIMD_COEF_64;
 
 			for (k = 0; k < 8; k++) {
 #if ARCH_LITTLE_ENDIAN==1
 				o[0] = in[1];
-				o += SIMD_COEF_64*2;
+				o += SIMD_COEF_64 * 2;
 				o[1] = in[0];
-				in += SIMD_COEF_64*2;
+				in += SIMD_COEF_64 * 2;
 #else
 				o[1] = in[0];
-				o += SIMD_COEF_64*2;
+				o += SIMD_COEF_64 * 2;
 				o[0] = in[1];
-				in += SIMD_COEF_64*2;
+				in += SIMD_COEF_64 * 2;
 #endif
 			}
 		}
 	}
 	// last iteration is output to start of input buffer, then 32 bit 0 appended.
 	// but this is still ends up being 24 bytes of crypt data.
-	for (j = 0; j < SHA512_LOOP_CNT; ++j) {
-		keys[GETPOS_512(0, j)] = i&0xff;
-		keys[GETPOS_512(1, j)] = (i>>8)&0xff;
-		keys[GETPOS_512(2, j)] = i>>16;
+	for (j = 0; j < SHA512_LOOP_CNT; j++) {
+		keys[GETPOS_512(0, j)] = i & 0xff;
+		keys[GETPOS_512(1, j)] = (i >> 8) & 0xff;
+		keys[GETPOS_512(2, j)] = i >> 16;
 	}
-	SIMDSHA512body(keys, keys64, NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+	SIMDSHA512body(keys, keys64, NULL, SSEi_MIXED_IN | SSEi_OUTPUT_AS_INP_FMT);
 
 	// Finally, append "block" (0) to H(n)
-	for (i = 0; i < SHA512_LOOP_CNT; ++i) {
-		for (j = 0; j < 8; ++j)
-			keys[GETPOS_512(64+j, i)] = encryptedVerifierHashInputBlockKey[j];
-		keys[GETPOS_512(64+j, i)] = 0x80;
+	for (i = 0; i < SHA512_LOOP_CNT; i++) {
+		for (j = 0; j < 8; j++)
+			keys[GETPOS_512(64 + j, i)] = encryptedVerifierHashInputBlockKey[j];
+		keys[GETPOS_512(64 + j, i)] = 0x80;
 		// 72 bytes of crypt data (0x240  we already have 0x220 here)
 		keys[GETPOS_512(127, i)] = 0x40;
 	}
-	SIMDSHA512body(keys, (uint64_t*)crypt, NULL, SSEi_MIXED_IN|SSEi_FLAT_OUT);
-	for (i = 0; i < SHA512_LOOP_CNT; ++i)
+	SIMDSHA512body(keys, (uint64_t*)crypt, NULL, SSEi_MIXED_IN | SSEi_FLAT_OUT);
+	for (i = 0; i < SHA512_LOOP_CNT; i++)
 		memcpy((uint64_t*)(hashBuf[i]), crypt[i], 64);
 
 	// And second "block" (0) to H(n)
-	for (i = 0; i < SHA512_LOOP_CNT; ++i) {
-		for (j = 0; j < 8; ++j)
-			keys[GETPOS_512(64+j, i)] = encryptedVerifierHashValueBlockKey[j];
+	for (i = 0; i < SHA512_LOOP_CNT; i++) {
+		for (j = 0; j < 8; j++)
+			keys[GETPOS_512(64 + j, i)] = encryptedVerifierHashValueBlockKey[j];
 	}
-	SIMDSHA512body(keys, (uint64_t*)crypt, NULL, SSEi_MIXED_IN|SSEi_FLAT_OUT);
+	SIMDSHA512body(keys, (uint64_t*)crypt, NULL, SSEi_MIXED_IN | SSEi_FLAT_OUT);
 
-	for (i = 0; i < SHA512_LOOP_CNT; ++i)
+	for (i = 0; i < SHA512_LOOP_CNT; i++)
 		memcpy((uint64_t*)(&hashBuf[i][64]), crypt[i], 64);
 }
 #else
-static void GenerateAgileEncryptionKey512(int idx, unsigned char hashBuf[SHA512_LOOP_CNT][128])
+static void GenerateAgileEncryptionKey512(int idx, uint8_t hashBuf[SHA512_LOOP_CNT][128])
 {
-	UTF16 *passwordBuf=saved_key[idx];
-	int passwordBufSize=saved_len[idx];
-	unsigned int inputBuf[128 / sizeof(int)];
+	UTF16 *passwordBuf = saved_key[idx];
+	int passwordBufSize = saved_len[idx];
+	uint32_t inputBuf[128 / sizeof(int)];
 	int i;
 	SHA512_CTX ctx;
 
 	SHA512_Init(&ctx);
-	SHA512_Update(&ctx, cur_salt->osalt, cur_salt->saltSize);
+	SHA512_Update(&ctx, cur_salt->salt, cur_salt->saltSize);
 	SHA512_Update(&ctx, passwordBuf, passwordBufSize);
 	SHA512_Final(hashBuf[0], &ctx);
 
@@ -569,173 +600,151 @@ static void GenerateAgileEncryptionKey512(int idx, unsigned char hashBuf[SHA512_
 		// 'append' the previously generated hash to the input buffer
 		SHA512_Init(&ctx);
 		SHA512_Update(&ctx, inputBuf, 64 + 0x04);
-		SHA512_Final((unsigned char*)&inputBuf[1], &ctx);
+		SHA512_Final((uint8_t*)&inputBuf[1], &ctx);
 	}
 
 	// Finally, append "block" (0) to H(n)
-	memcpy(&inputBuf[68/4], encryptedVerifierHashInputBlockKey, 8);
+	memcpy(&inputBuf[68 / 4], encryptedVerifierHashInputBlockKey, 8);
 	SHA512_Init(&ctx);
 	SHA512_Update(&ctx, &inputBuf[1], 64 + 8);
 	SHA512_Final(hashBuf[0], &ctx);
 	// And second "block" (0) to H(n)
-	memcpy(&inputBuf[68/4], encryptedVerifierHashValueBlockKey, 8);
+	memcpy(&inputBuf[68 / 4], encryptedVerifierHashValueBlockKey, 8);
 	SHA512_Init(&ctx);
 	SHA512_Update(&ctx, &inputBuf[1], 64 + 8);
 	SHA512_Final(&hashBuf[0][64], &ctx);
 }
 #endif
 
-static void init(struct fmt_main *self)
-{
-	omp_autotune(self, OMP_SCALE);
-
-	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
-	saved_len = mem_calloc(sizeof(*saved_len), self->params.max_keys_per_crypt);
-	crypt_key = mem_calloc(sizeof(*crypt_key), self->params.max_keys_per_crypt);
-	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);
-	if (options.target_enc == UTF_8)
-		self->params.plaintext_length = MIN(125, PLAINTEXT_LENGTH * 3);
-}
-
-static void done(void)
-{
-	MEM_FREE(cracked);
-	MEM_FREE(crypt_key);
-	MEM_FREE(saved_len);
-	MEM_FREE(saved_key);
-}
-
 static void set_salt(void *salt)
 {
 	cur_salt = (ms_office_custom_salt *)salt;
 }
 
-static void DecryptUsingSymmetricKeyAlgorithm(ms_office_custom_salt *cur_salt, unsigned char *verifierInputKey, unsigned char *encryptedVerifier, const unsigned char *decryptedVerifier, int length)
+static void
+DecryptUsingSymmetricKeyAlgorithm(ms_office_custom_salt *cur_salt,
+                                  uint8_t *verifierInputKey,
+                                  uint8_t *encryptedVerifier,
+                                  const uint8_t *decryptedVerifier,
+                                  int length)
 {
-	unsigned char iv[32];
+	uint8_t iv[32];
 	AES_KEY akey;
 
-	memcpy(iv, cur_salt->osalt, 16);
+	memcpy(iv, cur_salt->salt, 16);
 	memset(&iv[16], 0, 16);
 	AES_set_decrypt_key(verifierInputKey, cur_salt->keySize, &akey);
-	AES_cbc_encrypt(encryptedVerifier, (unsigned char*)decryptedVerifier, length, &akey, iv, AES_DECRYPT);
+	AES_cbc_encrypt(encryptedVerifier, (uint8_t*)decryptedVerifier,
+	                length, &akey, iv, AES_DECRYPT);
 }
 
-// We now pass in the 16 byte 'output'. The older code has been kept, but
-// it no longer used that way. We used to return the 'cracked' value, i.e.
-// if it matched, return 1, else 0. Now we store the encryption data to out,
-// and then in the format use normal binary_hash() methods to test it. The
-// old method used decryption (of the encrypted field). Now we use encrption
-// of the plaintext data, and then binary_hash() compares that to the known
-// encrypted field data.
-// For the time being, the original code has been kept (commented out). I am
-// doing this in hopes of figuring out some way to salt-dupe correct the
-// office 2010-2013 formats. I do not think they can be done, but I may be
-// wrong, so I will keep this code in an "easy to see what changed" layout.
-static void PasswordVerifier(ms_office_custom_salt *cur_salt, unsigned char *key, uint32_t *out)
+static int PasswordVerifier(ms_office_binary_blob *blob, uint8_t *key)
 {
-	unsigned char decryptedVerifier[16];
-	//unsigned char decryptedVerifierHash[16];
+	uint8_t decryptedVerifier[16];
+	uint8_t decryptedVerifierHash[16];
 	AES_KEY akey;
 	SHA_CTX ctx;
-	unsigned char checkHash[32];
-	unsigned char checkHashed[32];
+	uint8_t checkHash[20];
 
 	AES_set_decrypt_key(key, 128, &akey);
-	AES_ecb_encrypt(cur_salt->encryptedVerifier, decryptedVerifier, &akey, AES_DECRYPT);
+	AES_ecb_encrypt(blob->encryptedVerifier, decryptedVerifier,
+	                &akey, AES_DECRYPT);
 
-	// Not using cracked any more.
+	AES_set_decrypt_key(key, 128, &akey);
+	AES_ecb_encrypt(blob->encryptedVerifierHash, decryptedVerifierHash,
+	                &akey, AES_DECRYPT);
+
+	/* find SHA1 hash of decryptedVerifier */
 	SHA1_Init(&ctx);
 	SHA1_Update(&ctx, decryptedVerifier, 16);
 	SHA1_Final(checkHash, &ctx);
-	AES_set_encrypt_key(key, 128, &akey);
-	AES_ecb_encrypt(checkHash, checkHashed, &akey, AES_ENCRYPT);
-	memcpy(out, checkHashed, 16);
 
-	//AES_set_decrypt_key(key, 128, &akey);
-	//AES_ecb_encrypt(cur_salt->encryptedVerifierHash, decryptedVerifierHash, &akey, AES_DECRYPT);
-	//
-	///* find SHA1 hash of decryptedVerifier */
-	//SHA1_Init(&ctx);
-	//SHA1_Update(&ctx, decryptedVerifier, 16);
-	//SHA1_Final(checkHash, &ctx);
-	//
-	//return !memcmp(checkHash, decryptedVerifierHash, 16);
+	return !memcmp(checkHash, decryptedVerifierHash, 16);
 }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	int index = 0, inc = SHA1_LOOP_CNT;
-
-	if (cur_salt->version == 2013)
-		inc = SHA512_LOOP_CNT;
+	const int inc =
+		(cur_salt->version == 2013) ? SHA512_LOOP_CNT : SHA1_LOOP_CNT;
+	int index;
 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-	for (index = 0; index < count; index+=inc)
-	{
-		int i;
-		if (cur_salt->version == 2007) {
-			unsigned char encryptionKey[SHA1_LOOP_CNT][20];
-			GeneratePasswordHashUsingSHA1(index, encryptionKey);
-			for (i = 0; i < SHA1_LOOP_CNT; ++i)
-				PasswordVerifier(cur_salt, encryptionKey[i], crypt_key[index+i]);
-		}
-		else if (cur_salt->version == 2010) {
-			unsigned char verifierKeys[SHA1_LOOP_CNT][64], decryptedVerifierHashInputBytes[16], decryptedVerifierHashBytes[32];
-			unsigned char hash[20];
-			SHA_CTX ctx;
-			GenerateAgileEncryptionKey(index, verifierKeys);
-			for (i = 0; i < inc; ++i) {
-				DecryptUsingSymmetricKeyAlgorithm(cur_salt, verifierKeys[i], cur_salt->encryptedVerifier, decryptedVerifierHashInputBytes, 16);
-				DecryptUsingSymmetricKeyAlgorithm(cur_salt, &verifierKeys[i][32], cur_salt->encryptedVerifierHash, decryptedVerifierHashBytes, 32);
-				SHA1_Init(&ctx);
-				SHA1_Update(&ctx, decryptedVerifierHashInputBytes, 16);
-				SHA1_Final(hash, &ctx);
-				cracked[index+i] = !memcmp(hash, decryptedVerifierHashBytes, 20);
-			}
-		}
-		else if (cur_salt->version == 2013) {
-			unsigned char verifierKeys[SHA512_LOOP_CNT][128], decryptedVerifierHashInputBytes[16], decryptedVerifierHashBytes[32];
-			unsigned char hash[64];
-			SHA512_CTX ctx;
-			GenerateAgileEncryptionKey512(index, verifierKeys);
-			for (i = 0; i < inc; ++i) {
-				DecryptUsingSymmetricKeyAlgorithm(cur_salt, verifierKeys[i], cur_salt->encryptedVerifier, decryptedVerifierHashInputBytes, 16);
-				DecryptUsingSymmetricKeyAlgorithm(cur_salt, &verifierKeys[i][64], cur_salt->encryptedVerifierHash, decryptedVerifierHashBytes, 32);
-				SHA512_Init(&ctx);
-				SHA512_Update(&ctx, decryptedVerifierHashInputBytes, 16);
-				SHA512_Final(hash, &ctx);
-				cracked[index+i] = !memcmp(hash, decryptedVerifierHashBytes, 20);
-			}
-		}
+	for (index = 0; index < count; index += inc) {
+		if (cur_salt->version == 2007)
+			GeneratePasswordHashUsingSHA1(index, &encryptionKey[index]);
+		else if (cur_salt->version == 2010)
+			GenerateAgileEncryptionKey(index, &verifierKeys1[index]);
+		else //if (cur_salt->version == 2013)
+			GenerateAgileEncryptionKey512(index, &verifierKeys512[index]);
 	}
 	return count;
 }
 
 static int cmp_all(void *binary, int count)
 {
+	ms_office_binary_blob *blob = ((fmt_data*)binary)->blob;
 	int index;
-	if (cur_salt->version == 2007) {
-		for (index = 0; index < count; index++) {
-			if ( ((uint32_t*)binary)[0] == crypt_key[index][0] )
-				return 1;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index++) {
+		if (cur_salt->version == 2007)
+			cracked[index] = PasswordVerifier(blob, encryptionKey[index]);
+		else if (cur_salt->version == 2010) {
+			uint8_t decryptedVerifierHashInputBytes[16];
+			uint8_t decryptedVerifierHashBytes[32];
+			uint8_t hash[20];
+			SHA_CTX ctx;
+
+			DecryptUsingSymmetricKeyAlgorithm(cur_salt, verifierKeys1[index],
+			                                  blob->encryptedVerifier,
+			                                  decryptedVerifierHashInputBytes,
+			                                  16);
+			DecryptUsingSymmetricKeyAlgorithm(cur_salt,
+			                                  &verifierKeys1[index][32],
+			                                  blob->encryptedVerifierHash,
+			                                  decryptedVerifierHashBytes, 32);
+			SHA1_Init(&ctx);
+			SHA1_Update(&ctx, decryptedVerifierHashInputBytes, 16);
+			SHA1_Final(hash, &ctx);
+
+			cracked[index] = !memcmp(hash, decryptedVerifierHashBytes, 20);
 		}
-		return 0;
+		else /* if (cur_salt->version == 2013) */ {
+			uint8_t decryptedVerifierHashInputBytes[16];
+			uint8_t decryptedVerifierHashBytes[32];
+			uint8_t hash[64];
+			SHA512_CTX ctx;
+
+			DecryptUsingSymmetricKeyAlgorithm(cur_salt, verifierKeys512[index],
+			                                  blob->encryptedVerifier,
+			                                  decryptedVerifierHashInputBytes,
+			                                  16);
+			DecryptUsingSymmetricKeyAlgorithm(cur_salt,
+			                                  &verifierKeys512[index][64],
+			                                  blob->encryptedVerifierHash,
+			                                  decryptedVerifierHashBytes, 32);
+			SHA512_Init(&ctx);
+			SHA512_Update(&ctx, decryptedVerifierHashInputBytes, 16);
+			SHA512_Final(hash, &ctx);
+
+			cracked[index] = !memcmp(hash, decryptedVerifierHashBytes, 20);
+		}
 	}
+
 	for (index = 0; index < count; index++)
 		if (cracked[index])
 			return 1;
+
 	return 0;
 }
 
 static int cmp_one(void *binary, int index)
 {
-	if (cur_salt->version == 2007) {
-		return !memcmp(binary, crypt_key[index], BINARY_SIZE);
-	}
 	return cracked[index];
 }
 
@@ -744,18 +753,11 @@ static int cmp_exact(char *source, int index)
 	return 1;
 }
 
-static int get_hash_0(int index) { if (cur_salt->version!=2007) return 0; return crypt_key[index][0] & PH_MASK_0; }
-static int get_hash_1(int index) { if (cur_salt->version!=2007) return 0; return crypt_key[index][0] & PH_MASK_1; }
-static int get_hash_2(int index) { if (cur_salt->version!=2007) return 0; return crypt_key[index][0] & PH_MASK_2; }
-static int get_hash_3(int index) { if (cur_salt->version!=2007) return 0; return crypt_key[index][0] & PH_MASK_3; }
-static int get_hash_4(int index) { if (cur_salt->version!=2007) return 0; return crypt_key[index][0] & PH_MASK_4; }
-static int get_hash_5(int index) { if (cur_salt->version!=2007) return 0; return crypt_key[index][0] & PH_MASK_5; }
-static int get_hash_6(int index) { if (cur_salt->version!=2007) return 0; return crypt_key[index][0] & PH_MASK_6; }
-
-static void office_set_key(char *key, int index)
+static void set_key(char *key, int index)
 {
 	/* convert key to UTF-16LE */
-	saved_len[index] = enc_to_utf16(saved_key[index], PLAINTEXT_LENGTH, (UTF8*)key, strlen(key));
+	saved_len[index] = enc_to_utf16(saved_key[index], PLAINTEXT_LENGTH,
+	                                (UTF8*)key, strlen(key));
 	if (saved_len[index] < 0)
 		saved_len[index] = strlen16(saved_key[index]);
 	saved_len[index] <<= 1;
@@ -781,7 +783,7 @@ struct fmt_main fmt_office = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_ENC,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_ENC | FMT_BLOB,
 		{
 			"MS Office version",
 			"iteration count",
@@ -814,18 +816,12 @@ struct fmt_main fmt_office = {
 		fmt_default_salt_hash,
 		NULL,
 		set_salt,
-		office_set_key,
+		set_key,
 		get_key,
 		fmt_default_clear_keys,
 		crypt_all,
 		{
-			get_hash_0,
-			get_hash_1,
-			get_hash_2,
-			get_hash_3,
-			get_hash_4,
-			get_hash_5,
-			get_hash_6
+			fmt_default_get_hash
 		},
 		cmp_all,
 		cmp_one,

--- a/src/oldoffice_common.h
+++ b/src/oldoffice_common.h
@@ -1,0 +1,83 @@
+/*
+ * MS Office 97-2003 cracker patch for JtR. Hacked together during May of
+ * 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
+ *
+ * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
+ * Copyright (c) 2014-2019, magnum
+ * Copyright (c) 2009, David Leblanc (http://offcrypto.codeplex.com/)
+ *
+ * License: Microsoft Public License (MS-PL)
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "arch.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "options.h"
+#include "unicode.h"
+
+#define BINARY_SIZE             sizeof(fmt_data)
+#define BINARY_ALIGN            sizeof(size_t)
+#define SALT_SIZE               sizeof(custom_salt)
+#define SALT_ALIGN              MEM_ALIGN_WORD
+
+#define CIPHERTEXT_LENGTH       (TAG_LEN + 120)
+#define FORMAT_TAG              "$oldoffice$"
+#define TAG_LEN                 (sizeof(FORMAT_TAG) - 1)
+
+#ifndef OO_COMMON
+static struct fmt_tests oldoffice_tests[] = {
+	{"$oldoffice$1*de17a7f3c3ff03a39937ba9666d6e952*2374d5b6ce7449f57c9f252f9f9b53d2*e60e1185f7aecedba262f869c0236f81", "test"},
+	{"$oldoffice$0*e40b4fdade5be6be329c4238e2099b8a*259590322b55f7a3c38cb96b5864e72d*2e6516bfaf981770fe6819a34998295d", "123456789012345"},
+	{"$oldoffice$4*163ae8c43577b94902f58d0106b29205*87deff24175c2414cb1b2abdd30855a3*4182446a527fe4648dffa792d55ae7a15edfc4fb", "Google123"},
+	/* Meet-in-the-middle candidate produced with hashcat -m9710 */
+	/* Real pw is "hashcat", one collision is "zvDtu!" */
+	{"", "zvDtu!", {"", "$oldoffice$1*d6aabb63363188b9b73a88efb9c9152e*afbbb9254764273f8f4fad9a5d82981f*6f09fd2eafc4ade522b5f2bee0eaf66d","f2ab1219ae"} },
+#if PLAINTEXT_LENGTH >= 24
+	/* 2003-RC4-40bit-MS-Base-Crypto-1.0_myhovercraftisfullofeels_.doc */
+	{"$oldoffice$3*9f32522fe9bcb69b12f39d3c24b39b2f*fac8b91a8a578468ae7001df4947558f*f2e267a5bea45736b52d6d1051eca1b935eabf3a", "myhovercraftisfullofeels"},
+	/* Test-RC4-40bit-MS-Base-DSS_myhovercraftisfullofeels_.doc */
+	{"$oldoffice$3*095b777a73a10fb6bcd3e48d50f8f8c5*36902daab0d0f38f587a84b24bd40dce*25db453f79e8cbe4da1844822b88f6ce18a5edd2", "myhovercraftisfullofeels"},
+	/* 2003-RC4-40bit-MS-Base-DH-SChan_myhovercraftisfullofeels_.doc */
+	{"$oldoffice$3*284bc91cb64bc847a7a44bc7bf34fb69*1f8c589c6fcbd43c42b2bc6fff4fd12b*2bc7d8e866c9ea40526d3c0a59e2d37d8ded3550", "myhovercraftisfullofeels"},
+	/* Test-RC4-128bit-MS-Strong-Crypto_myhovercraftisfullofeels_.doc */
+	{"$oldoffice$4*a58b39c30a06832ee664c1db48d17304*986a45cc9e17e062f05ceec37ec0db17*fe0c130ef374088f3fec1979aed4d67459a6eb9a", "myhovercraftisfullofeels"},
+	/* 2003-RC4-40bit-MS-Base-1.0_myhovercraftisfullofeels_.xls */
+	{"$oldoffice$3*f426041b2eba9745d30c7949801f7d3a*888b34927e5f31e2703cc4ce86a6fd78*ff66200812fd06c1ba43ec2be9f3390addb20096", "myhovercraftisfullofeels"},
+#endif
+	/* the following hash was extracted from Proc2356.ppt (manually + by oldoffice2john.py */
+	{"$oldoffice$3*DB575DDA2E450AB3DFDF77A2E9B3D4C7*AB183C4C8B5E5DD7B9F3AF8AE5FFF31A*B63594447FAE7D4945D2DAFD113FD8C9F6191BF5", "crypto"},
+	{"$oldoffice$3*3fbf56a18b026e25815cbea85a16036c*216562ea03b4165b54cfaabe89d36596*91308b40297b7ce31af2e8c57c6407994b205590", "openwall"},
+	{NULL}
+};
+#endif
+
+typedef struct {
+	unsigned int type;
+	unsigned char salt[16];
+} custom_salt;
+
+typedef struct {
+	unsigned char verifier[16]; /* or encryptedVerifier */
+	unsigned char verifierHash[20];  /* or encryptedVerifierHash */
+	unsigned int has_mitm;
+	unsigned char mitm[5]; /* Meet-in-the-middle hint, if we have one */
+} binary_blob;
+
+extern int *oo_cracked;
+extern custom_salt *oo_cur_salt;
+
+extern int oldoffice_valid(char *ciphertext, struct fmt_main *self);
+extern char *oldoffice_prepare(char *split_fields[10], struct fmt_main *self);
+extern char *oldoffice_split(char *ciphertext, int index,
+                             struct fmt_main *self);
+extern void *oldoffice_get_binary(char *ciphertext);
+extern void *oldoffice_get_salt(char *ciphertext);
+extern int oldoffice_cmp_one(void *binary, int index);
+extern int oldoffice_cmp_exact(char *source, int index);
+extern unsigned int oldoffice_hash_type(void *salt);
+extern int oldoffice_salt_hash(void *salt);

--- a/src/oldoffice_common_plug.c
+++ b/src/oldoffice_common_plug.c
@@ -1,0 +1,251 @@
+/*
+ * MS Office 97-2003 cracker patch for JtR. Hacked together during May of
+ * 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
+ *
+ * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
+ * Copyright (c) 2014-2019, magnum
+ * Copyright (c) 2009, David Leblanc (http://offcrypto.codeplex.com/)
+ *
+ * License: Microsoft Public License (MS-PL)
+ */
+
+#define OO_COMMON
+#include "oldoffice_common.h"
+
+int *oo_cracked;
+custom_salt *oo_cur_salt;
+
+static struct {
+	int ct_hash;
+	unsigned char mitm[10];
+} mitm_catcher;
+
+/* Based on ldr_cracked_hash from loader.c */
+#define HASH_LOG 30
+#define HASH_SIZE (1 << HASH_LOG)
+static int hex_hash(char *ciphertext)
+{
+	unsigned int hash, extra;
+	unsigned char *p = (unsigned char *)ciphertext;
+
+	hash = p[0] | 0x20; /* ASCII case insensitive */
+	if (!hash)
+		goto out;
+	extra = p[1] | 0x20;
+	if (!extra)
+		goto out;
+
+	p += 2;
+	while (*p) {
+		hash <<= 1; extra <<= 1;
+		hash += p[0] | 0x20;
+		if (!p[1]) break;
+		extra += p[1] | 0x20;
+		p += 2;
+		if (hash & 0xe0000000) {
+			hash ^= hash >> HASH_LOG;
+			extra ^= extra >> (HASH_LOG - 1);
+			hash &= HASH_SIZE - 1;
+		}
+	}
+
+	hash -= extra;
+	hash ^= extra << (HASH_LOG / 2);
+	hash ^= hash >> HASH_LOG;
+	hash &= HASH_SIZE - 1;
+out:
+	return hash;
+}
+
+int oldoffice_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *ptr, *keeptr;
+	int type, extra;
+
+	if (strncmp(ciphertext, FORMAT_TAG, TAG_LEN))
+		return 0;
+	if (strlen(ciphertext) > CIPHERTEXT_LENGTH)
+		return 0;
+	if (!(ctcopy = strdup(ciphertext)))
+		return 0;
+	keeptr = ctcopy;
+	ctcopy += TAG_LEN;
+	if (!(ptr = strtokm(ctcopy, "*"))) /* type */
+		goto error;
+	type = atoi(ptr);
+	if (type < 0 || type > 4)
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* salt */
+		goto error;
+	if (hexlen(ptr, &extra) != 32 || extra)
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* verifier */
+		goto error;
+	if (hexlen(ptr, &extra) != 32 || extra)
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* verifier hash */
+		goto error;
+	if (type < 3 && (hexlen(ptr, &extra) != 32 || extra))
+		goto error;
+	else if (type >= 3 && (hexlen(ptr, &extra) != 40 || extra))
+		goto error;
+/*
+ * Deprecated field: mitm hash (40-bit RC4). The new way to put it is in the
+ * uid field, like hashcat's example hash.
+ */
+	if (type <= 3 && (ptr = strtokm(NULL, "*"))) {
+		if (hexlen(ptr, &extra) != 10 || extra)
+			goto error;
+	}
+	MEM_FREE(keeptr);
+	return 1;
+error:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+/* uid field may contain a meet-in-the-middle hash */
+char *oldoffice_prepare(char *split_fields[10], struct fmt_main *self)
+{
+	if (split_fields[0] && oldoffice_valid(split_fields[0], self) &&
+	    split_fields[1] &&
+	    hexlen(split_fields[1], 0) == 10) {
+		mitm_catcher.ct_hash = hex_hash(split_fields[0]);
+		memcpy(mitm_catcher.mitm, split_fields[1], 10);
+		return split_fields[0];
+	}
+	else if (oldoffice_valid(split_fields[1], self) && split_fields[2] &&
+	         hexlen(split_fields[2], 0) == 10) {
+		mitm_catcher.ct_hash = hex_hash(split_fields[1]);
+		memcpy(mitm_catcher.mitm, split_fields[2], 10);
+	}
+	return split_fields[1];
+}
+
+char *oldoffice_split(char *ciphertext, int index, struct fmt_main *self)
+{
+	static char out[CIPHERTEXT_LENGTH];
+	char *p;
+	int extra;
+
+	strnzcpy(out, ciphertext, sizeof(out));
+	strlwr(out);
+
+	/* Drop legacy embedded MITM hash */
+	if ((p = strrchr(out, '*')) && (hexlen(&p[1], &extra) == 10 || extra))
+		*p = 0;
+	return out;
+}
+
+void *oldoffice_get_binary(char *ciphertext)
+{
+	static fmt_data data;
+	binary_blob *blob;
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	char *p;
+	int i, type;
+
+	data.flags = FMT_DATA_TINY;
+	data.size = sizeof(binary_blob);
+
+	blob = (data.flags == FMT_DATA_TINY) ?
+		mem_alloc_tiny(data.size, BINARY_ALIGN) : mem_alloc(data.size);
+	data.blob = blob;
+
+	memset(blob, 0, sizeof(binary_blob));
+
+	ctcopy += TAG_LEN;	/* skip over "$oldoffice$" */
+	p = strtokm(ctcopy, "*");
+	type = atoi(p);
+	p = strtokm(NULL, "*");
+	p = strtokm(NULL, "*");
+	for (i = 0; i < 16; i++)
+		blob->verifier[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "*");
+	for (i = 0; i < 16; i++)
+		blob->verifierHash[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	if (type >= 3) {
+		for (; i < 20; i++)
+			blob->verifierHash[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	}
+
+	if ((p = strtokm(NULL, "*"))) { /* Deprecated field */
+		blob->has_mitm = 1;
+		for (i = 0; i < 5; i++)
+			blob->mitm[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	} else
+	if (hex_hash(ciphertext) == mitm_catcher.ct_hash) {
+		blob->has_mitm = 1;
+		for (i = 0; i < 5; i++)
+			blob->mitm[i] = atoi16[ARCH_INDEX(mitm_catcher.mitm[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(mitm_catcher.mitm[i * 2 + 1])];
+	} else
+		blob->has_mitm = 0;
+
+	MEM_FREE(keeptr);
+	return &data;
+}
+
+void *oldoffice_get_salt(char *ciphertext)
+{
+	static custom_salt cs;
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	char *p;
+	int i;
+
+	memset(&cs, 0, sizeof(cs));
+	ctcopy += TAG_LEN;	/* skip over "$oldoffice$" */
+	p = strtokm(ctcopy, "*");
+	cs.type = atoi(p);
+	p = strtokm(NULL, "*");
+	for (i = 0; i < 16; i++)
+		cs.salt[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+
+	MEM_FREE(keeptr);
+
+	return &cs;
+}
+
+int oldoffice_cmp_one(void *binary, int index)
+{
+	if (oo_cracked[index] && oo_cur_salt->type < 4 && !bench_or_test_running) {
+		binary_blob *cur_binary = ((fmt_data*)binary)->blob;
+		unsigned char *cp, out[11];
+		int i;
+
+		cp = cur_binary->mitm;
+		for (i = 0; i < 5; i++) {
+			out[2 * i + 0] = itoa16[*cp >> 4];
+			out[2 * i + 1] = itoa16[*cp & 0xf];
+			cp++;
+		}
+		out[10] = 0;
+		fprintf(stderr, "MITM key: %s\n", out);
+	}
+	return oo_cracked[index];
+}
+
+int oldoffice_cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+unsigned int oldoffice_hash_type(void *salt)
+{
+	return ((custom_salt*)salt)->type;
+}
+
+int oldoffice_salt_hash(void *salt)
+{
+	int salt32;
+
+	memcpy(&salt32, ((custom_salt*)salt)->salt, sizeof(salt32));
+	return salt32 & (SALT_HASH_SIZE - 1);
+}

--- a/src/oldoffice_fmt_plug.c
+++ b/src/oldoffice_fmt_plug.c
@@ -3,7 +3,7 @@
  * 2012 by Dhiru Kholia <dhiru.kholia at gmail.com>.
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
- * Copyright (c) 2014, magnum
+ * Copyright (c) 2014-2019, magnum
  * Copyright (c) 2009, David Leblanc (http://offcrypto.codeplex.com/)
  *
  * License: Microsoft Public License (MS-PL)
@@ -15,24 +15,14 @@ extern struct fmt_main fmt_oldoffice;
 john_register_one(&fmt_oldoffice);
 #else
 
-#include <stdint.h>
-#include <string.h>
-
 #ifdef _OPENMP
 #include <omp.h>
 #endif
 
+#include "oldoffice_common.h"
 #include "md5.h"
 #include "rc4.h"
 #include "sha.h"
-#include "arch.h"
-#include "misc.h"
-#include "common.h"
-#include "formats.h"
-#include "params.h"
-#include "options.h"
-#include "unicode.h"
-#include "dyna_salt.h"
 
 #define FORMAT_LABEL            "oldoffice"
 #define FORMAT_NAME             "MS Office <= 2003"
@@ -40,45 +30,12 @@ john_register_one(&fmt_oldoffice);
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        7
 #define PLAINTEXT_LENGTH        64
-#define BINARY_SIZE             0
-#define BINARY_ALIGN            MEM_ALIGN_NONE
-#define SALT_SIZE               sizeof(dyna_salt*)
-#define SALT_ALIGN              MEM_ALIGN_WORD
 #define MIN_KEYS_PER_CRYPT      1
 #define MAX_KEYS_PER_CRYPT      64
 
 #ifndef OMP_SCALE
 #define OMP_SCALE               8 // Tuned w/ MKPC for core i7
 #endif
-
-#define CIPHERTEXT_LENGTH       (TAG_LEN + 120)
-#define FORMAT_TAG              "$oldoffice$"
-#define TAG_LEN                 (sizeof(FORMAT_TAG) - 1)
-
-static struct fmt_tests oo_tests[] = {
-	{"$oldoffice$1*de17a7f3c3ff03a39937ba9666d6e952*2374d5b6ce7449f57c9f252f9f9b53d2*e60e1185f7aecedba262f869c0236f81", "test"},
-	{"$oldoffice$0*e40b4fdade5be6be329c4238e2099b8a*259590322b55f7a3c38cb96b5864e72d*2e6516bfaf981770fe6819a34998295d", "123456789012345"},
-	{"$oldoffice$4*163ae8c43577b94902f58d0106b29205*87deff24175c2414cb1b2abdd30855a3*4182446a527fe4648dffa792d55ae7a15edfc4fb", "Google123"},
-	/* Meet-in-the-middle candidate produced with hashcat -m9710 */
-	/* Real pw is "hashcat", one collision is "zvDtu!" */
-	{"", "zvDtu!", {"", "$oldoffice$1*d6aabb63363188b9b73a88efb9c9152e*afbbb9254764273f8f4fad9a5d82981f*6f09fd2eafc4ade522b5f2bee0eaf66d","f2ab1219ae"} },
-#if PLAINTEXT_LENGTH >= 24
-	/* 2003-RC4-40bit-MS-Base-Crypto-1.0_myhovercraftisfullofeels_.doc */
-	{"$oldoffice$3*9f32522fe9bcb69b12f39d3c24b39b2f*fac8b91a8a578468ae7001df4947558f*f2e267a5bea45736b52d6d1051eca1b935eabf3a", "myhovercraftisfullofeels"},
-	/* Test-RC4-40bit-MS-Base-DSS_myhovercraftisfullofeels_.doc */
-	{"$oldoffice$3*095b777a73a10fb6bcd3e48d50f8f8c5*36902daab0d0f38f587a84b24bd40dce*25db453f79e8cbe4da1844822b88f6ce18a5edd2", "myhovercraftisfullofeels"},
-	/* 2003-RC4-40bit-MS-Base-DH-SChan_myhovercraftisfullofeels_.doc */
-	{"$oldoffice$3*284bc91cb64bc847a7a44bc7bf34fb69*1f8c589c6fcbd43c42b2bc6fff4fd12b*2bc7d8e866c9ea40526d3c0a59e2d37d8ded3550", "myhovercraftisfullofeels"},
-	/* Test-RC4-128bit-MS-Strong-Crypto_myhovercraftisfullofeels_.doc */
-	{"$oldoffice$4*a58b39c30a06832ee664c1db48d17304*986a45cc9e17e062f05ceec37ec0db17*fe0c130ef374088f3fec1979aed4d67459a6eb9a", "myhovercraftisfullofeels"},
-	/* 2003-RC4-40bit-MS-Base-1.0_myhovercraftisfullofeels_.xls */
-	{"$oldoffice$3*f426041b2eba9745d30c7949801f7d3a*888b34927e5f31e2703cc4ce86a6fd78*ff66200812fd06c1ba43ec2be9f3390addb20096", "myhovercraftisfullofeels"},
-#endif
-	/* the following hash was extracted from Proc2356.ppt (manually + by oldoffice2john.py */
-	{"$oldoffice$3*DB575DDA2E450AB3DFDF77A2E9B3D4C7*AB183C4C8B5E5DD7B9F3AF8AE5FFF31A*B63594447FAE7D4945D2DAFD113FD8C9F6191BF5", "crypto"},
-	{"$oldoffice$3*3fbf56a18b026e25815cbea85a16036c*216562ea03b4165b54cfaabe89d36596*91308b40297b7ce31af2e8c57c6407994b205590", "openwall"},
-	{NULL}
-};
 
 /* Password encoded in UCS-2 */
 static UTF16 (*saved_key)[PLAINTEXT_LENGTH + 1];
@@ -87,27 +44,8 @@ static int *saved_len;
 /* Last hash with this salt and plain */
 static unsigned char (*mitm_key)[16];
 static unsigned char (*rc4_key)[16];
-static int any_cracked, *cracked;
+static int any_cracked;
 static size_t cracked_size;
-static int new_keys;
-
-typedef struct {
-	dyna_salt dsalt;
-	int type;
-	unsigned char salt[16];
-	unsigned char verifier[16]; /* or encryptedVerifier */
-	unsigned char verifierHash[20];  /* or encryptedVerifierHash */
-	unsigned int has_mitm;
-	unsigned char mitm[5]; /* Meet-in-the-middle hint, if we have one */
-} custom_salt;
-
-static struct {
-	int ct_hash;
-	unsigned char mitm[10];
-} mitm_catcher;
-
-static custom_salt cs;
-static custom_salt *cur_salt = &cs;
 
 static void init(struct fmt_main *self)
 {
@@ -125,215 +63,90 @@ static void init(struct fmt_main *self)
 	rc4_key = mem_alloc(self->params.max_keys_per_crypt *
 	                    sizeof(*rc4_key));
 	any_cracked = 0;
-	cracked_size = sizeof(*cracked) * self->params.max_keys_per_crypt;
-	cracked = mem_calloc(1, cracked_size);
+	cracked_size = sizeof(*oo_cracked) * self->params.max_keys_per_crypt;
+	oo_cracked = mem_calloc(1, cracked_size);
 }
 
 static void done(void)
 {
-	MEM_FREE(cracked);
+	MEM_FREE(oo_cracked);
 	MEM_FREE(rc4_key);
 	MEM_FREE(mitm_key);
 	MEM_FREE(saved_len);
 	MEM_FREE(saved_key);
 }
 
-/* Based on ldr_cracked_hash from loader.c */
-#define HASH_LOG 30
-#define HASH_SIZE (1 << HASH_LOG)
-static int hex_hash(char *ciphertext)
-{
-	unsigned int hash, extra;
-	unsigned char *p = (unsigned char *)ciphertext;
-
-	hash = p[0] | 0x20; /* ASCII case insensitive */
-	if (!hash)
-		goto out;
-	extra = p[1] | 0x20;
-	if (!extra)
-		goto out;
-
-	p += 2;
-	while (*p) {
-		hash <<= 1; extra <<= 1;
-		hash += p[0] | 0x20;
-		if (!p[1]) break;
-		extra += p[1] | 0x20;
-		p += 2;
-		if (hash & 0xe0000000) {
-			hash ^= hash >> HASH_LOG;
-			extra ^= extra >> (HASH_LOG - 1);
-			hash &= HASH_SIZE - 1;
-		}
-	}
-
-	hash -= extra;
-	hash ^= extra << (HASH_LOG / 2);
-	hash ^= hash >> HASH_LOG;
-	hash &= HASH_SIZE - 1;
-out:
-	return hash;
-}
-
-static int valid(char *ciphertext, struct fmt_main *self)
-{
-	char *ctcopy, *ptr, *keeptr;
-	int type, extra;
-
-	if (strncmp(ciphertext, FORMAT_TAG, TAG_LEN))
-		return 0;
-	if (strlen(ciphertext) > CIPHERTEXT_LENGTH)
-		return 0;
-	if (!(ctcopy = strdup(ciphertext)))
-		return 0;
-	keeptr = ctcopy;
-	ctcopy += TAG_LEN;
-	if (!(ptr = strtokm(ctcopy, "*"))) /* type */
-		goto error;
-	type = atoi(ptr);
-	if (type < 0 || type > 4)
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* salt */
-		goto error;
-	if (hexlen(ptr, &extra) != 32 || extra)
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* verifier */
-		goto error;
-	if (hexlen(ptr, &extra) != 32 || extra)
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* verifier hash */
-		goto error;
-	if (type < 3 && (hexlen(ptr, &extra) != 32 || extra))
-		goto error;
-	else if (type >= 3 && (hexlen(ptr, &extra) != 40 || extra))
-		goto error;
-/*
- * Deprecated field: mitm hash (40-bit RC4). The new way to put it is in the
- * uid field, like hashcat's example hash.
- */
-	if (type <= 3 && (ptr = strtokm(NULL, "*"))) {
-		if (hexlen(ptr, &extra) != 10 || extra)
-			goto error;
-	}
-	MEM_FREE(keeptr);
-	return 1;
-error:
-	MEM_FREE(keeptr);
-	return 0;
-}
-
-/* uid field may contain a meet-in-the-middle hash */
-static char *prepare(char *split_fields[10], struct fmt_main *self)
-{
-	if (split_fields[0] && valid(split_fields[0], self) && split_fields[1] &&
-	    hexlen(split_fields[1], 0) == 10) {
-		mitm_catcher.ct_hash = hex_hash(split_fields[0]);
-		memcpy(mitm_catcher.mitm, split_fields[1], 10);
-		return split_fields[0];
-	}
-	else if (valid(split_fields[1], self) && split_fields[2] &&
-	         hexlen(split_fields[2], 0) == 10) {
-		mitm_catcher.ct_hash = hex_hash(split_fields[1]);
-		memcpy(mitm_catcher.mitm, split_fields[2], 10);
-	}
-	return split_fields[1];
-}
-
-static char *split(char *ciphertext, int index, struct fmt_main *self)
-{
-	static char out[CIPHERTEXT_LENGTH];
-	char *p;
-	int extra;
-
-	strnzcpy(out, ciphertext, sizeof(out));
-	strlwr(out);
-
-	/* Drop legacy embedded MITM hash */
-	if ((p = strrchr(out, '*')) && (hexlen(&p[1], &extra) == 10 || extra))
-		*p = 0;
-	return out;
-}
-
-static void *get_salt(char *ciphertext)
-{
-	static void *ptr;
-	char *ctcopy = strdup(ciphertext);
-	char *keeptr = ctcopy;
-	char *p;
-	int i;
-
-	memset(&cs, 0, sizeof(cs));
-	ctcopy += TAG_LEN;	/* skip over "$oldoffice$" */
-	p = strtokm(ctcopy, "*");
-	cs.type = atoi(p);
-	p = strtokm(NULL, "*");
-	for (i = 0; i < 16; i++)
-		cs.salt[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	p = strtokm(NULL, "*");
-	for (i = 0; i < 16; i++)
-		cs.verifier[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	p = strtokm(NULL, "*");
-	if (cs.type < 3) {
-		for (i = 0; i < 16; i++)
-			cs.verifierHash[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	}
-	else {
-		for (i = 0; i < 20; i++)
-			cs.verifierHash[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	}
-	if ((p = strtokm(NULL, "*"))) { /* Deprecated field */
-		cs.has_mitm = 1;
-		for (i = 0; i < 5; i++)
-			cs.mitm[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	} else
-	if (hex_hash(ciphertext) == mitm_catcher.ct_hash) {
-		cs.has_mitm = 1;
-		for (i = 0; i < 5; i++)
-			cs.mitm[i] = atoi16[ARCH_INDEX(mitm_catcher.mitm[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(mitm_catcher.mitm[i * 2 + 1])];
-	} else
-		cs.has_mitm = 0;
-
-	MEM_FREE(keeptr);
-
-	cs.dsalt.salt_cmp_offset = SALT_CMP_OFF(custom_salt, type);
-	cs.dsalt.salt_cmp_size = SALT_CMP_SIZE(custom_salt, type, has_mitm, 0);
-	cs.dsalt.salt_alloc_needs_free = 0;
-
-	ptr = mem_alloc_copy(&cs, sizeof(custom_salt), MEM_ALIGN_WORD);
-	return &ptr;
-}
-
 static void set_salt(void *salt)
 {
-	if (memcmp(cur_salt->salt, (*(custom_salt**)salt)->salt, 16))
-	    new_keys = 1;
-	cur_salt = *(custom_salt**)salt;
-}
-
-static int salt_compare(const void *x, const void *y)
-{
-	int c;
-
-	c = memcmp((*(custom_salt**)x)->salt, (*(custom_salt**)y)->salt, 16);
-	if (c)
-		return c;
-	c = dyna_salt_cmp((void*)x, (void*)y, SALT_SIZE);
-	return c;
+	oo_cur_salt = salt;
 }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
-	int index = 0;
+	int index;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index++) {
+		int i;
+
+		if (oo_cur_salt->type < 3) {
+			MD5_CTX ctx;
+			unsigned char hashBuf[21 * 16];
+			unsigned char key_hash[16];
+
+			MD5_Init(&ctx);
+			MD5_Update(&ctx, saved_key[index], saved_len[index]);
+			MD5_Final(key_hash, &ctx);
+			for (i = 0; i < 16; i++) {
+				memcpy(hashBuf + i * 21, key_hash, 5);
+				memcpy(hashBuf + i * 21 + 5, oo_cur_salt->salt, 16);
+			}
+			MD5_Init(&ctx);
+			MD5_Update(&ctx, hashBuf, 21 * 16);
+			MD5_Final(mitm_key[index], &ctx);
+
+			memcpy(hashBuf, mitm_key[index], 5);
+			memset(hashBuf + 5, 0, 4);
+			MD5_Init(&ctx);
+			MD5_Update(&ctx, hashBuf, 9);
+			MD5_Final(rc4_key[index], &ctx);
+		}
+		else {
+			SHA_CTX ctx;
+			unsigned char H0[24];
+			unsigned char key_hash[20];
+
+			SHA1_Init(&ctx);
+			SHA1_Update(&ctx, oo_cur_salt->salt, 16);
+			SHA1_Update(&ctx, saved_key[index], saved_len[index]);
+			SHA1_Final(H0, &ctx);
+			memset(&H0[20], 0, 4);
+			SHA1_Init(&ctx);
+			SHA1_Update(&ctx, H0, 24);
+			SHA1_Final(key_hash, &ctx);
+
+			if (oo_cur_salt->type < 4) {
+				memcpy(mitm_key[index], key_hash, 5);
+				memset(&mitm_key[index][5], 0, 11);
+			} else
+				memcpy(mitm_key[index], key_hash, 16);
+
+		}
+	}
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	binary_blob *cur_binary = ((fmt_data*)binary)->blob;
+	int index;
 
 	if (any_cracked) {
-		memset(cracked, 0, cracked_size);
+		memset(oo_cracked, 0, cracked_size);
 		any_cracked = 0;
 	}
 
@@ -341,45 +154,16 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #pragma omp parallel for
 #endif
 	for (index = 0; index < count; index++) {
-		int i;
 		RC4_KEY key;
 
-		if (cur_salt->type < 3) {
+		if (oo_cur_salt->type < 3) {
 			MD5_CTX ctx;
 			unsigned char pwdHash[16];
 			unsigned char hashBuf[21 * 16];
 
-			if (new_keys) {
-				unsigned char key_hash[16];
-
-				MD5_Init(&ctx);
-				MD5_Update(&ctx, saved_key[index], saved_len[index]);
-				MD5_Final(key_hash, &ctx);
-				for (i = 0; i < 16; i++) {
-					memcpy(hashBuf + i * 21, key_hash, 5);
-					memcpy(hashBuf + i * 21 + 5, cur_salt->salt, 16);
-				}
-				MD5_Init(&ctx);
-				MD5_Update(&ctx, hashBuf, 21 * 16);
-				MD5_Final(mitm_key[index], &ctx);
-			}
-
-			// Early reject if we got a hint
-			if (cur_salt->has_mitm &&
-			    memcmp(mitm_key[index], cur_salt->mitm, 5))
-				continue;
-
-			if (new_keys) {
-				memcpy(hashBuf, mitm_key[index], 5);
-				memset(hashBuf + 5, 0, 4);
-				MD5_Init(&ctx);
-				MD5_Update(&ctx, hashBuf, 9);
-				MD5_Final(rc4_key[index], &ctx);
-			}
-
 			RC4_set_key(&key, 16, rc4_key[index]); /* rc4Key */
-			RC4(&key, 16, cur_salt->verifier, hashBuf); /* encryptedVerifier */
-			RC4(&key, 16, cur_salt->verifierHash, hashBuf + 16); /* encryptedVerifierHash */
+			RC4(&key, 16, cur_binary->verifier, hashBuf); /* encryptedVerifier */
+			RC4(&key, 16, cur_binary->verifierHash, hashBuf + 16); /* encryptedVerifierHash */
 			/* hash the decrypted verifier */
 			MD5_Init(&ctx);
 			MD5_Update(&ctx, hashBuf, 16);
@@ -389,45 +173,20 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #pragma omp critical
 #endif
 			{
-				any_cracked = cracked[index] = 1;
-				cur_salt->has_mitm = 1;
-				memcpy(cur_salt->mitm, mitm_key[index], 5);
+				any_cracked = oo_cracked[index] = 1;
+				cur_binary->has_mitm = 1;
+				memcpy(cur_binary->mitm, mitm_key[index], 5);
 			}
 		}
 		else {
 			SHA_CTX ctx;
-			unsigned char H0[24];
 			unsigned char Hfinal[20];
 			unsigned char DecryptedVerifier[16];
 			unsigned char DecryptedVerifierHash[20];
 
-			if (new_keys) {
-				unsigned char key_hash[20];
-
-				SHA1_Init(&ctx);
-				SHA1_Update(&ctx, cur_salt->salt, 16);
-				SHA1_Update(&ctx, saved_key[index], saved_len[index]);
-				SHA1_Final(H0, &ctx);
-				memset(&H0[20], 0, 4);
-				SHA1_Init(&ctx);
-				SHA1_Update(&ctx, H0, 24);
-				SHA1_Final(key_hash, &ctx);
-
-				if (cur_salt->type < 4) {
-					memcpy(mitm_key[index], key_hash, 5);
-					memset(&mitm_key[index][5], 0, 11);
-				} else
-					memcpy(mitm_key[index], key_hash, 16);
-			}
-
-			// Early reject if we got a hint
-			if (cur_salt->has_mitm &&
-			    memcmp(mitm_key[index], cur_salt->mitm, 5))
-				continue;
-
 			RC4_set_key(&key, 16, mitm_key[index]); /* dek */
-			RC4(&key, 16, cur_salt->verifier, DecryptedVerifier);
-			RC4(&key, 16, cur_salt->verifierHash, DecryptedVerifierHash);
+			RC4(&key, 16, cur_binary->verifier, DecryptedVerifier);
+			RC4(&key, 16, cur_binary->verifierHash, DecryptedVerifierHash);
 			SHA1_Init(&ctx);
 			SHA1_Update(&ctx, DecryptedVerifier, 16);
 			SHA1_Final(Hfinal, &ctx);
@@ -436,45 +195,16 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #pragma omp critical
 #endif
 			{
-				any_cracked = cracked[index] = 1;
-				if (cur_salt->type < 4) {
-					cur_salt->has_mitm = 1;
-					memcpy(cur_salt->mitm, mitm_key[index], 5);
+				any_cracked = oo_cracked[index] = 1;
+				if (oo_cur_salt->type < 4) {
+					cur_binary->has_mitm = 1;
+					memcpy(cur_binary->mitm, mitm_key[index], 5);
 				}
 			}
 		}
 	}
-	new_keys = 0;
 
-	return count;
-}
-
-static int cmp_all(void *binary, int count)
-{
 	return any_cracked;
-}
-
-static int cmp_one(void *binary, int index)
-{
-	return cracked[index];
-}
-
-static int cmp_exact(char *source, int index)
-{
-	if (cur_salt->type < 4 && !bench_or_test_running) {
-		unsigned char *cp, out[11];
-		int i;
-
-		cp = cur_salt->mitm;
-		for (i = 0; i < 5; i++) {
-			out[2 * i + 0] = itoa16[*cp >> 4];
-			out[2 * i + 1] = itoa16[*cp & 0xf];
-			cp++;
-		}
-		out[10] = 0;
-		fprintf(stderr, "MITM key: %s\n", out);
-	}
-	return 1;
 }
 
 static void set_key(char *key, int index)
@@ -484,20 +214,11 @@ static void set_key(char *key, int index)
 	if (saved_len[index] < 0)
 		saved_len[index] = strlen16(saved_key[index]);
 	saved_len[index] <<= 1;
-	new_keys = 1;
 }
 
 static char *get_key(int index)
 {
 	return (char*)utf16_to_enc(saved_key[index]);
-}
-
-static unsigned int oo_hash_type(void *salt)
-{
-	custom_salt *my_salt;
-
-	my_salt = *(custom_salt**)salt;
-	return (unsigned int) my_salt->type;
 }
 
 struct fmt_main fmt_oldoffice = {
@@ -515,30 +236,30 @@ struct fmt_main fmt_oldoffice = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_ENC | FMT_SPLIT_UNIFIES_CASE | FMT_DYNA_SALT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_ENC | FMT_SPLIT_UNIFIES_CASE | FMT_BLOB,
 		{
 			"hash type",
 		},
 		{ FORMAT_TAG },
-		oo_tests
+		oldoffice_tests
 	}, {
 		init,
 		done,
 		fmt_default_reset,
-		prepare,
-		valid,
-		split,
-		fmt_default_binary,
-		get_salt,
+		oldoffice_prepare,
+		oldoffice_valid,
+		oldoffice_split,
+		oldoffice_get_binary,
+		oldoffice_get_salt,
 		{
-			oo_hash_type,
+			oldoffice_hash_type,
 		},
 		fmt_default_source,
 		{
 			fmt_default_binary_hash
 		},
-		fmt_default_dyna_salt_hash,
-		salt_compare,
+		oldoffice_salt_hash,
+		NULL,
 		set_salt,
 		set_key,
 		get_key,
@@ -548,8 +269,8 @@ struct fmt_main fmt_oldoffice = {
 			fmt_default_get_hash
 		},
 		cmp_all,
-		cmp_one,
-		cmp_exact
+		oldoffice_cmp_one,
+		oldoffice_cmp_exact
 	}
 };
 

--- a/src/wpapmk_fmt_plug.c
+++ b/src/wpapmk_fmt_plug.c
@@ -115,11 +115,7 @@ static char* get_key(int index)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	const int count = *pcount;
-
-	wpapsk_postprocess(count);
-
-	return count;
+	return *pcount;
 }
 
 struct fmt_main fmt_wpapsk_pmk = {
@@ -137,9 +133,11 @@ struct fmt_main fmt_wpapsk_pmk = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_OMP,
+		FMT_OMP | FMT_BLOB,
 		{
-#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
+#if 1
+			NULL
+#elif !AC_BUILT || HAVE_OPENSSL_CMAC_H
 			"key version [0:PMKID 1:WPA 2:WPA2 3:802.11w]"
 #else
 			"key version [0:PMKID 1:WPA 2:WPA2]"
@@ -158,35 +156,29 @@ struct fmt_main fmt_wpapsk_pmk = {
 		valid,
 		fmt_default_split,
 		get_binary,
-		get_salt,
+		fmt_default_salt,
 		{
-			get_keyver,
+			NULL //get_keyver,
 		},
 		fmt_default_source,
 		{
-			fmt_default_binary_hash_0,
-			fmt_default_binary_hash_1,
-			fmt_default_binary_hash_2,
-			fmt_default_binary_hash_3,
-			fmt_default_binary_hash_4,
-			fmt_default_binary_hash_5,
-			fmt_default_binary_hash_6
+			binary_hash_0,
+			binary_hash_1,
+			binary_hash_2,
+			binary_hash_3,
+			binary_hash_4,
+			binary_hash_5,
+			binary_hash_6
 		},
-		salt_hash,
-		salt_compare,
-		set_salt,
+		fmt_default_salt_hash,
+		NULL,
+		fmt_default_set_salt,
 		set_key,
 		get_key,
 		fmt_default_clear_keys,
 		crypt_all,
 		{
-			get_hash_0,
-			get_hash_1,
-			get_hash_2,
-			get_hash_3,
-			get_hash_4,
-			get_hash_5,
-			get_hash_6
+			fmt_default_get_hash,
 		},
 		cmp_all,
 		cmp_one,


### PR DESCRIPTION
See #3497 

WPAPSK and a few other formats have FMT_BLOB at this time.

Notes:
Tunable costs only look at salts, so we can no longer separate WPA1 from WPA2 or 802.11w (OTOH they are not really costs per se - they take about the same time to process). For costs actually "hidden" in a FMT_BLOB we need to look at the blob data (a.k.a binary) and that'd be really hairy, right now I can't see it happening anytime soon. So for now we can't use costs that need to be separated from actual salt. For formats like office, we're storing actual salt, iteration count **and** office version in the "salt" so it's not a a problem there.
