### PR TITLE
Add support for --format=LIST (ie. --format=NAME,NAME[,...])

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -125,10 +125,12 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Add support for ssh new-style private keys encrypted using `aes256-ctr`
   cipher.  [vkhromov; 2020]
 
-- Implement full checking in SSH OpenCL format, and drop FMT_NOT_EXACT from
-  both it and the CPU format.  Bugs were squashed as well.  For remaining
-  false-positives (if any), user can selectively use the
-  --keep-guessing option.  [magnum; 2020]
+- Implement full checking in SSH OpenCL format, and stop it as well as the
+  CPU SSH format from defaulting to --keep-guessing.  Bugs were squashed as
+  well.  For any remaining problems with false-positives (if any), user can
+  selectively use the --keep-guessing option.  [magnum; 2020]
+
+- Add support for --format=LIST  [magnum; 2020]
 
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -394,29 +394,41 @@ their number could potentially be decreasing as some hashes get cracked.
 To have the cracked hashes (and possibly salts) removed from all
 processes, you may interrupt and restore the session once in a while.
 
---format=NAME			force hash type NAME
+--format=NAME[,NAME...]		force hash type NAME
 
-Allows you to override the hash type detection.  As of John the Ripper
-version 1.8.0, valid "format names" are descrypt, bsdicrypt, md5crypt,
-bcrypt, LM, AFS, tripcode, dummy, and crypt (and many more are added in
-Jumbo).  You can use this option when you're starting a cracking session
-or along with one of: "--test", "--show", "--make-charset".  Note that
-John can't crack hashes of different types at the same time.  If you
-happen to get a password file that uses more than one hash type, then
-you have to invoke John once for each hash type and you need to use this
-option to make John crack hashes of types other than the one it would
-autodetect by default.  Mainly for test and list purposes (see --list=WHAT),
-you can use group aliases "dynamic", "cpu", "gpu", "opencl" and "cuda"
-as a format name, or use one wildcard, as in "--format=mysql-*",
-"--format=raw*ng" or "--format=*office".  There's also a special way
-to match any substring within the "algorithm name" (the string shown
-within brackets, e.g. "[DES 128/128 AVX-16]" using @tag syntax as in
-e.g. "--format=@DES" or "--format=@AVX".  Similarly you can match a
-substring in the "format name" (the longer name, not the label) using
-#tag format.  For example, if you forgot which format handles the IPMI
-hashes, you can say --format=#ipmi or --format=#ipmi-opencl and the
-correct format (in this case RAKP or RAKP-opencl) will be used.
-Regardless of method, the matching ignores case.
+Override the hash type auto-detection.  You can use this option when
+you're starting a cracking session or along with things like: "--test",
+"--show", "-list" or "--make-charset".  Note that John can't crack hashes
+of different types at the same time.  If you happen to get a password file
+that uses more than one hash type, then you have to invoke John once for
+each hash type and you need to use this option to make John crack hashes of
+types other than the one it would autodetect by default.  For normal use,
+you'd use a full exact format label such as "--format=crypt-md5".  Mainly
+for test and list purposes (see --list=WHAT), you can use a single wildcard,
+as in "--format=mysql-*", "--format=raw*ng" or "--format=*office", or group
+aliases such as "dynamic", "cpu", "omp", "opencl", "ztex" as a format name.
+There's also a special way to match any substring within the "algorithm
+name" (the string shown within brackets, e.g. "[DES 128/128 AVX-16]")
+using @tag syntax as in e.g. "--format=@DES" or "--format=@AVX". Similarly
+you can match a substring in the "format name" (the longer name, not the
+label) using #tag format.  For example, if you forgot which format handles
+the  IPMI hashes, you can say --format=#ipmi and the correct format (in
+this case RAKP) will be used.  Regardless of method, the matching ignores
+case.  Several formats can be specified at once, separated by commas, and
+prepending a format, wildcard or class with a "-" will exclude instead of
+include (eg. "--format=#ipmi,-cpu" for again finding the RAKP format but
+this time rejecting the CPU version so will end up finding "RAKP-OpenCL"
+as long as your build supports OpenCL).  The order given of any "include"
+parts of a format list will be honored so this it feature can also be used
+for merely changing format precedence during auto-detection. Prepending a
+format, wildcard or class with a "+" will promote it to a requirement as
+opposed to an inclusion. That is, "--format=omp,+cpu" will first "include"
+any OMP formats but then prune all of them that does not match format class
+"CPU".
+
+The ad-hoc dynamic, or "dynamic compiler" format can not be used in a format
+list or with wildcards, only on it's own.  This is because the expression
+may need to include commas, wildcard etc.
 
 "--format=crypt" may or may not be supported in a given build of John.
 In default builds of John, this support is currently only included on

