### PR TITLE
crk_remove_hash: Always update the bitmap and hash table

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -290,12 +290,17 @@ static void crk_remove_hash(struct db_salt *salt, struct db_password *pw)
 	struct db_password **start, **current;
 	int hash, count;
 
+	assert(salt->count >= 1);
+
 	crk_db->password_count--;
 
 	if (!--salt->count) {
 		salt->list = NULL; /* "single crack" mode might care */
 		crk_remove_salt(salt);
-		return;
+		if (!salt->bitmap) {
+/* FIXME: should we BLOB_FREE()? */
+			return;
+		}
 	}
 
 /*
@@ -353,6 +358,7 @@ static void crk_remove_hash(struct db_salt *salt, struct db_password *pw)
  * during cracking, and will remove entries at that point.
  */
 	if (crk_guesses || (crk_params->flags & FMT_REMOVE)) {
+/* FIXME: should the BLOB_FREE() be unconditional? */
 		BLOB_FREE(crk_db->format, pw->binary);
 		pw->binary = NULL;
 	}


### PR DESCRIPTION
When removing the last hash for a salt, we didn't bother updating the bitmap and hash table for the salt.  Now we will (unfortunately, at some increase of memory consumption with "--fork" because of copy-on-write).

We need to do this to avoid logging a guess for the same hash more than once in case its correct password is tested more than once in the same crypt_all() call.  Such duplicate logging was not only confusing; it also resulted in incorrect values of password_count and guess_count.

Fixes #4390

```
[solar@super run]$ ./john -form=bcrypt -w=BF_TS_wordlist.txt BF_hashes.txt
Using default input encoding: UTF-8
Loaded 13 password hashes with 6 different salts (2.2x same-salt boost) (bcrypt [Blowfish 32/64 X3])
Cost 1 (iteration count) is 32 for all loaded hashes
Will run 32 OpenMP threads
Press 'q' or Ctrl-C to abort, almost any other key for status
Warning: Only 19 candidates left, minimum 96 needed for performance.
U*U              (vec_0)
U*U*             (vec_1)
                 (vec_3)
U*U*U            (vec_13)
U*U*U            (vec_2)
0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 (vec_4)
�                (vec_5)
�                (vec_6)
������������������������������������������������������������������������ (vec_9)
�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U�U (vec_10)
U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��U��               (vec_12)
������              (vec_8)
�                (vec_7)
13g 0:00:00:00 DONE (2020-10-29 22:45) 46.42g/s 67.85p/s 407.1c/s 882.1C/s 123456789012345678901234567890123456789012345678901234567890123456789012..U*U*U
Warning: passwords printed above might not be all those cracked
Use the "--show" option to display all of the cracked passwords reliably
Session completed.
[solar@super run]$ ./john -form=bcrypt -w=BF_TS_wordlist.txt BF_hashes.txt
Using default input encoding: UTF-8
Loaded 13 password hashes with 6 different salts (2.2x same-salt boost) (bcrypt [Blowfish 32/64 X3])
Warning: invalid UTF-8 seen reading $JOHN/john.pot
Remaining 1 password hash
Cost 1 (iteration count) is 32 for all loaded hashes
Will run 32 OpenMP threads
Press 'q' or Ctrl-C to abort, almost any other key for status
Warning: Only 19 candidates left, minimum 96 needed for performance.
U*U*U            (vec_2)
1g 0:00:00:00 DONE (2020-10-29 22:46) 4.545g/s 86.36p/s 86.36c/s 86.36C/s 123456789012345678901234567890123456789012345678901234567890123456789012..U*U*U
Warning: passwords printed above might not be all those cracked
Use the "--show" option to display all of the cracked passwords reliably
Session completed.
[solar@super run]$ ./john -form=bcrypt -w=BF_TS_wordlist.txt BF_hashes.txt
Using default input encoding: UTF-8
Loaded 13 password hashes with 6 different salts (2.2x same-salt boost) (bcrypt [Blowfish 32/64 X3])
Warning: invalid UTF-8 seen reading $JOHN/john.pot
No password hashes left to crack (see FAQ)
```

This no longer produces 14 guesses out of 13 hashes loaded (issue #4390), but it still has the issue with `vec_2` (issue #4388).

This needs more testing on other hash types. Also, I am adding two FIXME comments about the blobs that magnum might want to look and fix into separately (and then remove the comments).