### PR TITLE
zip2john: Refactor and support reading central directory

### DIFF
--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -248,26 +248,42 @@ static void handle_zip64_ef(FILE *fp, zip_ptr *p, uint16_t len, int is_local)
 {
 	uint64_t decomp_len = UINT64_MAX, cmp_len = UINT64_MAX, offset = UINT64_MAX;
 	long rem_len = len;
+#ifdef DEBUG
+	fprintf(stderr, "Handling ZIP64 ef (local = %d)\n", is_local);
+#endif
 	// Only read this if we didn't get it from the Central Directory yet, otherwise
 	// we need to store both, local and central values in the zip_ptr struct, as the
 	// handle_zip64_ef function needs to know whether the fields of the header this
 	// extra field belongs to were 0xff..ff, because only in that case the according
 	// 64bit fields will be present here.
 	// See "4.5.3 -Zip64 Extended Information Extra Field (0x0001)" in APPNOTE.TXT
+	// The additional checks that reset the read values to UINT64_MAX (=not present)
+	// is a workaround for archives that have valid values in their normal headers
+	// (ie. fitting into 32bit) but additionally supply a bogus ZIP64 extended field
+	// in their local header, where the according fields are 0.
 	if (p->zip64) {
 		xfseek(fp, len, SEEK_CUR);
 		return;
 	}
-	if (p->decomp_len == 0xffffffff || is_local) {
+	if (p->decomp_len == UINT32_MAX || is_local) {
 		decomp_len = fget64LE(fp);
+		if (p->decomp_len != UINT32_MAX && decomp_len == 0) {
+			decomp_len = UINT64_MAX;
+		}
 		rem_len -= 8;
 	}
-	if (p->cmp_len == 0xffffffff || is_local) {
+	if (p->cmp_len == UINT32_MAX || is_local) {
 		cmp_len = fget64LE(fp);
+		if (p->cmp_len != UINT32_MAX && cmp_len == 0) {
+			cmp_len = UINT64_MAX;
+		}
 		rem_len -= 8;
 	}
-	if (p->offset == 0xffffffff) {
+	if (p->offset == UINT32_MAX) {
 		offset = fget64LE(fp);
+		if (p->offset != UINT32_MAX && offset == 0) {
+			offset = UINT64_MAX;
+		}
 		rem_len -= 8;
 	}
 	// Other fields we don't care about follow...

--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -149,8 +149,7 @@
 static void xfseek(FILE *stream, long offset, int whence)
 {
 	if (fseek(stream, offset, whence) == -1) {
-		perror("fseek");
-		exit(1);
+		error(1, errno, "fseek");
 	}
 }
 
@@ -159,13 +158,13 @@ static size_t xfread(void *ptr, size_t size, size_t nmemb, FILE *stream)
 	size_t ret = fread(ptr, size, nmemb, stream);
 	if (ret != nmemb) {
 		if (feof(stream)) {
-			fprintf(stderr, "Reached end of stream on fread\n");
+			error(1, 0, "Reached end of stream on fread");
 		} else if (ferror(stream)) {
-			fprintf(stderr, "ferror triggered on fread\n");
+			error(1, 0, "ferror triggered on fread");
 		} else {
-			fprintf(stderr, "No reason for short read on fread (%"PRIu64"/%"PRIu64")\n", (uint64_t)ret, (uint64_t)size * nmemb);
+			error(1, 0, "No reason for short read on fread (%"PRIu64"/%"PRIu64" records)",
+			      (uint64_t)ret, (uint64_t)nmemb);
 		}
-		exit(1);
 	}
 	return ret;
 }

--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -612,6 +612,7 @@ static void scan_for_data_descriptor(zip_file *zip, zip_ptr *p)
 		return;
 	// Likewise, no flag set and at least one field filled: accept
 	if ((p->cmp_len || p->decomp_len || p->crc) && !(p->flags & FLAG_LOCAL_SIZE_UNKNOWN))
+		return;
 
 	fprintf(stderr, "Scanning for EOD... ");
 	while (!feof(fp)) {

--- a/src/zip_fmt_plug.c
+++ b/src/zip_fmt_plug.c
@@ -119,7 +119,7 @@ static my_salt *saved_salt;
 //  ZFILE This is the literal string ZFILE
 //  Fn    This is the name of the .zip file.  NOTE the user will need to keep the .zip file in proper locations (same as
 //        was seen when running zip2john. If the file is removed, this hash line will no longer be valid.
-//  Oh    Offset to the zip central header record for this blob.
+//  Oh    Offset to the zip local header record for this blob.
 //  Ob    Offset to the start of the blob data
 
 static void init(struct fmt_main *self)


### PR DESCRIPTION
By default zip2john now reads the central directory and
processes files from there. This makes handling streaming
archives (where the local header is missing length information)
more robust. The old behavior of scanning the file from the
beginning is still available by passing the -s command line
switch.