### PR TITLE
bitcoin2john further cleanup

### DIFF
--- a/run/bitcoin2john.py
+++ b/run/bitcoin2john.py
@@ -16,17 +16,6 @@
 # BitcoinTools (wallet.dat handling code, MIT License)
 # https://github.com/gavinandresen/bitcointools
 # Copyright (c) 2010 Gavin Andresen
-#
-# python-ecdsa (EC_KEY implementation, MIT License)
-# http://github.com/warner/python-ecdsa
-# "python-ecdsa" Copyright (c) 2010 Brian Warner
-# Portions written in 2005 by Peter Pearson and placed in the public domain.
-#
-# SlowAES (aes.py code, Apache 2 License)
-# http://code.google.com/p/slowaes/
-# Copyright (c) 2008, Josh Davis (http://www.josh-davis.org),
-# Alex Martelli (http://www.aleax.it)
-# Ported from C code written by Laurent Haan (http://www.progressive-coding.com)
 
 try:
         from bsddb.db import *


### PR DESCRIPTION
This passed the same tests as I used for #4145. Again, the two commits should probably remain separate.
 
I think even further cleanup is possible - perhaps there's no need to parse item types other than "ckey" and "mkey", which would also eliminate the need to have hashing and base58 decoding in here. However, dropping processing of other key-related item types would _potentially_ affect the output for some wallets that I don't have, so I don't dare to make that change yet.