### PR TITLE
john.c: Protect from segfaulting from division by zero

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -703,7 +703,7 @@ char *john_loaded_counts(struct db_main *db, char *prelude)
 	static char buf[128];
 	char nbuf[24];
 
-	if (db->password_count == 0)
+	if (db->password_count == 0 || db->salt_count == 0)
 		return "No remaining hashes";
 
 	if (db->password_count == 1) {


### PR DESCRIPTION
Seen occasionally during bcrypt testing.  Apparently salt_count was zero while password_count was not.  I was using non-standard local config options `ShowSaltProgress = Y` and `ShowRemainOnStatus = Y`, that probably helped triggering the bug by calling `john_loaded_counts()` at a time database is not yet consistent.

See #4388 though - perhaps the `vec3` double reporting is involved? Anyway, this commit adds safety.