### PR TITLE
Fix gcc 10 warnings and errors

### DIFF
--- a/src/SIPdump.c
+++ b/src/SIPdump.c
@@ -412,11 +412,8 @@ static void parse_payload(const conn_t * connection,
 				    strlen(conn_table[i].buffer) + 1;
 				payload_buffer =
 				    (char *) Calloc(payload_buffer_len);
-				strncpy(payload_buffer, conn_table[i].buffer,
-				    payload_buffer_len - 1);
-				strncat(payload_buffer, (char *) payload,
-				    payload_buffer_len -
-				    strlen(payload_buffer) - 1);
+				strcpy(payload_buffer, conn_table[i].buffer);
+				strncat(payload_buffer, (char *) payload, payload_len);
 
 				/* Parse buffer (saved buffer + packet payload) */
 				ret = parse_sip_proto(buffer,

--- a/src/diskcryptor_fmt_plug.c
+++ b/src/diskcryptor_fmt_plug.c
@@ -139,11 +139,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #endif
 		// kdf
 #ifdef SIMD_COEF_64
-		for (i = 0; i < MIN_KEYS_PER_CRYPT && index+i < count; ++i) {
+		i = 0;
+		do {
 			lens[i] = saved_len[index+i];
 			pin[i] = (unsigned char*)saved_key[index+i];
 			pout[i] = seed[i];
-		}
+			++i;
+		} while (i < MIN_KEYS_PER_CRYPT && index+i < count);
 		for (; i < MIN_KEYS_PER_CRYPT; ++i) {
 			lens[i] = 0;
 			pin[i] = pin[0];

--- a/src/ztex/pkt_comm/word_gen.h
+++ b/src/ztex/pkt_comm/word_gen.h
@@ -32,7 +32,7 @@ struct word_gen {
 	//unsigned char magic;	// 0xBB <- added by pkt_word_gen_new()
 };
 
-struct word_gen word_gen_words_pass_by;
+extern struct word_gen word_gen_words_pass_by;
 
 struct pkt *pkt_word_gen_new(struct word_gen *word_gen);
 

--- a/src/ztex/ztex.c
+++ b/src/ztex/ztex.c
@@ -752,7 +752,7 @@ short hex_byte(char *str)
 	return result & 0xff;
 }
 
-const int IHX_SIZE_MAX = 65536;
+static const int IHX_SIZE_MAX = 65536;
 
 int ihx_load_data(struct ihx_data *ihx_data, FILE *fp)
 {

--- a/src/ztex/ztex.h
+++ b/src/ztex/ztex.h
@@ -167,7 +167,6 @@ int ztex_upload_bitstream(struct ztex_device *dev, FILE *fp);
 int ztex_reset_cpu(struct ztex_device *dev, int r);
 
 // firmware image loaded from an ihx (Intel Hex format) file.
-const int IHX_SIZE_MAX;
 struct ihx_data {
 	short *data;
 };

--- a/src/ztex_common.h
+++ b/src/ztex_common.h
@@ -14,15 +14,15 @@
  * List of boards detected at initialization.
  * --dev command-line option applies.
  */
-struct list_main *ztex_detected_list;
+extern struct list_main *ztex_detected_list;
 
 /*
  * List of boards for use in current fork.
  */
-struct list_main *ztex_use_list;
+extern struct list_main *ztex_use_list;
 
-int ztex_devices_per_fork;
-int ztex_fork_num;
+extern int ztex_devices_per_fork;
+extern int ztex_fork_num;
 
 /*
  * The function is to be called on the access to ZTEX formats.


### PR DESCRIPTION
This fixes the following:

gcc 9.3.0

```
diskcryptor_fmt_plug.c: In function 'crypt_all._omp_fn.0':
diskcryptor_fmt_plug.c:149:16: warning: 'pin[0]' may be used uninitialized in this function [-Wmaybe-uninitialized]
  149 |    pin[i] = pin[0];
      |             ~~~^~~
```

gcc 10.1.0

```
SIPdump.c: In function 'parse_payload':
SIPdump.c:415:5: warning: '__builtin_strncpy' specified bound depends on the length of the source argument [-Wstringop-overflow=]
  415 |     strncpy(payload_buffer, conn_table[i].buffer,
      |     ^~~~~~~
SIPdump.c:412:9: note: length computed here
  412 |         strlen(conn_table[i].buffer) + 1;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

ztex_common.o: In function `ztex_init':
/home/solar/j/bleeding-jumbo-20200607/src/ztex_common.c:25: multiple definition of `ztex_detected_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1593: first defined here
ztex_common.o: In function `ztex_init':
/home/solar/j/bleeding-jumbo-20200607/src/ztex_common.c:28: multiple definition of `ztex_use_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1627: first defined here
ztex_common.o: In function `ztex_init':
/home/solar/j/bleeding-jumbo-20200607/src/ztex_common.c:25: multiple definition of `ztex_fork_num'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex_common.o: In function `ztex_init':
/home/solar/j/bleeding-jumbo-20200607/src/ztex_common.c:25: multiple definition of `ztex_devices_per_fork'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/device.o:(.bss+0x10): multiple definition of `ztex_use_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1627: first defined here
ztex/device.o:(.bss+0x4): multiple definition of `ztex_fork_num'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/device.o:(.bss+0x8): multiple definition of `ztex_devices_per_fork'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/device.o:(.bss+0x18): multiple definition of `ztex_detected_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1593: first defined here
ztex/device_format.o:(.bss+0x48): multiple definition of `ztex_use_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1627: first defined here
ztex/device_format.o:(.bss+0x40): multiple definition of `ztex_fork_num'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/device_format.o:(.bss+0x44): multiple definition of `ztex_devices_per_fork'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/device_format.o:(.bss+0x50): multiple definition of `ztex_detected_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1593: first defined here
ztex/inouttraffic.o:(.rodata+0x0): multiple definition of `IHX_SIZE_MAX'
ztex/device.o:(.rodata+0x0): first defined here
ztex/jtr_device.o:(.rodata+0x14): multiple definition of `IHX_SIZE_MAX'
ztex/device.o:(.rodata+0x0): first defined here
ztex/jtr_mask.o:(.bss+0x420): multiple definition of `word_gen_words_pass_by'
ztex/jtr_device.o:(.bss+0x20): first defined here
ztex/task.o:(.bss+0x0): multiple definition of `word_gen_words_pass_by'
ztex/jtr_device.o:(.bss+0x20): first defined here
ztex/ztex.o:(.bss+0x4): multiple definition of `ztex_fork_num'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/ztex.o:(.bss+0x8): multiple definition of `ztex_devices_per_fork'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/ztex.o:(.bss+0x10): multiple definition of `ztex_use_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1627: first defined here
ztex/ztex.o:(.bss+0x18): multiple definition of `ztex_detected_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1593: first defined here
ztex/ztex.o:(.rodata+0x0): multiple definition of `IHX_SIZE_MAX'
ztex/device.o:(.rodata+0x0): first defined here
ztex/ztex_scan.o:(.rodata+0x0): multiple definition of `IHX_SIZE_MAX'
ztex/device.o:(.rodata+0x0): first defined here
ztex/ztex_scan.o:(.bss+0x20): multiple definition of `ztex_fork_num'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/ztex_scan.o:(.bss+0x24): multiple definition of `ztex_devices_per_fork'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1625: first defined here
ztex/ztex_scan.o:(.bss+0x28): multiple definition of `ztex_use_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1627: first defined here
ztex/ztex_scan.o:(.bss+0x30): multiple definition of `ztex_detected_list'
john.o:/home/solar/j/bleeding-jumbo-20200607/src/john.c:1593: first defined here
ztex/pkt_comm/word_gen.o:(.bss+0x0): multiple definition of `word_gen_words_pass_by'
ztex/jtr_device.o:(.bss+0x20): first defined here
```