### PR TITLE
Benchmark: don't read more than the format's binary_size from binary()

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -432,12 +432,12 @@ char *benchmark_format(struct fmt_main *format, int salts,
 	if (format->params.binary_size > binary_size) {
 		binary_size = format->params.binary_size;
 		binary = mem_alloc_tiny(binary_size, MEM_ALIGN_SIMD);
-		memset(binary, 0x55, binary_size);
 	}
+	memset(binary, 0x55, binary_size);
 	if (format->params.flags & FMT_BLOB)
 		memcpy(binary,
 		       format->methods.binary(format->params.tests[0].ciphertext),
-		       binary_size);
+		       format->params.binary_size);
 
 	for (index = 0; index < 2; index++) {
 		two_salts[index] = mem_alloc_align(format->params.salt_size,


### PR DESCRIPTION
Previously, we'd over-read for FMT_BLOB formats, which crashed at least in some ASan builds.

While at it, also re-initialize the dummy binary with 0x55's to have consistent behavior for non-FMT_BLOB format benchmarks after FMT_BLOB formats might (or might not) have been benchmarked.

Fixes #4311