--- a/src/formats.c
+++ b/src/formats.c
@@ -3,6 +3,12 @@
  * Copyright (c) 1996-2001,2006,2008,2010-2013,2015 by Solar Designer
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#else
+#define _GNU_SOURCE 1 /* for strcasestr */
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -14,6 +20,7 @@
 #include "misc.h"
 #include "unicode.h"
 #include "base64_convert.h"
+#include "dynamic_compiler.h"
 #ifndef BENCH_BUILD
 #include "options.h"
 #include "loader.h"
@@ -53,6 +60,258 @@ static void test_fmt_case(struct fmt_main *format, void *binary,
 	char *ciphertext, char* plaintext, int *is_case_sensitive,
 	int *plaintext_has_alpha, struct db_salt *dbsalt);
 #endif
+
+/*
+ * Does req_format match format?
+ *
+ * req_format can be an exact full match or a wildc*rd, for format label,
+ * or it can be @algo where 'algo' must be a substring of algorithm_name,
+ * or it can be #name where 'name' must be a substring of format's long name
+ * or it can be a format class/group such as "opencl", "dynamic" or "omp"
+ */
+int fmt_match(const char *req_format, struct fmt_main *format)
+{
+	char *pos = NULL;
+
+	/* Exact full match */
+	if (!strcasecmp(req_format, format->params.label))
+		return 1;
+
+	/* Label wildcard, as in --format=office* */
+	/* We disregard '*' for dynamic compiler format in case it's part of an expression */
+	if (strncasecmp(req_format, "dynamic=", 8) && (pos = strchr(req_format, '*'))) {
+		if (pos != strrchr(req_format, '*')) {
+			if (john_main_process)
+				fprintf(stderr, "Error: Only one wildcard allowed in a format name\n");
+			error();
+		}
+
+		/* Match anything before wildcard */
+		if (strncasecmp(format->params.label, req_format, (int)(pos - req_format)))
+			return 0;
+
+		/* If anything after wildcard, as in *office or raw*ng, does this also match? */
+		if (*(++pos)) {
+			int wild_len = strlen(pos);
+			int label_len = strlen(format->params.label);
+
+			if (strcasecmp(&format->params.label[label_len - wild_len], pos))
+				return 0;
+		}
+		return 1;
+	}
+
+	/* Algo match, eg. --format=@xop or --format=@sha384 */
+	if (strncasecmp(req_format, "dynamic=", 8) && (pos = strchr(req_format, '@')))
+		return (strcasestr(format->params.algorithm_name, ++pos) != NULL);
+
+	/* Long-name match, eg. --format=#ipmi or --format=#1password */
+	if (strncasecmp(req_format, "dynamic=", 8) && (pos = strchr(req_format, '#')))
+		return (strcasestr(format->params.format_name, ++pos) != NULL);
+
+	/* Format classes */
+	if (!strcasecmp(req_format, "dynamic") || !strcasecmp(req_format, "dynamic-all"))
+		return (format->params.flags & FMT_DYNAMIC);
+
+	if (!strcasecmp(req_format, "cpu"))
+		return !(strstr(format->params.label, "-opencl") || strstr(format->params.label, "-ztex"));
+
+	if (!strcasecmp(req_format, "opencl"))
+		return strstr(format->params.label, "-opencl") != NULL;
+
+	if (!strcasecmp(req_format, "ztex"))
+		return strstr(format->params.label, "-ztex") != NULL;
+
+	if (!strcasecmp(req_format, "mask"))
+		return (format->params.flags & FMT_MASK);
+
+	if (!strcasecmp(req_format, "omp"))
+		return (format->params.flags & FMT_OMP);
+
+#if !defined BENCH_BUILD && !defined DYNAMIC_DISABLED
+	if (!strncasecmp(req_format, "dynamic=", 8) && !strcasecmp(format->params.label, "dynamic=")) {
+		DC_HANDLE H;
+
+		if (dynamic_compile(req_format, &H) && dynamic_assign_script_to_format(H, format))
+			return 1;
+	}
+#endif
+	return 0;
+}
+
+#ifndef BENCH_BUILD
+
+/* Exclusions. Drop any format(s) matching rej_format from full list */
+static int exclude_formats(char *rej_format, struct fmt_main **full_fmt_list)
+{
+	struct fmt_main *current, *prev = NULL;
+	int removed = 0;
+
+	if ((current = *full_fmt_list))
+	do {
+		if (fmt_match(rej_format, current)) {
+			if (prev)
+				prev->next = current->next;
+			else
+				*full_fmt_list = current->next;
+			removed++;
+		} else
+			prev = current;
+	} while ((current = current->next));
+
+	return removed;
+}
+
+/* Inclusions. Move any format(s) matching req_format from full list to new list */
+static int include_formats(char *req_format, struct fmt_main **full_fmt_list)
+{
+	struct fmt_main *current, *prev = NULL, *next = NULL;
+	int added = 0;
+
+	if ((current = *full_fmt_list))
+	do {
+		next = current->next;
+		if (fmt_match(req_format, current)) {
+			if (prev)
+				prev->next = next;
+			else
+				*full_fmt_list = next;
+			fmt_register(current);
+			added++;
+		} else
+			prev = current;
+	} while ((current = next));
+
+	return added;
+}
+
+/* Requirements. Drop any format(s) NOT matching req_format from new list */
+static int prune_formats(char *req_format)
+{
+	struct fmt_main *current, *prev = NULL;
+	int removed = 0;
+
+	if ((current = fmt_list))
+	do {
+		if (!fmt_match(req_format, current)) {
+			if (prev)
+				prev->next = current->next;
+			else
+				fmt_list = current->next;
+			removed++;
+		} else
+			prev = current;
+	} while ((current = current->next));
+
+	return removed;
+}
+
+/* Modelled after ldr_split_string */
+static void comma_split(struct list_main *dst, const char *src)
+{
+	char *word, *pos;
+	char c;
+	char *src_cpy = strdup(src);
+
+	strlwr(src_cpy);
+
+	pos = src_cpy;
+	do {
+		word = pos;
+		while (*word == ',')
+			word++;
+
+		if (!*word)
+			break;
+
+		pos = word;
+
+		while (*pos && *pos != ',')
+			pos++;
+
+		c = *pos;
+		*pos = 0;
+
+		list_add_unique(dst, word);
+
+		*pos++ = c;
+
+	} while (c);
+
+	MEM_FREE(src_cpy);
+}
+
+int fmt_check_custom_list(void)
+{
+	if (strchr(options.format_list, ',')) {
+		struct list_main *req_formats;
+
+		list_init(&req_formats);
+		comma_split(req_formats, options.format_list);
+
+		if (req_formats->count) {
+			struct list_entry *req_format = req_formats->head;
+			struct fmt_main *full_fmt_list = fmt_list;
+			int had_i = 0, num_e = 0;
+
+			fmt_list = NULL;
+			fmt_tail = &fmt_list;
+
+			/* "-" Exclusions first, from the full list. */
+			do {
+				if (req_format->data[0] == '-') {
+					char *exclude_fmt = &(req_format->data[1]);
+
+					if (!exclude_fmt[0])
+						error_msg("Error: '%s' in format list doesn't make sense\n", req_format->data);
+					num_e += exclude_formats(exclude_fmt, &full_fmt_list);
+				}
+			} while ((req_format = req_format->next));
+
+			/* Inclusions. Move to the new list. */
+			req_format = req_formats->head;
+			do {
+				if ((req_format->data[0] != '-') && (req_format->data[0] != '+')) {
+					had_i = 1;
+					if (!include_formats(req_format->data, &full_fmt_list)) {
+						if (john_main_process)
+							fprintf(stderr, "Error: No format matched '%s'%s\n", req_format->data,
+							        num_e ? " after exclusions" : "");
+						error();
+					}
+				}
+			} while ((req_format = req_format->next));
+
+			if (had_i == 0)
+				include_formats("*", &full_fmt_list);
+
+			/* "+" Requirements. Scan the new list and prune formats not matching. */
+			req_format = req_formats->head;
+			do {
+				if (req_format->data[0] == '+') {
+					char *require_fmt = &(req_format->data[1]);
+
+					if (!require_fmt[0])
+						error_msg("Error: '%s' in format list doesn't make sense\n", req_format->data);
+					prune_formats(require_fmt);
+				}
+			} while ((req_format = req_format->next));
+
+			if (!fmt_list) {
+				if (john_main_process)
+					fprintf(stderr, "Error: No format matched '%s' after processing final requirements\n",
+					        options.format_list);
+				error();
+			}
+
+			return 1;
+		} else
+			error_msg("Error: Format list '%s' made no sense\n", options.format_list);
+	}
+
+	return 0;
+}
+#endif /* BENCH_BUILD */
 
 void fmt_register(struct fmt_main *format)
 {

--- a/src/formats.h
+++ b/src/formats.h
@@ -445,6 +445,16 @@ extern struct fmt_main *fmt_list;
 extern void fmt_register(struct fmt_main *format);
 
 /*
+ * Match req_format to format, supporting wildcards/groups/classes etc.
+ */
+extern int fmt_match(const char *req_format, struct fmt_main *format);
+
+/*
+ * Check for --format=LIST and if so, re-populate fmt_list from it.
+ */
+extern int fmt_check_custom_list(void);
+
+/*
  * Initializes the format's internal structures unless already initialized.
  */
 extern void fmt_init(struct fmt_main *format);

--- a/src/john.h
+++ b/src/john.h
@@ -42,7 +42,6 @@ extern char *john_terminal_locale;
 
 /* Current target for options.max_cands */
 extern unsigned long long john_max_cands;
-extern int wildcard_format;
 
 /* Print loaded/remaining counts */
 extern char *john_loaded_counts(struct db_main *db, char *prelude);

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -557,15 +557,15 @@ void listconf_parse_late(void)
 		struct fmt_main *format;
 		int column = 0, dynamics = 0;
 		int grp_dyna;
+		char *format_option = options.format ? options.format : options.format_list;
 
-		grp_dyna = options.format ?
-			strcmp(options.format, "dynamic") ?
-			0 : strstr(options.format, "*") != 0 : 1;
+		grp_dyna = !format_option || !strcasestr(format_option, "dynamic");
 
 		format = fmt_list;
 		do {
 			int length;
 			const char *label = format->params.label;
+
 			if (grp_dyna && !strncmp(label, "dynamic", 7)) {
 				if (dynamics++)
 					continue;
@@ -578,8 +578,11 @@ void listconf_parse_late(void)
 				printf("\n");
 				column = length;
 			}
-			printf("%s%s", label, format->next ? ", " : "\n");
+			printf("%s%s", label,
+			       (format->next && (!grp_dyna || !dynamics || strncmp(format->next->params.label, "dynamic", 7))) ?
+			       ", " : "\n");
 		} while ((format = format->next));
+
 		exit(EXIT_SUCCESS);
 	}
 	if (!strcasecmp(options.listconf, "format-details")) {

--- a/src/options.h
+++ b/src/options.h
@@ -218,6 +218,9 @@ struct options_main {
 /* Ciphertext format name */
 	char *format;
 
+/* Ciphertext format list, as a comma-separated string */
+	char *format_list;
+
 /* Wordlist file name */
 	char *wordlist;
 

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -263,23 +263,6 @@ void rec_save(void)
 #endif
 	opt = rec_argv;
 	while (*++opt) {
-		/*
-		 * If a format wildcard or class (eg. --format=opencl) was used,
-		 * we remove it from argv and replace with the actually chosen one.
-		 */
-		if (wildcard_format && !strncmp(*opt, "--format", 8)) {
-			char **shuf = opt;
-
-			wildcard_format = 0;
-			rec_argc--;
-			while (shuf[1]) {
-				*shuf = shuf[1];
-				shuf++;
-			}
-			*shuf = NULL;
-			if (opt == shuf)
-				break;
-		}
 		/********* Re-write deprecated options *********/
 		if (!strncmp(*opt, "--internal-encoding", 19))
 			memcpy(*opt, "--internal-codepage", 19);


### PR DESCRIPTION
Support a comma-separated list of formats given with --format option.
The order given will be honored.  Closes #4366 and extremely useful (along with `--test`) for several open issues.