### PR TITLE
Fix a bug that sometimes b0rked "hashcat rules" w/ node/fork

### DIFF
--- a/src/single.c
+++ b/src/single.c
@@ -776,7 +776,7 @@ static void single_run(void)
 	do {
 		rec_rule[1] = min[1] = rules_stacked_number;
 		while ((prerule = rpp_next(rule_ctx))) {
-			if (options.node_count) {
+			if (options.node_count && strncmp(prerule, "!!", 2)) {
 				int for_node = rule_number % options.node_count + 1;
 				if (for_node < options.node_min ||
 				    for_node > options.node_max) {

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -1217,7 +1217,7 @@ REDO_AFTER_LMLOOP:
 		struct list_entry *joined;
 
 		if (rules) {
-			if (dist_rules) {
+			if (dist_rules && strncmp(prerule, "!!", 2)) {
 				int for_node =
 				    rule_number % options.node_count + 1;
 				if (for_node < options.node_min ||


### PR DESCRIPTION
Fix a bug that b0rked the support for "hashcat specific" rules in case of node/fork combined with either a tiny wordlist or single mode.