### PR TITLE
Remove external credits from 4690-OS stuff

### DIFF
--- a/run/adxcsouf2john.py
+++ b/run/adxcsouf2john.py
@@ -10,9 +10,6 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted.
 #
-# Special thanks goes to Michael Dim for helping me with access to IBM/Toshiba
-# 4690 v6.3 OS.
-#
 # Notes,
 #
 # 1. IBM/Toshiba 4690 v6.3 OS runs fine under VMware ESXi 6.7 (Select "Other

--- a/src/adxcrypt_fmt_plug.c
+++ b/src/adxcrypt_fmt_plug.c
@@ -9,9 +9,6 @@
  *
  * The ADXCRYPT algorithm was reverse engineered by Dhiru Kholia on
  * 15-August-2018.
- *
- * Special thanks goes to Michael Dim for helping me with access to IBM/Toshiba
- * 4690 v6.3 OS.
  */
 
 #if FMT_EXTERNS_H


### PR DESCRIPTION
One of the [4690 encryption research related repositories](https://github.com/github/dmca/blob/master/2019/05/2019-05-06-Toshiba.md) was taken down by Toshiba lawyers using DMCA a couple of months back.

I am not sure why Toshiba lawyers are this aggressive.