### PR TITLE
Unicode tweaks for use eg. in log_print()

### DIFF
--- a/src/cprepair.c
+++ b/src/cprepair.c
@@ -263,10 +263,10 @@ int main(int argc, char **argv)
 			printable = 1;
 			break;
 		case 'f':
-			auto_cp = cp_name2id(optarg);
+			auto_cp = cp_name2id(optarg, 1);
 			break;
 		case 'i':
-			inv_cp = cp_name2id(optarg);
+			inv_cp = cp_name2id(optarg, 1);
 			break;
 		case 'l':
 			puts("Supported encodings:");

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -82,6 +82,7 @@
 #include "regex.h"
 #include "opencl_common.h"
 #include "mask_ext.h"
+#include "john.h"
 #include "version.h"
 #include "listconf.h" /* must be included after version.h */
 
@@ -343,6 +344,9 @@ static void listconf_list_build_info(void)
 		printf("Available physical host memory: %sB\n", human_prefix(avail_mem));
 	else
 		puts("Available physical host memory: unknown");
+
+	printf("Terminal locale string: %s\n", john_terminal_locale);
+	printf("Parsed terminal locale: %s\n", cp_id2name(options.terminal_enc));
 
 // OK, now append debugging options, BUT only output  something if
 // one or more of them is set. IF none set, be silent.

--- a/src/loader.c
+++ b/src/loader.c
@@ -448,9 +448,7 @@ void ldr_set_encoding(struct fmt_main *format)
 		    !strcasecmp(format->params.label, "netlm") ||
 		    !strcasecmp(format->params.label, "nethalflm")) {
 			options.target_enc =
-				cp_name2id(cfg_get_param(SECTION_OPTIONS,
-				                         NULL,
-				                         "DefaultMSCodepage"));
+				cp_name2id(cfg_get_param(SECTION_OPTIONS, NULL, "DefaultMSCodepage"), 1);
 			if (options.target_enc)
 				options.default_target_enc = 1;
 			else
@@ -473,16 +471,12 @@ void ldr_set_encoding(struct fmt_main *format)
 	}
 
 	/* john.conf alternative for --internal-codepage */
-	if (options.flags &
-	    (FLG_RULES_IN_USE | FLG_SINGLE_CHK | FLG_BATCH_CHK | FLG_MASK_CHK))
-	if ((!options.target_enc || options.target_enc == UTF_8) &&
-	    !options.internal_cp) {
+	if (options.flags & (FLG_RULES_IN_USE | FLG_SINGLE_CHK | FLG_BATCH_CHK | FLG_MASK_CHK))
+	if ((!options.target_enc || options.target_enc == UTF_8) && !options.internal_cp) {
 		if (!(options.internal_cp =
-			cp_name2id(cfg_get_param(SECTION_OPTIONS, NULL,
-			                         "DefaultInternalCodepage"))))
+		      cp_name2id(cfg_get_param(SECTION_OPTIONS, NULL, "DefaultInternalCodepage"), 1)))
 			options.internal_cp =
-			    cp_name2id(cfg_get_param(SECTION_OPTIONS, NULL,
-			                         "DefaultInternalEncoding"));
+				cp_name2id(cfg_get_param(SECTION_OPTIONS, NULL, "DefaultInternalEncoding"), 1);
 	}
 
 	/* Performance opportunity - avoid unneccessary conversions */

--- a/src/options.c
+++ b/src/options.c
@@ -978,13 +978,13 @@ void opt_init(char *name, int argc, char **argv, int show_usage)
 	}
 
 	if (encoding_str)
-		options.input_enc = cp_name2id(encoding_str);
+		options.input_enc = cp_name2id(encoding_str, 1);
 
 	if (target_enc_str)
-		options.target_enc = cp_name2id(target_enc_str);
+		options.target_enc = cp_name2id(target_enc_str, 1);
 
 	if (internal_cp_str)
