### PR TITLE
libreoffice2john.py, ODF formats: LibreOffice 7 support, robustness fixes

### DIFF
--- a/run/libreoffice2john.py
+++ b/run/libreoffice2john.py
@@ -47,7 +47,7 @@ def process_file(filename):
 
     is_encrypted = False
     key_size = 16
-    for i in range(0, len(elements)):
+    for i in range(0, len(elements) - 4):
         element = elements[i]
         if element.get("{urn:oasis:names:tc:opendocument:xmlns:manifest:1.0}full-path") == "content.xml":
             for j in range(i + 1, i + 1 + 4):

--- a/run/libreoffice2john.py
+++ b/run/libreoffice2john.py
@@ -50,7 +50,7 @@ def process_file(filename):
     for i in range(0, len(elements)):
         element = elements[i]
         if element.get("{urn:oasis:names:tc:opendocument:xmlns:manifest:1.0}full-path") == "content.xml":
-            for j in range(i + 1, i + 1 + 3):
+            for j in range(i + 1, i + 1 + 4):
                 element = elements[j]
                 # print element.items()
                 data = element.get("{urn:oasis:names:tc:opendocument:xmlns:manifest:1.0}checksum")

--- a/run/libreoffice2john.py
+++ b/run/libreoffice2john.py
@@ -75,6 +75,9 @@ def process_file(filename):
                 data = element.get("{urn:oasis:names:tc:opendocument:xmlns:manifest:1.0}key-size")
                 if data:
                     key_size = data
+                data = element.get("{urn:oasis:names:tc:opendocument:xmlns:manifest:1.0}start-key-generation-name")
+                if data:
+                    start_key_generation_name = data
 
     if not is_encrypted:
         sys.stderr.write("%s is not an encrypted OpenOffice file!\n" % filename)
@@ -97,7 +100,7 @@ def process_file(filename):
     elif algorithm_name.find("aes256-cbc") > -1:
         algorithm_type = 1
     else:
-        sys.stderr.write("%s uses un-supported encryption!\n" % filename)
+        sys.stderr.write("%s uses unsupported encryption!\n" % filename)
         return 6
 
     if checksum_type.upper().find("SHA1") > -1:
@@ -105,9 +108,21 @@ def process_file(filename):
     elif checksum_type.upper().find("SHA256") > -1:
         checksum_type = 1
     else:
-        sys.stderr.write("%s uses un-supported checksum algorithm!\n" % \
+        sys.stderr.write("%s uses unsupported checksum algorithm!\n" % \
                 filename)
         return 7
+
+    if start_key_generation_name.upper().find("SHA1") > -1:
+        required_checksum_type = 0
+    elif start_key_generation_name.upper().find("SHA256") > -1:
+        required_checksum_type = 1
+    else:
+        required_checksum_type = -1
+
+    if checksum_type != required_checksum_type:
+        sys.stderr.write("%s uses unsupported combination of algorithms!\n" % \
+                filename)
+        return 8
 
     meta_data_available = True
     gecos = ""


### PR DESCRIPTION
3 commits here, which I'd like to retain separate (merge this PR with rebase-and-merge). Fixes #4392

I tested this on two files: `john-samples/Office/LibreOffice_3.5.1/Libre-Default_myhovercraftisfullofeels_.odt` (also worked before) and `john-samples/Office/Libre-v7_123456.odt` (didn't, but works now), each with two versions of Python (2.6.6 and 3.6.9).

However, I didn't actually test on an unencrypted file - as I understand, @claudioandre-br has a sample where the script previously exhibited the "IndexError: list index out of range" issue, so I'd appreciate it if Claudio confirms that this issue is indeed gone now.