### PR TITLE
Fix legacy build (e.g., "make -f Makefile.legacy generic")

### DIFF
--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -94,7 +94,7 @@ CFLAGS = -c -Wall -O2 -fomit-frame-pointer -I/usr/local/include -DHAVE_LIBSSL $(
 # CFLAGS for use on the main john.c file only
 CFLAGS_MAIN = $(CFLAGS)
 ASFLAGS = -c $(OMPFLAGS) $(JOHN_ASFLAGS)
-LDFLAGS = -s -L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz \
+LDFLAGS = -s -L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lrt \
 	$(OMPFLAGS) $(GMP_LDFLAGS) $(JOHN_LDFLAGS) $(REXGEN_LDFLAGS)
 # -lskey
 LDFLAGS_SOLARIS = -lrt -lnsl -lsocket -lm -lz -lcrypto -lssl

--- a/src/bench.c
+++ b/src/bench.c
@@ -418,6 +418,7 @@ char *benchmark_format(struct fmt_main *format, int salts,
 	current = format->params.tests;
 #endif
 #ifdef BENCH_BUILD
+	const char *where;
 	if ((where = fmt_self_test(format, test_db))) {
 		snprintf(s_error, sizeof(s_error), "FAILED (%s)\n", where);
 		return s_error;


### PR DESCRIPTION
...which was broken (again) by a16ffedb1ad314dc1996141208753f39c0ec3c10 and 838d1ed7688a662708f308b02e54004cc67e8aeb.