### PR TITLE
If a format class or wildcard was used, remove it from argv...

### DIFF
--- a/src/john.h
+++ b/src/john.h
@@ -40,5 +40,6 @@ extern char *john_terminal_locale;
 
 /* Current target for options.max_cands */
 extern unsigned long long john_max_cands;
+extern int wildcard_format;
 
 #endif

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -263,6 +263,23 @@ void rec_save(void)
 #endif
 	opt = rec_argv;
 	while (*++opt) {
+		/*
+		 * If a format wildcard or class (eg. --format=opencl) was used,
+		 * we remove it from argv and replace with the actually chosen one.
+		 */
+		if (wildcard_format && !strncmp(*opt, "--format", 8)) {
+			char **shuf = opt;
+
+			wildcard_format = 0;
+			rec_argc--;
+			while (shuf[1]) {
+				*shuf = shuf[1];
+				shuf++;
+			}
+			*shuf = NULL;
+			if (opt == shuf)
+				break;
+		}
 		/********* Re-write deprecated options *********/
 		if (!strncmp(*opt, "--internal-encoding", 19))
 			memcpy(*opt, "--internal-codepage", 19);


### PR DESCRIPTION
...and replace with the actually picked format.

Example: `john pwdump -form:opencl`. The NT-opencl format will be picked. but prior to this patch "--format=opencl" would be in the .rec file instead of "--format=NT-opencl".