### PR TITLE
Reset CFLAGS at `-q` option test for darwin

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -10889,7 +10889,8 @@ CFLAGS="$CFLAGS $SIMD_FLAGS -O0"
 
   case $host_os in #(
   darwin*) :
-    CC="$CC_BACKUP -mavx"
+    CC="$CC_BACKUP"
+    CFLAGS="-mavx"
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OS X 'as' needs -q option" >&5
 $as_echo_n "checking whether OS X 'as' needs -q option... " >&6; }
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -10937,9 +10938,11 @@ rm -f core conftest.err conftest.$ac_objext \
     if test x$OSX_AS_CLANG != x; then :
   CC_BACKUP="$CC_BACKUP $OSX_AS_CLANG"
       AS="$AS $OSX_AS_CLANG"
+      CFLAGS="$CFLAGS_BACKUP"
 
 fi
     CC="$CC_BACKUP"
+    CFLAGS="$CFLAGS_BACKUP"
    ;; #(
   *) :
      ;;

--- a/src/m4/jtr_x86_logic.m4
+++ b/src/m4/jtr_x86_logic.m4
@@ -45,7 +45,8 @@ dnl ======================================================================
 CFLAGS="$CFLAGS $SIMD_FLAGS -O0"
 
   AS_CASE([$host_os], [darwin*],
-    [CC="$CC_BACKUP -mavx"
+    [CC="$CC_BACKUP"
+    CFLAGS="-mavx"
     AC_MSG_CHECKING([whether OS X 'as' needs -q option])
     AC_LINK_IFELSE(
       [
@@ -73,8 +74,10 @@ CFLAGS="$CFLAGS $SIMD_FLAGS -O0"
     AS_IF([test x$OSX_AS_CLANG != x],
       [CC_BACKUP="$CC_BACKUP $OSX_AS_CLANG"]
       [AS="$AS $OSX_AS_CLANG"]
+      [CFLAGS="$CFLAGS_BACKUP"]
     )
-    [CC="$CC_BACKUP"]]
+    [CC="$CC_BACKUP"]
+    [CFLAGS="$CFLAGS_BACKUP"]]
   )
 
 if test "x$simd" != xno; then


### PR DESCRIPTION
I've discovered that at some cases clang at macOS Sierra and High Sierra may define `__SSE4_1__` but can't compile test case with error: `needs target feature sse4.1`.

As result we should have an option to switch SSE4.1 at this machines by `-mno-sse4.1` but when I did it I've broke test to determin does `-q` option requires because it requires `-mavx` to itself and `-mavx -mno-sse4.1` fails.

As result of this fails configure things that `-q` is required and adds `-Wa,-q` to each clang call and it brokes things at very differnet and wierd places.

Fixed this test by reseting for testing time `CFLAGS` to plain `-mavx`.