### PR TITLE
optional PyCrypto for telegram2john

### DIFF
--- a/run/telegram2john.py
+++ b/run/telegram2john.py
@@ -50,11 +50,14 @@ import xml.etree.ElementTree as ET
 import struct
 import hashlib
 
+check_empty_pass = True
+
 try:
     from Crypto.Cipher import AES
 except ImportError:
-    sys.stderr.write("PyCrypto is missing, run 'pip install --user PyCrypto' to install it!\n")
-    sys.exit(-1)
+    check_empty_pass = False
+    sys.stderr.write("For additional functionality, please install the PyCrypto package.\n")
+    sys.stderr.write("run 'pip install --user PyCrypto' to install it!\n")
 
 PY3 = sys.version_info[0] == 3
 
@@ -146,6 +149,10 @@ def is_correct_ige_decryption(file_path, key, data):
     return False
 
 def is_map0_empty_pass(file_path, salt_hex, data_hex):
+    if not check_empty_pass:
+        sys.stderr.write("ATTENTION: it couldn't be verified if a password was set for the file/account: '%s' (please install the PyCrypto package)\n" % file_path)
+        return False
+
     salt = binascii.unhexlify(salt_hex)
     data = binascii.unhexlify(data_hex)
 
@@ -154,6 +161,10 @@ def is_map0_empty_pass(file_path, salt_hex, data_hex):
     return is_correct_ige_decryption(file_path, key, data)
 
 def is_key_datas_empty_pass(file_path, salt_hex, data_hex):
+    if not check_empty_pass:
+        sys.stderr.write("ATTENTION: it couldn't be verified if a password was set for the file/account: '%s' (please install the PyCrypto package)\n" % file_path)
+        return False
+
     salt = binascii.unhexlify(salt_hex)
     data = binascii.unhexlify(data_hex)
 


### PR DESCRIPTION
This idea / suggestion came up [here](https://github.com/openwall/john/issues/4387#issuecomment-716824145) .

I think it's an acceptable solution for letting the user run it without the `PyCrypto` python package installed, with the additional *noticable* warnings about the possibility of empty-pass hashes etc.

This makes it a little bit user-friendly, but still encourages the user to install the (now loose) dependency `PyCrypto`.

Thx