### PR TITLE
opencl_common.h: Handle systems that already defined CL_DEVICE_TOPOLOGY_AMD

### DIFF
--- a/src/opencl_common.h
+++ b/src/opencl_common.h
@@ -81,6 +81,9 @@
 
 #ifndef CL_DEVICE_TOPOLOGY_AMD
 #define CL_DEVICE_TOPOLOGY_AMD                      0x4037
+#endif
+
+#ifndef CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD
 typedef union {
 	struct {
 		cl_uint type;


### PR DESCRIPTION
…but not CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD and corresponding typedef.
Closes #4331