### PR TITLE
Fix electrum2python python3 bytes object error

### DIFF
--- a/run/electrum2john.py
+++ b/run/electrum2john.py
@@ -66,7 +66,7 @@ def process_file(filename, options):
 
     # detect Electrum 2.7+ encrypted wallets
     try:
-        if base64.b64decode(data).startswith('BIE1'):
+        if base64.b64decode(data).startswith(b'BIE1'):
             # sys.stderr.write("%s: Encrypted Electrum 2.8+ wallets are not supported yet!\n" % bname)
             process_electrum28_wallets(bname, data, options)
             return


### PR DESCRIPTION
When running electrum2python.py using python3+ on an electrum2.7+ wallet, the error ` Unable to parse the wallet file!` is returned. Example wallet attached [testwallet.txt](https://github.com/magnumripper/JohnTheRipper/files/4022303/testwallet.txt).

In python2.7, the b64decode function returns a decoded string, whereas in python3 the function returns a bytes object. Both can safely be compared to an explicit bytes object, but in python3 comparison against a string raises a TypeError. Example below:

Python2:
> source_str = 'my test string'
print(source_str.startswith(b'my'))
\>True
print(source_str.startswith(b'invalid'))
\> False
print(source_str.startswith('my'))
\> True

Python3
> source_str = b'my test string'
print(source_str.startswith(b'my'))
\> True
print(source_str.startswith(b'invalid'))
\> False
print(source_str.startswith('my'))
\> Traceback (most recent call last):
\> File "main.py", line 4, in <module>    print(source_str.startswith('my'))TypeError: startswith first arg must be bytes or a tuple of bytes, not str