### PR TITLE
Further rework of bitcoin2john.py

### DIFF
--- a/run/bitcoin2john.py
+++ b/run/bitcoin2john.py
@@ -18,11 +18,9 @@
 # Copyright (c) 2010 Gavin Andresen
 
 import binascii
-import hashlib
 import logging
 import struct
 import sys
-import traceback
 
 try:
     from bsddb.db import *
@@ -34,60 +32,10 @@ except:
         sys.exit(1)
 
 
-addrtype = 0
 json_db = {}
 
 def hexstr(bytestr):
     return binascii.hexlify(bytestr).decode('ascii')
-
-def hash_160(public_key):
-        md = hashlib.new('ripemd160')
-        md.update(hashlib.sha256(public_key).digest())
-        return md.digest()
-
-def public_key_to_bc_address(public_key):
-        h160 = hash_160(public_key)
-        return hash_160_to_bc_address(h160)
-
-def hash_160_to_bc_address(h160):
-        vh160 = struct.pack('B', addrtype) + h160
-        h = Hash(vh160)
-        addr = vh160 + h[0:4]
-        return b58encode(addr)
-
-__b58chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-__b58base = len(__b58chars)
-
-def b58encode(v):
-        """ encode v, which is a string of bytes, to base58.
-        """
-
-        long_value = 0
-        for (i, c) in enumerate(v[::-1]):
-                if isinstance(c, str):
-                    c = ord(c)
-                long_value += (256 ** i) * c
-
-        result = ''
-        while long_value >= __b58base:
-                div, mod = divmod(long_value, __b58base)
-                result = __b58chars[mod] + result
-                long_value = div
-        result = __b58chars[long_value] + result
-
-        # Bitcoin does a little leading-zero-compression:
-        # leading 0-bytes in the input become leading-1s
-        nPad = 0
-        for c in v:
-                if c == '\0' or c == 0: nPad += 1
-                else: break
-
-        return (__b58chars[0] * nPad) + result
-
-# end of bitcointools base58 implementation
-
-def Hash(data):
-        return hashlib.sha256(hashlib.sha256(data).digest()).digest()
 
 # bitcointools wallet.dat handling code
 
@@ -138,7 +86,6 @@ class BCDataStream(object):
                 return ''
 
         def read_uint32(self): return self._read_num('<I')
-        def read_int64(self): return self._read_num('<q')
 
         def read_compact_size(self):
                 size = self.input[self.read_cursor]
@@ -191,73 +138,39 @@ def parse_wallet(db, item_callback):
                 d["__type__"] = type
 
                 try:
-                        if type == "key":
-                                d['public_key'] = kds.read_bytes(kds.read_compact_size())
-                                d['private_key'] = vds.read_bytes(vds.read_compact_size())
-                        elif type == "wkey":
-                                d['public_key'] = kds.read_bytes(kds.read_compact_size())
-                                d['private_key'] = vds.read_bytes(vds.read_compact_size())
-                                d['created'] = vds.read_int64()
-                                d['expires'] = vds.read_int64()
-                                d['comment'] = vds.read_string()
-                        elif type == "ckey":
-                                d['public_key'] = kds.read_bytes(kds.read_compact_size())
-                                d['encrypted_private_key'] = vds.read_bytes(vds.read_compact_size())
-                        elif type == "mkey":
-                                d['nID'] = kds.read_uint32()
+                        if type == "mkey":
+                                #d['nID'] = kds.read_uint32()
                                 d['encrypted_key'] = vds.read_bytes(vds.read_compact_size())
                                 d['salt'] = vds.read_bytes(vds.read_compact_size())
                                 d['nDerivationMethod'] = vds.read_uint32()
                                 d['nDerivationIterations'] = vds.read_uint32()
-                                d['otherParams'] = vds.read_string()
+                                #d['otherParams'] = vds.read_string()
 
                         item_callback(type, d)
 
                 except Exception:
-                        traceback.print_exc()
                         sys.stderr.write("ERROR parsing wallet.dat, type %s\n" % type)
                         sys.stderr.write("key data in hex: %s\n" % hexstr(key))
                         sys.stderr.write("value data in hex: %s\n" % hexstr(value))
                         sys.exit(1)
 
-
 # end of bitcointools wallet.dat handling code
 
-# wallet.dat reader / writer
+# wallet.dat reader
 
 def read_wallet(json_db, walletfile):
         db = open_wallet(walletfile)
 
-        json_db['keys'] = []
-        json_db['ckey'] = []
         json_db['mkey'] = {}
 
         def item_callback(type, d):
