### PR TITLE
descrypt, LM: Compare against loaded hashes in crypt_all()

### DIFF
--- a/src/DES_bs.c
+++ b/src/DES_bs.c
@@ -497,8 +497,8 @@ int DES_bs_cmp_all(uint32_t *binary, int count)
 
 		mask = b[0] START ^ -(value & 1);
 		mask |= b[1] START ^ -((value >> 1) & 1);
-		if (mask == ~(ARCH_WORD)0) goto next_depth;
 		mask |= b[2] START ^ -((value >> 2) & 1);
+		if (mask == ~(ARCH_WORD)0) goto next_depth;
 		mask |= b[3] START ^ -((value >> 3) & 1);
 		if (mask == ~(ARCH_WORD)0) goto next_depth;
 		value >>= 4;

--- a/src/DES_bs.h
+++ b/src/DES_bs.h
@@ -154,12 +154,12 @@ extern void DES_bs_crypt(int count, int keys_count);
 /*
  * A simplified special-case implementation: 12-bit salts, 25 iterations.
  */
-extern void DES_bs_crypt_25(int keys_count);
+extern int DES_bs_crypt_25(int *pcount, struct db_salt *salt);
 
 /*
  * Another special-case version: a non-zero IV, no salts, no iterations.
  */
-extern int DES_bs_crypt_LM(int *keys_count, struct db_salt *salt);
+extern int DES_bs_crypt_LM(int *pcount, struct db_salt *salt);
 
 /*
  * Converts an ASCII ciphertext to binary to be used with one of the

--- a/src/DES_fmt.c
+++ b/src/DES_fmt.c
@@ -207,12 +207,7 @@ static void set_salt(void *salt)
 	DES_bs_set_salt(*(ARCH_WORD *)salt);
 }
 
-static int crypt_all(int *pcount, struct db_salt *salt)
-{
-	const int count = *pcount;
-	DES_bs_crypt_25(count);
-	return count;
-}
+#define crypt_all DES_bs_crypt_25
 
 static int cmp_one(void *binary, int index)
 {

--- a/src/bench.c
+++ b/src/bench.c
@@ -591,14 +591,15 @@ char *benchmark_format(struct fmt_main *format, int salts,
 			bench_set_keys(format, current, pass);
 		}
 
-		if (salts > 1) format->methods.set_salt(two_salts[index & 1]);
+		if (salts > 1)
+			format->methods.set_salt(two_salts[index & 1]);
 #ifndef BENCH_BUILD
-		format->methods.cmp_all(binary,
-		    format->methods.crypt_all(&count, two_salts_db[index & 1]));
+		int match = format->methods.crypt_all(&count, two_salts_db[index & 1]);
 #else
-		format->methods.cmp_all(binary,
-		    format->methods.crypt_all(&count, NULL));
+		int match = format->methods.crypt_all(&count, NULL);
 #endif
+		if (match)
+			format->methods.cmp_all(binary, match);
 
 		crypts += (uint32_t)count;
 #if !OS_TIMER

--- a/src/loader.c
+++ b/src/loader.c
@@ -1809,6 +1809,10 @@ static void ldr_init_hash(struct db_main *db)
  * comparing it against less than 1 loaded hash on average due to the use of a
  * hash table) vs. the complexity of DES_bs_cmp_all() for all computed hashes
  * at once (but calling it for each loaded hash individually).
+ *
+ * FIXME: This isn't yet aware of our use of SIMD for the comparisons embedded
+ * in crypt_all() for descrypt and LM, nor of our use of OpenMP there and in
+ * DES_bs_cmp_all().  The threshold should be much higher for those cases.
  */
 		threshold = 5 * ARCH_BITS / ARCH_BITS_LOG + 1;
 	}

--- a/src/trip_fmt.c
+++ b/src/trip_fmt.c
@@ -432,7 +432,7 @@ static MAYBE_INLINE void crypt_traverse_by_salt(int count)
 			    buffer[gindex].next < 0) {
 #endif
 				int tindex;
-				DES_bs_crypt_25(lindex);
+				DES_bs_crypt_25(&lindex, NULL);
 				for_each_t(n) {
 					blkcpy58(crypt_out[block_count++],
 					    DES_bs_all.B);


### PR DESCRIPTION
I am posting this PR to validate these changes with our CI before I spend more of my time on them. I haven't completed my own testing yet, and might push more commits in here even if all tests pass.

We only do this when there's no bitmap for the current salt since we would otherwise not make proper use of the bitmap.

This is an initial implementation, which isn't fully optimized yet (e.g., cmp_all() has the first few iterations of the per-bit loop unrolled, but we don't have the same here yet).  It's also currently limited to just descrypt (but would also be relevant for LM and bsdicrypt), and to x86-alikes with SSE4.1/AVX, AVX2, or MIC/AVX-512.

Further, we might want to adjust the loader's threshold so that when we do have this new functionality compiled in, a bitmap would only be created for higher hash per salt counts than before.  Such adjustment hasn't been made yet, meaning that this new functionality is made use of in fewer cases than optimal.  Moreover, the loader's threshold isn't yet aware of our use of OpenMP here and in cmp_all() vs. our non-use of OpenMP in cracker.c's loop that uses the bitmap.