### PR TITLE
Botcheck for two separate commits

### DIFF
--- a/src/inc.c
+++ b/src/inc.c
@@ -499,7 +499,8 @@ void do_incremental_crack(struct db_main *db, const char *mode)
 	if ((options.flags & FLG_BATCH_CHK || rec_restored) && john_main_process) {
 		fprintf(stderr, "Proceeding with incremental:%s", mode);
 		if (options.flags & FLG_MASK_CHK)
-			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
+			fprintf(stderr, ", hybrid mask:%s", options.mask ?
+			        options.mask : options.eff_mask);
 		if (options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 		if (options.req_minlength >= 0 || options.req_maxlength)

--- a/src/mkv.c
+++ b/src/mkv.c
@@ -735,7 +735,8 @@ void do_markov_crack(struct db_main *db, char *mkv_param)
 		fprintf(stderr, "Proceeding with Markov%s%s",
 		        param ? " " : "", param ? param : "");
 		if (options.flags & FLG_MASK_CHK)
-			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
+			fprintf(stderr, ", hybrid mask:%s", options.mask ?
+			        options.mask : options.eff_mask);
 		if (options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 		if (options.req_minlength >= 0 || options.req_maxlength)

--- a/src/pp.c
+++ b/src/pp.c
@@ -1312,7 +1312,7 @@ void do_prince_crack(struct db_main *db, const char *wordlist, int rules)
     fprintf(stderr, "Proceeding with prince%c%s",
             loopback ? '-' : ':',
             loopback ? "loopback" : path_expand(wordlist));
-    if (options.activewordlistrules) {
+    if (options.flags & FLG_RULES_CHK) {
       if (options.rule_stack)
         fprintf(stderr, ", rules:(%s x %s)",
                 options.activewordlistrules, options.rule_stack);
@@ -1320,7 +1320,8 @@ void do_prince_crack(struct db_main *db, const char *wordlist, int rules)
         fprintf(stderr, ", rules:%s", options.activewordlistrules);
     }
     if (options.flags & FLG_MASK_CHK)
-      fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
+      fprintf(stderr, ", hybrid mask:%s", options.mask ?
+              options.mask : options.eff_mask);
     if (!options.activewordlistrules && options.rule_stack)
       fprintf(stderr, ", rules-stack:%s", options.rule_stack);
     if (options.req_minlength >= 0 || options.req_maxlength)

--- a/src/regex.c
+++ b/src/regex.c
@@ -343,7 +343,8 @@ void do_regex_crack(struct db_main *db, const char *regex)
 	if (rec_restored && john_main_process) {
 		fprintf(stderr, "Proceeding with regex:%s", regex);
 		if (options.flags & FLG_MASK_CHK)
-			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
+			fprintf(stderr, ", hybrid mask:%s", options.mask ?
+			        options.mask : options.eff_mask);
 		if (options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 		if (options.req_minlength >= 0 || options.req_maxlength)

--- a/src/rules.c
+++ b/src/rules.c
@@ -696,7 +696,7 @@ char *rules_reject(char *rule, int split, char *last, struct db_main *db)
 				rules_errno = RULES_ERROR_END;
 				return NULL;
 			}
-			if (rules_stacked_after) continue;
+			if (rules_stacked_after && RULE) continue;
 			if (rules_vars[ARCH_INDEX(RULE)] <=
 			    rules_max_length) continue;
 			return NULL;
@@ -707,7 +707,7 @@ char *rules_reject(char *rule, int split, char *last, struct db_main *db)
 				rules_errno = RULES_ERROR_END;
 				return NULL;
 			}
-			if (rules_stacked_after) continue;
+			if (rules_stacked_after && RULE) continue;
 			if (rules_vars[ARCH_INDEX(RULE)] >= min_length)
 				continue;
 			return NULL;

--- a/src/subsets.c
+++ b/src/subsets.c
@@ -605,7 +605,8 @@ int do_subsets_crack(struct db_main *db, char *req_charset)
 			        req_charset ? ": " : "",
 			        req_charset ? req_charset : "");
 			if (options.flags & FLG_MASK_CHK)
-				fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
+				fprintf(stderr, ", hybrid mask:%s", options.mask ?
+				        options.mask : options.eff_mask);
 			if (options.rule_stack)
 				fprintf(stderr, ", rules-stack:%s", options.rule_stack);
 			if (options.req_minlength >= 0 || options.req_maxlength)

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -648,17 +648,17 @@ void do_wordlist_crack(struct db_main *db, const char *name, int rules)
 		fprintf(stderr, "Proceeding with wordlist:%s",
 		        loopBack ? "loopback" :
 		        name ? path_expand(name) : "stdin");
-		if (options.activewordlistrules) {
+		if (options.flags & FLG_RULES_CHK) {
 			if (options.rule_stack)
 				fprintf(stderr, ", rules:(%s x %s)",
 				        options.activewordlistrules, options.rule_stack);
 			else
 				fprintf(stderr, ", rules:%s", options.activewordlistrules);
-		}
-		if (options.flags & FLG_MASK_CHK)
-			fprintf(stderr, ", hybrid mask:%s", options.eff_mask);
-		if (!options.activewordlistrules && options.rule_stack)
+		} else if (options.rule_stack)
 			fprintf(stderr, ", rules-stack:%s", options.rule_stack);
+		if (options.flags & FLG_MASK_CHK)
+			fprintf(stderr, ", hybrid mask:%s", options.mask ?
+			        options.mask : options.eff_mask);
 		if (options.req_minlength >= 0 || options.req_maxlength)
 			fprintf(stderr, ", lengths: %d-%d",
 			        options.eff_minlength + mask_add_len,


### PR DESCRIPTION
Fix a bug with rules x rules when ->N or -<N is used in first set of rules.  Closes #4107

Fix a few cosmetic bugs with "Proceeding with..." messages.  Closes #4157
