### PR TITLE
README-OPENCL: give a more relevant build flags override example

### DIFF
--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -76,11 +76,10 @@ which needs the "--enable-mpi" option to be supplied to configure (nearly
 all users should use the --fork option instead of MPI so wont need this). If
 something is missing, it's likely installed in a non-standard location so
 you'd need to pass parameters:
-	./configure LDFLAGS=-L/opt/lib CFLAGS="-O2 -I/opt/include" && make -sj4
+	./configure LDFLAGS=-L/opt/lib CPPFLAGS=-I/opt/include && make -sj4
 
-NOTE! If you pass CFLAGS like above, you probably also want to add "-O2"
-since it (and "-g") will only be added automatically provided CFLAGS start
-out empty. This is a feature of the autoconf macros, not specific to JtR.
+Note that it's important to use CPPFLAGS and not CFLAGS in the example above,
+so that you don't override our compiler optimization flags in CFLAGS.
 
 If you have a broken pkg-config (eg. claiming there is no OpenSSL even though
 there is one) you can disable its use within configure:

--- a/doc/README-OPENCL
+++ b/doc/README-OPENCL
@@ -46,7 +46,7 @@ COMPILING:
 The new autoconf (./configure) should find your OpenCL installation and
 enable it.  If it doesn't, you may need to pass some parameters about where
 it's located, e.g.,
-    ./configure LDFLAGS=-L/opt/AMDAPP/lib CFLAGS=-I/opt/AMDAPP/include
+    ./configure LDFLAGS=-L/usr/local/cuda-11.0/targets/x86_64-linux/lib CPPFLAGS=-I/usr/local/cuda-11.0/targets/x86_64-linux/include
     make -sj4
 
 To force a build without OpenCL, use:


### PR DESCRIPTION
In the example, use CUDA rather than AMDAPP, and override CPPFLAGS rather than
CFLAGS.  Overriding CFLAGS resulted in our -O flags getting overridden as well.