### PR TITLE
Fix bugs with [Disabled:Formats] and new --list=LIST feature.

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -548,10 +548,10 @@ Frequency = 180
 Frequency = 180
 #TargetRounds = 2048
 
-# These formats are disabled from --test runs. Even when disabled, you can
-# use --test for them as long as you add them out with the --format option.
-# Or you can delete a line, comment it out, or change to 'N' and the format
-# will always test
+# These formats are disabled from listing or self-test/benchmark unless
+# specifically requested.  You can use them as long as you add them out with
+# the --format option.  Or you can delete a line, comment it out, or change
+# to 'N' and the format will be enabled again.
 [Disabled:Formats]
 #formatname = Y
 .include '$JOHN/dynamic_disabled.conf'

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -743,7 +743,7 @@ check: default
 	../run/john --list=build-info
 	$(MAKE) unit-tests
 	../run/john --test=0 --verbosity=2 --format=cpu
-	../run/john --test=0 --verbosity=2 --format=dynamic-all
+	../run/john --test=0 --verbosity=2 --format=+dynamic,all
 
 depend:
 	makedepend -fMakefile.dep -Y *.c 2>> /dev/null

--- a/src/formats.h
+++ b/src/formats.h
@@ -447,7 +447,7 @@ extern void fmt_register(struct fmt_main *format);
 /*
  * Match req_format to format, supporting wildcards/groups/classes etc.
  */
-extern int fmt_match(const char *req_format, struct fmt_main *format);
+extern int fmt_match(const char *req_format, struct fmt_main *format, int override_disable);
 
 /*
  * Check for --format=LIST and if so, re-populate fmt_list from it.

--- a/src/john.c
+++ b/src/john.c
@@ -198,14 +198,17 @@ static void john_register_one(struct fmt_main *format)
 {
 	if (options.format) {
 		if (options.format[0] == '-' && options.format[1]) {
-			if (fmt_match(&options.format[1], format))
+			if (fmt_match(&options.format[1], format, 1))
 				return;
 		} else if (options.format[0] == '+' && options.format[1]) {
-			if (!fmt_match(&options.format[1], format))
+			if (!fmt_match(&options.format[1], format, 0))
 				return;
-		} else if (!fmt_match(options.format, format))
+		} else if (!fmt_match(options.format, format, 0))
 			return;
-	}
+	} else if (!options.format_list)
+		if (cfg_get_bool(SECTION_DISABLED, SUBSECTION_FORMATS, format->params.label, 0) &&
+		    ((options.flags & FLG_TEST_CHK) || options.listconf))
+			return;
 
 	fmt_register(format);
 }

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -411,6 +411,9 @@ void listconf_parse_early(void)
 
 	if (!strcasecmp(options.listconf, "encodings"))
 	{
+		if (options.format)
+			error_msg("--format not allowed with \"--list=%s\"\n", options.listconf);
+
 		listEncodings(stdout);
 		exit(EXIT_SUCCESS);
 	}
@@ -479,6 +482,9 @@ void listconf_parse_late(void)
 	if ((options.subformat && !strcasecmp(options.subformat, "list")) ||
 	    (options.listconf && !strcasecmp(options.listconf, "subformats")))
 	{
+		if (options.format)
+			error_msg("--format not allowed with \"--list=subformats\"\n");
+
 		dynamic_DISPLAY_ALL_FORMATS();
 /* NOTE if we have other 'generics', like sha1, sha2, rc4... then EACH of them
    should have a DISPLAY_ALL_FORMATS() function and we can call them here. */


### PR DESCRIPTION
From now we again do not list disabled formats unless specifically requested (eg. using --format=all or --format=disabled).  If it's listed with --list it will be tested with --test.  Using neither --test nor --list we do register all formats so #4324 is still fixed.
Closes #4391

I'm yet to test this thoroughly, need to sleep. @claudioandre-br please test if you like to!