### PR TITLE
pfx2john: use decode() for python3 compatibility

### DIFF
--- a/run/pfx2john.py
+++ b/run/pfx2john.py
@@ -81,9 +81,9 @@ def parse_pkcs12(filename):
         size = len(salt)
         sys.stdout.write("%s:$pfxng$%s$%s$%s$%s$%s$%s$%s:::::%s\n" %
                          (os.path.basename(filename), mac_algo_numeric,
-                          key_length, iterations, size, binascii.hexlify(salt),
-                          binascii.hexlify(data),
-                          binascii.hexlify(stored_hmac), filename))
+                          key_length, iterations, size, binascii.hexlify(salt).decode(),
+                          binascii.hexlify(data).decode(),
+                          binascii.hexlify(stored_hmac).decode(), filename))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
pfx2john failes to convert to  JTR format when using Python 3 (Arch Linux):

```
pfx2john user.p12 |john /dev/stdin 
Using default input encoding: UTF-8
No password hashes loaded (see FAQ)
```

because Python 3 prints bytes as bytes literals (`b'xyz'`):
```
pfx2john user.p12
user.p12:$pfxng$1$20$2048$8$b'3998193b478d283f'$b'308202f3308202ef06092a864886f70d010706a08202e0308202dc020100308202d506092a864886f70d010701301c060a2a864886f70d010c0106300e0408118a3a77fb166bd402020800808202a8f3d80f5805d4852ed26ae6ba8178e4d8e11c2de925ca4c2428f423be0454b866a804cb4040c55a3b5fe0b2897fd5f6d4d3083774edcc466ed23438adc0aec73a51ac2a67ddf8d44fe544b8b1fd112a67c6e1a731a92cb10a15c13810832929a0d85bfc3ee3e8757f21e557b18264235799b746c5525342447a644b82e3bb085e86700454cda533fedd0bdfdcb93e470ee2978accd872ee9efc50a67881da61b3e012453ae620b934e3dc5ca9db2bf2364c933ee077482beda2f450b9b332c67bc0d297e4fc64aecf17a1ef12054d962e4df37c5e86d7b3e844b187e60acee65121c4f180a654bbbb87658929f2ff3cfe192baf86eb0f4124f03fdb42fd926bceaf2240fdaea862c86a58a09045e9287190e7e86a71a63ef4dc55582a5dfe0e3e9bb79ca20af7cae48f30700f31ebd7eab4631da610856202bb161b9de4aa38cc9133413e72555a52b32a30a2b8026da2f0d347d8ec214e2bd233436a9d7d7c4cd68070f62fbb0f05c6e787c184de74d8f031c6fb3ac204df0861b0cab0b56bc1e53916071a513bde79958a71fd71c52ada520ca36545e125dac0e7be7cae123fee734f3d83ee3903d08cc64417dcb4c0124f294b3accf1e34708283b04b992e1827ba8a55766b90591592015903b8f0d8f878e21d77c62d1417b66ef5a9dc822a847e222cdeb05e4e9f1617909dbd356f9f6428eeb7ef3704a8b33bd22e4206b43b2a1f39638da59762af22d1ba013769205fff10a01161b9ec25e84ce4cae36bd0ee99e4e467dead1644eb1f72f0bfdfaf5e5cdb4f2ec5c6bbe9d0fc4dc1c3c3de29069a3834afb0317385d386a1e4938a210532492861032eda2363f523b82e98807188715636f270ea049e1ced2e1e7db0548ff2520ee496994b2de198b2208678d8d0013f3dba73b0ba40cbf892f051e036129a4fe8228113f8e44737a1d177a2f45daf13303'$b'5879ba2a6a496ef4d343af226366ab152e7fd1c7':::::user.p12

```
