### PR TITLE
kwallet format, add FMT_HUGE_INPUT flag

### DIFF
--- a/src/kwallet_fmt_plug.c
+++ b/src/kwallet_fmt_plug.c
@@ -400,7 +400,7 @@ struct fmt_main fmt_kwallet = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
 		{ NULL },
 		{ FORMAT_TAG },
 		kwallet_tests


### PR DESCRIPTION
My kwallet file was ignored without this flag