### PR TITLE
Unify salt strings for storage/matching in john.pot

### DIFF
--- a/src/BF_common.c
+++ b/src/BF_common.c
@@ -73,6 +73,7 @@ unsigned char BF_atoi64[0x80] = {
 	64, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
 	43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 64, 64, 64, 64, 64
 };
+
 int BF_common_valid(char *ciphertext, struct fmt_main *self)
 {
 	int rounds;
@@ -97,6 +98,18 @@ int BF_common_valid(char *ciphertext, struct fmt_main *self)
 	if (BF_atoi64[ARCH_INDEX(ciphertext[28])] & 0xF) return 0;
 
 	return 1;
+}
+
+char *BF_common_split(char *ciphertext, int index, struct fmt_main *self)
+{
+	if (ciphertext[2] == 'b' || ciphertext[2] == 'y') {
+		static char out[CIPHERTEXT_LENGTH + 1];
+		strcpy(out, ciphertext);
+		out[2] = 'a';
+		return out;
+	}
+
+	return ciphertext;
 }
 
 /*

--- a/src/BF_common.h
+++ b/src/BF_common.h
@@ -58,6 +58,7 @@ extern BF_word BF_magic_w[6];
 extern struct BF_ctx BF_init_state;
 
 int BF_common_valid(char *ciphertext, struct fmt_main *self);
+char *BF_common_split(char *ciphertext, int index, struct fmt_main *self);
 void *BF_common_get_binary(char *ciphertext);
 void *BF_common_get_salt(char *ciphertext);
 unsigned int BF_common_iteration_count(void *salt);

--- a/src/BF_fmt.c
+++ b/src/BF_fmt.c
@@ -209,7 +209,7 @@ struct fmt_main fmt_BF = {
 		fmt_default_reset,
 		fmt_default_prepare,
 		BF_common_valid,
-		fmt_default_split,
+		BF_common_split,
 		BF_common_get_binary,
 		BF_common_get_salt,
 		{

--- a/src/BSDI_fmt.c
+++ b/src/BSDI_fmt.c
@@ -117,10 +117,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 
 	if (ciphertext[0] != '_') return 0;
 
-	for (pos = &ciphertext[1]; pos < &ciphertext[9]; pos++)
-	if (!*pos) return 0;
-
-	for (pos = &ciphertext[9]; atoi64[ARCH_INDEX(*pos)] != 0x7F; pos++);
+	for (pos = &ciphertext[1]; atoi64[ARCH_INDEX(*pos)] != 0x7F; pos++);
 	if (*pos || pos - ciphertext != CIPHERTEXT_LENGTH) return 0;
 
 	if (atoi64[ARCH_INDEX(*(pos - 1))] & 3) return 0;

--- a/src/DES_fmt.c
+++ b/src/DES_fmt.c
@@ -129,8 +129,13 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		memcpy(&out[2], &ciphertext[13], 11);
 	} else
 		memcpy(out, ciphertext, 13);
-
 	out[13] = 0;
+
+/* Replace potential invalid salts with their valid counterparts */
+	unsigned int salt = DES_raw_get_salt(out);
+	out[0] = itoa64[salt & 0x3f];
+	out[1] = itoa64[salt >> 6];
+
 	return out;
 }
 

--- a/src/opencl_DES_fmt_plug.c
+++ b/src/opencl_DES_fmt_plug.c
@@ -132,20 +132,6 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 	}
 }
 
-static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
-{
-	static char out[14];
-
-	if (index) {
-		memcpy(out, &ciphertext[2], 2);
-		memcpy(&out[2], &ciphertext[13], 11);
-	} else
-		memcpy(out, ciphertext, 13);
-
-	out[13] = 0;
-	return out;
-}
-
 static WORD *do_IP(WORD in[2])
 {
 	static WORD out[2];
@@ -225,6 +211,25 @@ static WORD raw_get_salt(char *ciphertext)
 		((WORD)DES_atoi64[ARCH_INDEX(ciphertext[8])] << 18);
 	else return DES_atoi64[ARCH_INDEX(ciphertext[0])] |
 		((WORD)DES_atoi64[ARCH_INDEX(ciphertext[1])] << 6);
+}
+
+static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
+{
+	static char out[14];
+
+	if (index) {
+		memcpy(out, &ciphertext[2], 2);
+		memcpy(&out[2], &ciphertext[13], 11);
+	} else
+		memcpy(out, ciphertext, 13);
+	out[13] = 0;
+
+/* Replace potential invalid salts with their valid counterparts */
+	unsigned int salt = raw_get_salt(out);
+	out[0] = itoa64[salt & 0x3f];
+	out[1] = itoa64[salt >> 6];
+
+	return out;
 }
 
 static void *get_salt(char *ciphertext)

--- a/src/opencl_bf_fmt_plug.c
+++ b/src/opencl_bf_fmt_plug.c
@@ -186,7 +186,7 @@ struct fmt_main fmt_opencl_bf = {
 		fmt_default_reset,
 		fmt_default_prepare,
 		BF_common_valid,
-		fmt_default_split,
+		BF_common_split,
 		BF_common_get_binary,
 		BF_common_get_salt,
 		{

--- a/src/ztex_bcrypt.c
+++ b/src/ztex_bcrypt.c
@@ -314,7 +314,7 @@ struct fmt_main fmt_ztex_bcrypt = {
 		device_format_reset,
 		fmt_default_prepare,
 		BF_common_valid,
-		fmt_default_split,
+		BF_common_split,
 		BF_common_get_binary,
 		BF_common_get_salt,
 		{

--- a/src/ztex_descrypt.c
+++ b/src/ztex_descrypt.c
@@ -157,8 +157,13 @@ static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
 		memcpy(&out[2], &ciphertext[13], 11);
 	} else
 		memcpy(out, ciphertext, 13);
-
 	out[13] = 0;
+
+/* Replace potential invalid salts with their valid counterparts */
+	unsigned int salt = DES_raw_get_salt(out);
+	out[0] = itoa64[salt & 0x3f];
+	out[1] = itoa64[salt >> 6];
+
 	return out;
 }
 


### PR DESCRIPTION
This covers bsdicrypt (disallows invalid salts), descrypt, bcrypt. Fixes #4388.