-                if type == "key":
-                        addr = public_key_to_bc_address(d['public_key'])
-                        compressed = d['public_key'][0] != '\04'
-                        sec = SecretToASecret(PrivKeyToSecret(d['private_key']), compressed)
-                        hexsec = ASecretToSecret(sec).encode('hex')
-                        json_db['keys'].append({'addr': addr, 'sec': sec, 'hexsec': hexsec, 'secret': hexsec, 'pubkey': hexstr(d['public_key']), 'compressed': compressed, 'private': hexstr(d['private_key'])})
-
-                elif type == "wkey":
-                        if not json_db.has_key('wkey'): json_db['wkey'] = []
-                        json_db['wkey']['created'] = d['created']
-
-                elif type == "ckey":
-                        compressed = d['public_key'][0] != '\04'
-                        json_db['keys'].append({'pubkey': hexstr(d['public_key']), 'addr': public_key_to_bc_address(d['public_key']), 'encrypted_privkey':  hexstr(d['encrypted_private_key']), 'compressed':compressed})
-
-                elif type == "mkey":
-                        json_db['mkey']['nID'] = d['nID']
+                if type == "mkey":
+                        #json_db['mkey']['nID'] = d['nID']
                         json_db['mkey']['encrypted_key'] = hexstr(d['encrypted_key'])
                         json_db['mkey']['salt'] = hexstr(d['salt'])
                         json_db['mkey']['nDerivationMethod'] = d['nDerivationMethod']
                         json_db['mkey']['nDerivationIterations'] = d['nDerivationIterations']
-                        json_db['mkey']['otherParams'] = d['otherParams']
-
-                else:
-                        json_db[type] = 'unsupported'
+                        #json_db['mkey']['otherParams'] = d['otherParams']
 
         parse_wallet(db, item_callback)
 
@@ -268,10 +181,6 @@ def read_wallet(json_db, walletfile):
         if not crypted:
                 sys.stderr.write("%s: this wallet is not encrypted\n" % walletfile)
                 return -1
-
-        for k in json_db['keys']:
-                if k['compressed'] and 'secret' in k:
-                        k['secret'] += "01"
 
         return {'crypted':crypted}
 
@@ -298,11 +207,6 @@ if __name__ == '__main__':
             sys.stderr.write("%s: this wallet is not encrypted\n" % filename)
             continue
 
-        for k in json_db['keys']:
-            pass  # dirty hack but it works!
-
-        ckey = k['encrypted_privkey']
-        public_key = k['pubkey']
         cry_master = json_db['mkey']['encrypted_key'][-64:]  # last two aes blocks should be enough
         cry_salt = json_db['mkey']['salt']
 

--- a/run/bitcoin2john.py
+++ b/run/bitcoin2john.py
@@ -306,7 +306,5 @@ if __name__ == '__main__':
         cry_master = json_db['mkey']['encrypted_key'][-64:]  # last two aes blocks should be enough
         cry_salt = json_db['mkey']['salt']
 
-        sys.stdout.write("$bitcoin$%s$%s$%s$%s$%s$%s$%s$%s$%s\n" %
-                (len(cry_master), cry_master, len(cry_salt),
-                cry_salt, cry_rounds, len(ckey), ckey, len(public_key),
-                public_key))
+        sys.stdout.write("$bitcoin$%s$%s$%s$%s$%s$2$00$2$00\n" %
+            (len(cry_master), cry_master, len(cry_salt), cry_salt, cry_rounds))

--- a/run/bitcoin2john.py
+++ b/run/bitcoin2john.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python
 
-# This software is Copyright (c) 2012, Dhiru Kholia <dhiru at openwall.com> and
-# it is hereby placed in the public domain.
+# This software is
+# Copyright (c) 2012-2018 Dhiru Kholia <dhiru at openwall.com>
+# Copyright (c) 2019 Solar Designer
+# Copyright (c) 2019 exploide
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.  (This is a heavily cut-down "BSD license".)
 #
-# This utility (bitcoin2john.py) is based on jackjack's pywallet.py [1] which
-# is forked from Joric's pywallet.py whose licensing information follows,
+# While the above applies to the stated copyright holders' contributions,
+# this software is also dual-licensed under the MIT License, to be certain
+# of license compatibility with that of the components listed below.
+#
+# This script (bitcoin2john.py) might still contain portions of jackjack's
+# pywallet.py [1] which is forked from Joric's pywallet.py whose licensing
+# information follows,
 #
 # [1] https://github.com/jackjack-jj/pywallet
 #


### PR DESCRIPTION
Having read and understood and revised the Bitcoin format in JtR and mode 11300 in hashcat, I now have better understanding of what's needed from this script. Thus, I finally dare to drop all parsing of items other than `mkey`, since that's the only one we currently use for cracking. This dropping also makes the "hashes" much less security sensitive.

Besides dropping stuff, I now also add stuff (and thus my copyright): checks that the wallet's key derivation method, salt size, and master key size are as expected by us. I also add a lengthy comment explaining the rationale for insisting on specific known master key sizes.

Like before, I'd like my 4 commits to remain separate in our tree. As I understand, magnum has been using "rebase and merge" for that lately.

After these changes, the only cleanup I'm aware still needs to be done is of indentation, which I leave to @exploide, who might also have other cleanups pending.