### PR TITLE
phpass-opencl: Transfer keys only when changed

### DIFF
--- a/src/opencl_phpass_fmt_plug.c
+++ b/src/opencl_phpass_fmt_plug.c
@@ -55,6 +55,7 @@ static phpass_hash *outbuffer;			/** calculated hashes **/
 static cl_int cl_error;
 static cl_mem mem_in, mem_out, mem_salt;
 static size_t insize, outsize, saltsize;
+static int new_keys;
 static struct fmt_main *self;
 
 #define STEP			0
@@ -134,6 +135,7 @@ static void set_key(char *key, int index)
 {
 	inbuffer[index].length = strlen(key);
 	strncpy((char*)inbuffer[index].v, key, sizeof(inbuffer[index].v));
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -217,9 +219,12 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,


### PR DESCRIPTION
This is the same logic we had e.g. for md5crypt-opencl, and it's quite ridiculous we forgot about it for phpass until now.

Before:

```
Device 1: gfx900 [Radeon RX Vega]
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=64 GWS=65536 (1024 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Warning: "Many salts" test limited: 218/256
Many salts:     7143K c/s real, 59528K c/s virtual
Only one salt:  6357K c/s real, 26624K c/s virtual

Device 4: GeForce GTX 1080
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=1024 GWS=20480 (20 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     5939K c/s real, 5499K c/s virtual, Dev#4 util: 89%
Only one salt:  5335K c/s real, 4986K c/s virtual, Dev#4 util: 79%

Device 4: GeForce GTX 1080
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=512 GWS=20480 (40 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     5447K c/s real, 4907K c/s virtual, Dev#4 util: 84%
Only one salt:  4976K c/s real, 4565K c/s virtual, Dev#4 util: 76%

Device 5: GeForce GTX TITAN X
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=1024 GWS=24576 (24 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     4536K c/s real, 4240K c/s virtual, Dev#5 util: 92%
Only one salt:  4022K c/s real, 3726K c/s virtual, Dev#5 util: 80%

Device 6: GeForce GTX TITAN
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=512 GWS=21504 (42 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Warning: "Many salts" test limited: 186/256
Many salts:     1989K c/s real, 1941K c/s virtual, Dev#6 util: 96%
Only one salt:  1924K c/s real, 1868K c/s virtual, Dev#6 util: 93%

Device 6: GeForce GTX TITAN
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=128 GWS=21504 (168 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Warning: "Many salts" test limited: 179/256
Many salts:     1924K c/s real, 1841K c/s virtual, Dev#6 util: 94%
Only one salt:  1850K c/s real, 1779K c/s virtual, Dev#6 util: 91%
```

After:

```
Device 1: gfx900 [Radeon RX Vega]
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=64 GWS=65536 (1024 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Warning: "Many salts" test limited: 225/256
Many salts:     7372K c/s real, 86738K c/s virtual
Only one salt:  6325K c/s real, 27051K c/s virtual

Device 4: GeForce GTX 1080
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=1024 GWS=20480 (20 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     6819K c/s real, 6819K c/s virtual, Dev#4 util: 96%
Only one salt:  4976K c/s real, 4503K c/s virtual, Dev#4 util: 75%

Device 4: GeForce GTX 1080
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=512 GWS=20480 (40 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     6543K c/s real, 6543K c/s virtual, Dev#4 util: 96%
Only one salt:  5058K c/s real, 4705K c/s virtual, Dev#4 util: 80%

Device 5: GeForce GTX TITAN X
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=1024 GWS=24576 (24 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Many salts:     5062K c/s real, 5062K c/s virtual, Dev#5 util: 97%
Only one salt:  4091K c/s real, 3788K c/s virtual, Dev#5 util: 80%

Device 6: GeForce GTX TITAN
Benchmarking: phpass-opencl ($P$9) [MD5 OpenCL]... LWS=128 GWS=21504 (168 blocks) DONE
Speed for cost 1 (iteration count) of 2048
Warning: "Many salts" test limited: 191/256
Many salts:     2053K c/s real, 2053K c/s virtual, Dev#6 util: 99%
Only one salt:  1882K c/s real, 1837K c/s virtual, Dev#6 util: 92%
```

Good speedup (and increase of utilization) for "Many salts" on the newer and faster NVIDIA GPUs (it could matter that the 1080 is in an 8-lane slot, not 16-lane), smaller speedup on Vega 64, smaller yet speedup on the slowest GPU (as expected).