### PR TITLE
john.c: Bug fixes for ext_init() setting cipher_limit

### DIFF
--- a/src/external.c
+++ b/src/external.c
@@ -197,9 +197,9 @@ int ext_has_function(const char *mode, const char *function)
 void ext_init(char *mode, struct db_main *db)
 {
 	ext_minlen = options.eff_minlength;
-	ext_cipher_limit = maxlen = options.eff_maxlength;
-	ext_target_utf8 =
-		(options.target_enc <= CP_UNDEF || options.target_enc == UTF_8);
+	maxlen = options.eff_maxlength;
+	ext_cipher_limit = (db && db->format) ? db->format->params.plaintext_length : maxlen;
+	ext_target_utf8 = (options.target_enc <= CP_UNDEF || options.target_enc == UTF_8);
 
 	/* This is second time we are called, just update the above */
 	if (db && db->format)

--- a/src/john.c
+++ b/src/john.c
@@ -1189,10 +1189,6 @@ static void john_load(void)
 			    database.format->params.format_name[0] ? ", " : "",
 			    database.format->params.format_name,
 			    database.format->params.algorithm_name);
-
-			/* Tell External our max length */
-			if (options.flags & FLG_EXTERNAL_CHK)
-				ext_init(options.external, &database);
 		}
 
 		total = database.password_count;
@@ -1714,6 +1710,10 @@ static void john_run(void)
 			MIN(options.req_maxlength,
 			    database.format->params.plaintext_length) :
 			database.format->params.plaintext_length;
+
+		/* Tell External our max length */
+		if (options.flags & FLG_EXTERNAL_CHK)
+			ext_init(options.external, &database);
 
 		/* Some formats have a minimum plaintext length */
 		if (options.eff_maxlength < options.eff_minlength) {


### PR DESCRIPTION
Ensure the length-update call to ext_init() is made after we've processed any length options, and that it's made at all for --stdout. Also fixes a minor bug for external Unicode modes such as repeats32, they benefit from knowing actual cipher_limit (in bytes).  Closes #4367