### PR TITLE
Python 3 compatibility for 1password2john and krb2john

### DIFF
--- a/run/1password2john.py
+++ b/run/1password2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Written by Dhiru Kholia <dhiru at openwall.com> in July 2012 for JtR project.
 # Copyright (c) 2012-2013, Dhiru Kholia.

--- a/run/krb2john.py
+++ b/run/krb2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # This file was named krbpa2john.py previously.
 #
@@ -70,7 +70,7 @@ def process_file(f):
                     for item in r:
                         if "value" in item.attrib:
                             try:
-                                salt = binascii.unhexlify(item.attrib["value"])
+                                salt = binascii.unhexlify(item.attrib["value"]).decode('ascii')
                                 break
                             except:
                                 continue
@@ -108,7 +108,7 @@ def process_file(f):
                 user = r.attrib["show"]
 
             if user == "":
-                user = binascii.unhexlify(salt)
+                user = salt
 
             # user, realm and salt are unused when etype is 23 ;)
             checksum = PA_DATA_ENC_TIMESTAMP[0:32]


### PR DESCRIPTION
I made the converter scripts Python 3 compatible.

- `1password2john.py` was already compatible, only the shebang needed to be adapted. Tested with https://openwall.info/wiki/john/sample-non-hashes#Password-Agile-Keychain
- `krb2john.py` had a minor bytestring issue that should be fixed now. Produces the same results as before for all testcases from https://openwall.info/wiki/john/sample-non-hashes#Kerberos-v5-Pre-Authentication (though I think these do not cover all code branches from the script, but more was not available)

Apart from that, there are now only two scripts left with an explicit `python2` shebang: `bitwarden2john.py` and `ccache2john.py`. Unfortunately I could not find test files for these scripts so I cannot fix them yet.