### PR TITLE
Postpone path_init() for non-john* tools without fallbacks

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -2160,8 +2160,10 @@ int main(int argc, char **argv)
 	}
 #endif
 
-        /* Needed before CPU fallback */
+#if CPU_FALLBACK || OMP_FALLBACK
+	/* Needed before CPU fallback */
 	path_init(argv);
+#endif
 
 	if (!strcmp(name, "unshadow")) {
 		CPU_detect_or_fallback(argv, 0);
@@ -2197,10 +2199,16 @@ int main(int argc, char **argv)
 		CPU_detect_or_fallback(argv, 0);
 		return zip2john(argc, argv);
 	}
+
 	if (!strcmp(name, "base64conv")) {
 		CPU_detect_or_fallback(argv, 0);
 		return base64conv(argc, argv);
 	}
+
+#if !(CPU_FALLBACK || OMP_FALLBACK)
+	path_init(argv);
+#endif
+
 	john_init(name, argc, argv);
 
 	if (options.max_cands) {

--- a/src/path.c
+++ b/src/path.c
@@ -104,7 +104,7 @@ void path_init(char **argv)
 					pos = strchr(pos, '\\');
 				}
 #if !(defined(__DJGPP__) || defined(__CYGWIN__) || defined(_MSC_VER) || defined(__MINGW32__))
-			} else if (!strncmp(argv[0], "john", 4)) {
+			} else {
 				fprintf(stderr,
 				    "Error: Cannot find John home. Invoke the program via full or relative pathname.\n"
 				    "For example, /full/path/%s or path/%s, or set and use a shell alias.\n", argv[0], argv[0]);


### PR DESCRIPTION
As I proposed in a comment on #4229, this should allow for copying of tools/symlinks other than `john*` e.g. to `~/bin` or `/usr/local/bin` in without-fallbacks builds. This also disallows that for with-fallbacks non-systemwide builds, where it'd be unsafe.