### PR TITLE
fixes #4150: for Electrum 4/5 use BN_bn2binpad() instead of BN_bn2bin()

### DIFF
--- a/src/electrum_fmt_plug.c
+++ b/src/electrum_fmt_plug.c
@@ -348,7 +348,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				BN_CTX_free(ctx);
 				BN_free(p);
 				BN_free(q);
-				BN_bn2bin(r, static_privkey[i]);
+				BN_bn2binpad(r, static_privkey[i], 32);
 				BN_free(r);
 				sctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
 				// multiply point with a scaler, shared_pubkey is compressed representation


### PR DESCRIPTION
as explained in #4150 the use of BN_bn2bin() is dangerous and not what JTR assumed (fixed-length output, always 32 bytes).

I suggest the use of BN_bn2binpad() .... for some reasons bitcoin core is using another method (maybe because the padding function didn't exist at that time): https://github.com/bitcoin-core/secp256k1/blob/master/src/tests.c#L4484

please read #4150 for all details

Thanks

BTW : I didn't add test vectors etc... feel free to add them if you like (test.pl of hashcat is able to generate the hashes, philsmd's electrum 4 branch for the time being). **update**: I added an example hash on the bottom of https://github.com/magnumripper/JohnTheRipper/issues/4150#issue-521508560 (just so that you can debug the result of BN_bn2bin() vs BN_bn2binpad() very easily for convenience)... you might add it as an example hash if you want (NOT really needed)