### PR TITLE
SSH formats fixes

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -125,6 +125,12 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Add support for ssh new-style private keys encrypted using `aes256-ctr`
   cipher.  [vkhromov; 2020]
 
+- Implement full checking in SSH OpenCL format, and drop FMT_NOT_EXACT from
+  both it and the CPU format.  Bugs were squashed as well.  For remaining
+  false-positives (if any), user can selectively use the
+  --keep-guessing option.  [magnum; 2020]
+
+
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 
 - Updated to 1.9.0 core, which brought the following relevant major changes:

--- a/src/opencl_ssh_fmt_plug.c
+++ b/src/opencl_ssh_fmt_plug.c
@@ -275,7 +275,7 @@ struct fmt_main fmt_opencl_ssh = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_NOT_EXACT | FMT_HUGE_INPUT,
+		FMT_CASE | FMT_8_BIT | FMT_SPLIT_UNIFIES_CASE | FMT_HUGE_INPUT,
 		{
 			"KDF/cipher [0=MD5/AES 1=MD5/3DES 2=Bcrypt/AES]",
 			"iteration count",
@@ -288,7 +288,7 @@ struct fmt_main fmt_opencl_ssh = {
 		reset,
 		fmt_default_prepare,
 		ssh_valid,
-		fmt_default_split,
+		ssh_split,
 		fmt_default_binary,
 		ssh_get_salt,
 		{

--- a/src/ssh_common.h
+++ b/src/ssh_common.h
@@ -21,6 +21,7 @@ struct custom_salt {
 };
 
 extern int ssh_valid(char *ciphertext, struct fmt_main *self);
+extern char *ssh_split(char *ciphertext, int index, struct fmt_main *self);
 extern void *ssh_get_salt(char *ciphertext);
 extern unsigned int ssh_iteration_count(void *salt);
 extern unsigned int ssh_kdf(void *salt);

--- a/src/ssh_fmt_plug.c
+++ b/src/ssh_fmt_plug.c
@@ -98,19 +98,6 @@ static void done(void)
 	MEM_FREE(saved_key);
 }
 
-static char *split(char *ciphertext, int index, struct fmt_main *self)
-{
-	static char buf[sizeof(struct custom_salt)+100];
-
-	if (strnlen(ciphertext, LINE_BUFFER_SIZE) < LINE_BUFFER_SIZE &&
-	    strstr(ciphertext, "$SOURCE_HASH$"))
-		return ciphertext;
-
-	strnzcpy(buf, ciphertext, sizeof(buf));
-	strlwr(buf);
-	return buf;
-}
-
 static void set_salt(void *salt)
 {
 	cur_salt = (struct custom_salt *)salt;
@@ -527,7 +514,7 @@ struct fmt_main fmt_ssh = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_NOT_EXACT | FMT_SPLIT_UNIFIES_CASE | FMT_HUGE_INPUT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE | FMT_HUGE_INPUT,
 		{
 			"KDF/cipher [0=MD5/AES 1=MD5/3DES 2=Bcrypt/AES]",
 			"iteration count",
@@ -540,7 +527,7 @@ struct fmt_main fmt_ssh = {
 		fmt_default_reset,
 		fmt_default_prepare,
 		ssh_valid,
-		split,
+		ssh_split,
 		fmt_default_binary,
 		ssh_get_salt,
 		{


### PR DESCRIPTION
- Add FMT_SPLIT_UNIFIES_CASE to the OpenCL format, as the CPU format does so.
- Fix missing glue in "cost" reporting.
- Ensure the OpenCL format rejects hashes with unsupported ciphers.
- Implement full checking in OpenCL format and drop FMT_NOT_EXACT from both as they now seem to produce few enough of FP's and user can still request it manually with --keep-guessing option.
- A logic bug or two was squashed as well.

Closes #4028