-		options.internal_cp = cp_name2id(internal_cp_str);
+		options.internal_cp = cp_name2id(internal_cp_str, 1);
 
 	if (options.input_enc && options.input_enc != UTF_8) {
 		if (!options.target_enc)

--- a/src/options.h
+++ b/src/options.h
@@ -317,6 +317,9 @@ struct options_main {
    is set, or ISO-8859-1 only if FMT_ENC is false. */
 	int target_enc;
 
+/* Terminal encoding, as parsed from LC_ALL or LC_CTYPE */
+	int terminal_enc;
+
 /* If different from target_enc, this is an intermediate encoding only
    used within rules/mask processing. This is only applicable for the case
    "UTF-8 -> rules -> UTF-8" or "mask -> UTF-8". Since the rules engine can't

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -488,6 +488,26 @@ inline unsigned int strlen8(const UTF8 *source)
 	return targetLen;
 }
 
+/*
+ * Return length (in characters) of a string, best-effort.
+ * For a fully valid UTF-8 string, return number of characters.
+ * If the string contains invalid UTF-8, just count bytes from that point.
+ */
+inline size_t strlen_any(const void *source)
+{
+	const UTF8 *src = source;
+	int len;
+
+	len = strlen8(src);
+	if (len < 0) {
+		size_t extra;
+		len = -len;
+		extra = strlen(&((char*)source)[len + 1]);
+		len += extra;
+	}
+	return len;
+}
+
 /* Check if a string is valid UTF-8 */
 int valid_utf8(const UTF8 *source)
 {

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -989,8 +989,9 @@ char *cp_id2macro(int encoding)
 }
 
 /* Convert encoding name to numerical ID */
-int cp_name2id(const char *encoding)
+int cp_name2id(const char *encoding, int error_exit)
 {
+	const char *orig_arg = encoding;
 	char enc[16] = "";
 	char *d = enc;
 
@@ -1004,13 +1005,17 @@ int cp_name2id(const char *encoding)
 		encoding += 4;
 	else if (!strncasecmp(encoding, "iso", 3))
 		encoding += 3;
+	/* Strip cp prefix */
+	else if (!strncasecmp(encoding, "cp", 2))
+		encoding += 2;
 
 	/* Lowercase */
-	while (*encoding)
-	if (*encoding >= 'A' && *encoding <= 'Z')
-		*d++ = *encoding++ | 0x20;
-	else
-		*d++ = *encoding++;
+	do {
+		if (*encoding >= 'A' && *encoding <= 'Z')
+			*d++ = *encoding++ | 0x20;
+		else
+			*d++ = *encoding++;
+	} while (*encoding);
 
 	/* Now parse this canonical format */
 	if (!strcmp(enc, "utf8") || !strcmp(enc, "utf-8"))
@@ -1032,58 +1037,61 @@ int cp_name2id(const char *encoding)
 	if (!strcmp(enc, "koi8r") || !strcmp(enc, "koi8-r"))
 		return KOI8_R;
 	else
-	if (!strcmp(enc, "cp437"))
+	if (!strcmp(enc, "437"))
 		return CP437;
 	else
-	if (!strcmp(enc, "cp720"))
+	if (!strcmp(enc, "720"))
 		return CP720;
 	else
-	if (!strcmp(enc, "cp737"))
+	if (!strcmp(enc, "737"))
 		return CP737;
 	else
-	if (!strcmp(enc, "cp850"))
+	if (!strcmp(enc, "850"))
 		return CP850;
 	else
-	if (!strcmp(enc, "cp852"))
+	if (!strcmp(enc, "852"))
 		return CP852;
 	else
-	if (!strcmp(enc, "cp858"))
+	if (!strcmp(enc, "858"))
 		return CP858;
 	else
-	if (!strcmp(enc, "cp866"))
+	if (!strcmp(enc, "866"))
 		return CP866;
 	else
-	if (!strcmp(enc, "cp868"))
+	if (!strcmp(enc, "868"))
 		return CP868;
 	else
-	if (!strcmp(enc, "cp1250"))
+	if (!strcmp(enc, "1250"))
 		return CP1250;
 	else
-	if (!strcmp(enc, "cp1251"))
+	if (!strcmp(enc, "1251"))
 		return CP1251;
 	else
-	if (!strcmp(enc, "cp1252"))
+	if (!strcmp(enc, "1252"))
 		return CP1252;
 	else
-	if (!strcmp(enc, "cp1253"))
+	if (!strcmp(enc, "1253"))
 		return CP1253;
 	else
-	if (!strcmp(enc, "cp1254"))
+	if (!strcmp(enc, "1254"))
 		return CP1254;
 	else
-	if (!strcmp(enc, "cp1255"))
+	if (!strcmp(enc, "1255"))
 		return CP1255;
 	else
-	if (!strcmp(enc, "cp1256"))
+	if (!strcmp(enc, "1256"))
 		return CP1256;
 	else
 	if (!strcmp(enc, "raw") || !strcmp(enc, "ascii"))
 		return ASCII;
 
  err:
-	fprintf(stderr, "Invalid encoding. Supported encodings:\n");
-	listEncodings(stderr);
-	error();
+	if (error_exit) {
+		fprintf(stderr, "Invalid encoding '%s'. Supported encodings:\n", orig_arg);
+		listEncodings(stderr);
+		error();
+	} else
+		return CP_UNDEF;
 }
 
 int cp_class(int encoding)

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -196,6 +196,12 @@ extern unsigned int strlen32(const UTF32* str);
 extern unsigned int strlen16(const UTF16* str);
 
 /*
+ * Return length (in characters) of a string, best-effort. If the string
+ * contains invalid UTF-8, just count bytes from that point.
+ */
+extern size_t strlen_any(const void* str);
+
+/*
  * Return length (in characters) of a UTF-8 string
  * Will return a "truncated" length if fed with invalid data.
  */

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -314,7 +314,7 @@ extern UTF8 CP_isDigit[0x100];
 #define enc_toupper(c) (char)CP_up[ARCH_INDEX(c)]
 
 /* Conversion between encoding names and integer id */
-extern int cp_name2id(const char *encoding);
+extern int cp_name2id(const char *encoding, int error_exit);
 extern char *cp_id2name(int encoding);
 extern char *cp_id2macro(int encoding);
 


### PR DESCRIPTION
Improve parsing of LC_* environment, store a "terminal encoding".
Add a strlen_any() function, that can handle invalid UTF-8 best-effort.