### PR TITLE
update credits in telegram2john

### DIFF
--- a/run/telegram2john.py
+++ b/run/telegram2john.py
@@ -22,14 +22,17 @@ file(s) and from Telegram Desktop's local storage (map/key_datas) files"""
 # Special thanks goes to https://github.com/MihaZupan for documenting
 # this hashing scheme.
 #
+# Written by Dhiru Kholia <dhiru at openwall.com> in July, 2018 for JtR
+# project.
+#
+#
 # A newer and stronger algorithm was introduced with Telegram Desktop version
 # 2.1.14: it uses PBKDF2-HMAC-SHA512 with higher iteration count and an initial
 # sha512 hash of pass and salt (https://github.com/openwall/john/issues/4387).
 # The supported Telegram Desktop file types are now the old "map0"/"map1" files
 # and new "key_datas" (or similar named) files.
 #
-# Written by Dhiru Kholia <dhiru at openwall.com> in July, 2018 for JtR
-# project.
+# Updated and refactored by philsmd <philsmd at hashcat.net> in October, 2020.
 #
 #
 # This software is Copyright (c) 2018, Dhiru Kholia <dhiru at openwall.com> and


### PR DESCRIPTION
There was this suggestion [here](https://github.com/openwall/john/issues/4387#issuecomment-716824145) that the comments at the start of the `telegram2john.py` script should be updated with the date and the credits for my contribution.

This little commit should make it very clear when the `telegram2john.py` script was updated (by me). I think this is enough even though there was a suggestion that I should be the new copyright holder... but I still think it's just a improved/refactored/newer update of the old script, so the license terms and holder remains the same (in my opinion).

Thx