### PR TITLE
phpass-opencl: specialized code for password lengths below 8 and 12

### DIFF
--- a/run/opencl/phpass_kernel.cl
+++ b/run/opencl/phpass_kernel.cl
@@ -398,6 +398,183 @@ __kernel void phpass (__global const phpass_password *data,
 	x12 = x[12];
 	x13 = x[13];
 
+#ifdef SCALAR
+	if (length < 8)
+	do {
+		b = 0xefcdab89;
+		c = 0x98badcfe;
+		//d = 0x10325476;
+
+		a = AC1 + x0;
+		a = ROTATE_LEFT(a, S11);
+		a += b;                 /* 1 */
+		d = (c ^ (a & MASK1)) + x1 + AC2pCd;
+		d = ROTATE_LEFT(d, S12);
+		d += a;                 /* 2 */
+		c = F(d, a, b) + x2 + AC3pCc;
+		c = ROTATE_LEFT(c, S13);
+		c += d;                 /* 3 */
+		b = F(c, d, a) + x3 + AC4pCb;
+		b = ROTATE_LEFT(b, S14);
+		b += c;
+		FF(a, b, c, d, x4, S11, 0xf57c0faf);
+		FF(d, a, b, c, x5, S12, 0x4787c62a);
+		FF(c, d, a, b, 0, S13, 0xa8304613);
+		FF(b, c, d, a, 0, S14, 0xfd469501);
+		FF(a, b, c, d, 0, S11, 0x698098d8);
+		FF(d, a, b, c, 0, S12, 0x8b44f7af);
+		FF(c, d, a, b, 0, S13, 0xffff5bb1);
+		FF(b, c, d, a, 0, S14, 0x895cd7be);
+		FF(a, b, c, d, 0, S11, 0x6b901122);
+		FF(d, a, b, c, 0, S12, 0xfd987193);
+		FF(c, d, a, b, x14, S13, 0xa679438e);
+		FF2(b, c, d, a, S14, 0x49b40821);
+
+		GG(a, b, c, d, x1, S21, 0xf61e2562);
+		GG(d, a, b, c, 0, S22, 0xc040b340);
+		GG(c, d, a, b, 0, S23, 0x265e5a51);
+		GG(b, c, d, a, x0, S24, 0xe9b6c7aa);
+		GG(a, b, c, d, x5, S21, 0xd62f105d);
+		GG(d, a, b, c, 0, S22, 0x2441453);
+		GG2(c, d, a, b, S23, 0xd8a1e681);
+		GG(b, c, d, a, x4, S24, 0xe7d3fbc8);
+		GG(a, b, c, d, 0, S21, 0x21e1cde6);
+		GG(d, a, b, c, x14, S22, 0xc33707d6);
+		GG(c, d, a, b, x3, S23, 0xf4d50d87);
+		GG(b, c, d, a, 0, S24, 0x455a14ed);
+		GG(a, b, c, d, 0, S21, 0xa9e3e905);
+		GG(d, a, b, c, x2, S22, 0xfcefa3f8);
+		GG(c, d, a, b, 0, S23, 0x676f02d9);
+		GG(b, c, d, a, 0, S24, 0x8d2a4c8a);
+
+		HH(a, b, c, d, x5, S31, 0xfffa3942);
+		HH(d, a, b, c, 0, S32, 0x8771f681);
+		HH(c, d, a, b, 0, S33, 0x6d9d6122);
+		HH(b, c, d, a, x14, S34, 0xfde5380c);
+		HH(a, b, c, d, x1, S31, 0xa4beea44);
+		HH(d, a, b, c, x4, S32, 0x4bdecfa9);
+		HH(c, d, a, b, 0, S33, 0xf6bb4b60);
+		HH(b, c, d, a, 0, S34, 0xbebfbc70);
+		HH(a, b, c, d, 0, S31, 0x289b7ec6);
+		HH(d, a, b, c, x0, S32, 0xeaa127fa);
+		HH(c, d, a, b, x3, S33, 0xd4ef3085);
+		HH(b, c, d, a, 0, S34, 0x4881d05);
+		HH(a, b, c, d, 0, S31, 0xd9d4d039);
+		HH(d, a, b, c, 0, S32, 0xe6db99e5);
+		HH2(c, d, a, b, S33, 0x1fa27cf8);
+		HH(b, c, d, a, x2, S34, 0xc4ac5665);
+
+		II(a, b, c, d, x0, S41, 0xf4292244);
+		II(d, a, b, c, 0, S42, 0x432aff97);
+		II(c, d, a, b, x14, S43, 0xab9423a7);
+		II(b, c, d, a, x5, S44, 0xfc93a039);
+		II(a, b, c, d, 0, S41, 0x655b59c3);
+		II(d, a, b, c, x3, S42, 0x8f0ccc92);
+		II(c, d, a, b, 0, S43, 0xffeff47d);
+		II(b, c, d, a, x1, S44, 0x85845dd1);
+		II(a, b, c, d, 0, S41, 0x6fa87e4f);
+		II2(d, a, b, c, S42, 0xfe2ce6e0);
+		II(c, d, a, b, 0, S43, 0xa3014314);
+		II(b, c, d, a, 0, S44, 0x4e0811a1);
+		II(a, b, c, d, x4, S41, 0xf7537e82);
+		II(d, a, b, c, 0, S42, 0xbd3af235);
+		II(c, d, a, b, x2, S43, 0x2ad7d2bb);
+		II(b, c, d, a, 0, S44, 0xeb86d391);
+
+		x0 = a + 0x67452301;
+		x1 = b + 0xefcdab89;
+		x2 = c + 0x98badcfe;
+		x3 = d + 0x10325476;
+	} while (--count);
+	else if (length < 12)
+	do {
+		b = 0xefcdab89;
+		c = 0x98badcfe;
+		//d = 0x10325476;
+
+		a = AC1 + x0;
+		a = ROTATE_LEFT(a, S11);
+		a += b;                 /* 1 */
+		d = (c ^ (a & MASK1)) + x1 + AC2pCd;
+		d = ROTATE_LEFT(d, S12);
+		d += a;                 /* 2 */
+		c = F(d, a, b) + x2 + AC3pCc;
+		c = ROTATE_LEFT(c, S13);
+		c += d;                 /* 3 */
+		b = F(c, d, a) + x3 + AC4pCb;
+		b = ROTATE_LEFT(b, S14);
+		b += c;
+		FF(a, b, c, d, x4, S11, 0xf57c0faf);
+		FF(d, a, b, c, x5, S12, 0x4787c62a);
+		FF(c, d, a, b, x6, S13, 0xa8304613);
+		FF(b, c, d, a, 0, S14, 0xfd469501);
+		FF(a, b, c, d, 0, S11, 0x698098d8);
+		FF(d, a, b, c, 0, S12, 0x8b44f7af);
+		FF(c, d, a, b, 0, S13, 0xffff5bb1);
+		FF(b, c, d, a, 0, S14, 0x895cd7be);
+		FF(a, b, c, d, 0, S11, 0x6b901122);
+		FF(d, a, b, c, 0, S12, 0xfd987193);
+		FF(c, d, a, b, x14, S13, 0xa679438e);
+		FF2(b, c, d, a, S14, 0x49b40821);
+
+		GG(a, b, c, d, x1, S21, 0xf61e2562);
+		GG(d, a, b, c, x6, S22, 0xc040b340);
+		GG(c, d, a, b, 0, S23, 0x265e5a51);
+		GG(b, c, d, a, x0, S24, 0xe9b6c7aa);
+		GG(a, b, c, d, x5, S21, 0xd62f105d);
+		GG(d, a, b, c, 0, S22, 0x2441453);
+		GG2(c, d, a, b, S23, 0xd8a1e681);
+		GG(b, c, d, a, x4, S24, 0xe7d3fbc8);
+		GG(a, b, c, d, 0, S21, 0x21e1cde6);
+		GG(d, a, b, c, x14, S22, 0xc33707d6);
+		GG(c, d, a, b, x3, S23, 0xf4d50d87);
+		GG(b, c, d, a, 0, S24, 0x455a14ed);
+		GG(a, b, c, d, 0, S21, 0xa9e3e905);
+		GG(d, a, b, c, x2, S22, 0xfcefa3f8);
+		GG(c, d, a, b, 0, S23, 0x676f02d9);
+		GG(b, c, d, a, 0, S24, 0x8d2a4c8a);
+
+		HH(a, b, c, d, x5, S31, 0xfffa3942);
+		HH(d, a, b, c, 0, S32, 0x8771f681);
+		HH(c, d, a, b, 0, S33, 0x6d9d6122);
+		HH(b, c, d, a, x14, S34, 0xfde5380c);
+		HH(a, b, c, d, x1, S31, 0xa4beea44);
+		HH(d, a, b, c, x4, S32, 0x4bdecfa9);
+		HH(c, d, a, b, 0, S33, 0xf6bb4b60);
+		HH(b, c, d, a, 0, S34, 0xbebfbc70);
+		HH(a, b, c, d, 0, S31, 0x289b7ec6);
+		HH(d, a, b, c, x0, S32, 0xeaa127fa);
+		HH(c, d, a, b, x3, S33, 0xd4ef3085);
+		HH(b, c, d, a, x6, S34, 0x4881d05);
+		HH(a, b, c, d, 0, S31, 0xd9d4d039);
+		HH(d, a, b, c, 0, S32, 0xe6db99e5);
+		HH2(c, d, a, b, S33, 0x1fa27cf8);
+		HH(b, c, d, a, x2, S34, 0xc4ac5665);
+
+		II(a, b, c, d, x0, S41, 0xf4292244);
+		II(d, a, b, c, 0, S42, 0x432aff97);
+		II(c, d, a, b, x14, S43, 0xab9423a7);
+		II(b, c, d, a, x5, S44, 0xfc93a039);
+		II(a, b, c, d, 0, S41, 0x655b59c3);
+		II(d, a, b, c, x3, S42, 0x8f0ccc92);
+		II(c, d, a, b, 0, S43, 0xffeff47d);
+		II(b, c, d, a, x1, S44, 0x85845dd1);
+		II(a, b, c, d, 0, S41, 0x6fa87e4f);
+		II2(d, a, b, c, S42, 0xfe2ce6e0);
+		II(c, d, a, b, x6, S43, 0xa3014314);
+		II(b, c, d, a, 0, S44, 0x4e0811a1);
+		II(a, b, c, d, x4, S41, 0xf7537e82);
+		II(d, a, b, c, 0, S42, 0xbd3af235);
+		II(c, d, a, b, x2, S43, 0x2ad7d2bb);
+		II(b, c, d, a, 0, S44, 0xeb86d391);
+
+		x0 = a + 0x67452301;
+		x1 = b + 0xefcdab89;
+		x2 = c + 0x98badcfe;
+		x3 = d + 0x10325476;
+	} while (--count);
+	else
+#endif
 	do {
 		b = 0xefcdab89;
 		c = 0x98badcfe;


### PR DESCRIPTION
This is a PoC hack inspired by my md5crypt-opencl optimizations from early last year, which we didn't yet have equivalents of in our phpass code. (BTW, we should probably also add similar optimizations on CPU, which we don't yet have for either hash.)

This provides a 10%'ish speedup in my testing on fixed-low-length candidate passwords on a Tesla V100. Before:

```
user@twin:~/j/run$ ../run/john -test -form=phpass-opencl
Device 1: Tesla V100-SXM2-32GB
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=32 GWS=20480 (640 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     11816K c/s real, 10503K c/s virtual, Dev#1 util: 82%
Only one salt:  9994K c/s real, 8923K c/s virtual, Dev#1 util: 69%

user@twin:~/j/run$ ../run/john -test -form=phpass-opencl
Device 1: Tesla V100-SXM2-32GB
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=32 GWS=20480 (640 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     11356K c/s real, 9583K c/s virtual, Dev#1 util: 78%
Only one salt:  9881K c/s real, 8744K c/s virtual, Dev#1 util: 68%

user@twin:~/j/run$ LWS=256 GWS=1310720 ../run/john -test -form=phpass-opencl
Device 1: Tesla V100-SXM2-32GB
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=256 GWS=1310720 (5120 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Warning: "Many salts" test limited: 19/256
Many salts:     12389K c/s real, 10734K c/s virtual, Dev#1 util: 89%
Only one salt:  10976K c/s real, 10082K c/s virtual, Dev#1 util: 65%

user@twin:~/j/run$ ./john -mask='?l' -min-len=7 -max-len=7 -form=phpass-opencl ~/09-pro-rp.phpass.400
Device 1: Tesla V100-SXM2-32GB
Using default input encoding: UTF-8
Loaded 4202 password hashes with 4202 different salts (phpass-opencl [MD5 OpenCL])
Cost 1 (iteration count) is 2048 for all loaded hashes
LWS=32 GWS=20480 (640 blocks)
Press 'q' or Ctrl-C to abort, almost any other key for status
0g 0:00:01:04 0.00% (ETA: 2020-09-15 03:13) 0g/s 2558p/s 10780Kc/s 10780KC/s Dev#1:63C umtmaaa..rgycaaa
Session aborted
```

After:

```
user@twin:~/j/c/JohnTheRipper/run$ ../run/john -test -form=phpass-opencl
Device 1: Tesla V100-SXM2-32GB
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=32 GWS=20480 (640 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     12759K c/s real, 11291K c/s virtual, Dev#1 util: 80%
Only one salt:  10515K c/s real, 9310K c/s virtual, Dev#1 util: 66%

user@twin:~/j/c/JohnTheRipper/run$ ../run/john -test -form=phpass-opencl
Device 1: Tesla V100-SXM2-32GB
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=32 GWS=20480 (640 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     12738K c/s real, 11223K c/s virtual, Dev#1 util: 81%
Only one salt:  10598K c/s real, 9379K c/s virtual, Dev#1 util: 66%

user@twin:~/j/c/JohnTheRipper/run$ LWS=256 GWS=1310720 ../run/john -test -form=phpass-opencl
Device 1: Tesla V100-SXM2-32GB
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=256 GWS=1310720 (5120 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Warning: "Many salts" test limited: 21/256
Many salts:     13559K c/s real, 11663K c/s virtual, Dev#1 util: 90%
Only one salt:  11802K c/s real, 10827K c/s virtual, Dev#1 util: 75%

user@twin:~/j/c/JohnTheRipper/run$ ./john -mask='?l' -min-len=7 -max-len=7 -form=phpass-opencl ~/09-pro-rp.phpass.400
Device 1: Tesla V100-SXM2-32GB
Using default input encoding: UTF-8
Loaded 4202 password hashes with 4202 different salts (phpass-opencl [MD5 OpenCL])
Cost 1 (iteration count) is 2048 for all loaded hashes
LWS=32 GWS=20480 (640 blocks)
Press 'q' or Ctrl-C to abort, almost any other key for status
0g 0:00:01:01 0.00% (ETA: 2020-09-13 10:23) 0g/s 2651p/s 12161Kc/s 12161KC/s Dev#1:66C umtmaaa..rgycaaa
Session aborted
```

Somehow the GPU utilization is very low at default GWS (~80%) and is somewhat low even at high GWS (~90%). We'll need to investigate and hopefully fix that separately.

What's worse for this PR, it probably hurts speeds in mixed-length runs. In our md5crypt-opencl, we now have code to detect whether all 64 candidate passwords in an aligned block would follow the same code paths or not, and we disable the length specialization if not. We should probably add similar logic for phpass-opencl.

Also, phpass-opencl supports vectorized builds (what for? CPUs?), but the specialized code added in this PR is for scalar builds only. I think that's OK, and I hope my `#ifdef SCALAR` is right.

When extending this beyond PoC, we could also add similar code for some higher length ranges. And we could possibly add code for specific lengths (not ranges) where we can hard-code the `0x80` constant, so that it gets mixed with other MD5 constants at compile time (we have that for md5crypt-opencl).

(BTW, no, this hack wasn't used by any team in the contest. I just made it quickly right after contest end. However, yes, I was reminded about us missing this optimization opportunity by teams playing with phpass hashes in the contest. I was also reminded about it a few days earlier by our phpass-opencl benchmark "mysteriously" showing a lower rate of MD5s per second than our md5crypt-opencl did in benchmarks on V100.)