### PR TITLE
Add 'd' keypress for delayed status (after current batch)

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -141,6 +141,10 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   reading status/quit keystrokes even if we're not the foreground process.
   [magnum; 2020]
 
+- Make keypress [d] special: It will also emit a status line, but not until
+  the current batch has been run among all salts.  Under some circumstances
+  that make take a good while.  [magnum; 2020]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/cracker.c
+++ b/src/cracker.c
@@ -1035,9 +1035,11 @@ static int crk_salt_loop(void)
 			break;
 	} while ((salt = salt->next));
 
-	if (crk_db->salt_count < sc && john_main_process &&
-	    cfg_get_bool(SECTION_OPTIONS, NULL, "ShowSaltProgress", 0))
+	if (event_delayed_status || (crk_db->salt_count < sc && john_main_process &&
+	                             cfg_get_bool(SECTION_OPTIONS, NULL, "ShowSaltProgress", 0))) {
+		event_delayed_status = 0;
 		event_status = event_pending = 1;
+	}
 
 	if (!salt || crk_db->salt_count < 2)
 		status.resume_salt_md5 = NULL;

--- a/src/logger.c
+++ b/src/logger.c
@@ -543,14 +543,14 @@ void log_guess(char *login, char *uid, char *ciphertext, char *rep_plain,
 	if (options.verbosity > 2 || (admin && options.verbosity > 1)) {
 		if (options.secure) {
 			secret = components(rep_plain, len);
-			printf("%-16s (%s%s%s%s%s)\n", secret,
+			printf("%-16s (%s%s%s%s%s)     \n", secret,
 			       ADM_START, login, uid_sep, uid_out, ADM_END);
 		} else {
 			char spacer[] = "                ";
 
 			spacer[len > 16 ? 0 : 16 - len] = 0;
 
-			printf("%s%s%s%s (%s%s%s%s%s%s)\n", ADM_START, rep_plain, ADM_END,
+			printf("%s%s%s%s (%s%s%s%s%s%s)     \n", ADM_START, rep_plain, ADM_END,
 			       spacer, ADM_START, login, ADM_END,
 			       uid_sep, uid_out, terminal_reset);
 

--- a/src/signals.c
+++ b/src/signals.c
@@ -55,7 +55,7 @@
 #include "john_mpi.h"
 
 volatile int event_pending = 0, event_reload = 0;
-volatile int event_abort = 0, event_save = 0, event_status = 0;
+volatile int event_abort = 0, event_save = 0, event_status = 0, event_delayed_status = 0;
 volatile int event_ticksafety = 0;
 volatile int event_mpiprobe = 0, event_poll_files = 0;
 
@@ -427,6 +427,9 @@ static void sig_handle_timer(int signum)
 					verb_msg[14] += options.verbosity;
 					write_loop(2, verb_msg, sizeof(verb_msg) - 1);
 				}
+			} else if (c == 'd') {
+				event_delayed_status = 1;
+				write_loop(2, "Delayed status pending...\r", 26);
 #endif
 			} else {
 #if OS_FORK

--- a/src/signals.h
+++ b/src/signals.h
@@ -35,6 +35,7 @@ extern volatile int event_abort;	/* Abort requested */
 extern volatile int event_reload;	/* Reload of pot file requested */
 extern volatile int event_save;		/* Save the crash recovery file */
 extern volatile int event_status;	/* Status display requested */
+extern volatile int event_delayed_status;	/* Status display requested after current batch */
 extern volatile int event_ticksafety;	/* System time in ticks may overflow */
 #ifdef HAVE_MPI
 extern volatile int event_mpiprobe;	/* MPI probe for messages requested */

--- a/src/single.c
+++ b/src/single.c
@@ -786,6 +786,8 @@ static void single_run(void)
 	do {
 		rec_rule[1] = min[1] = rules_stacked_number;
 		while ((prerule = rpp_next(rule_ctx))) {
+			int sc = single_db->salt_count;
+
 			if (options.node_count && strncmp(prerule, "!!", 2)) {
 				int for_node = rule_number % options.node_count + 1;
 				if (for_node < options.node_min ||
@@ -849,6 +851,12 @@ static void single_run(void)
 				if (salt->keys->rule[1] < min[1])
 					min[1] = salt->keys->rule[1];
 			} while ((salt = salt->next));
+
+			if (event_delayed_status || (single_db->salt_count < sc && john_main_process &&
+			                             cfg_get_bool(SECTION_OPTIONS, NULL, "ShowSaltProgress", 0))) {
+				event_delayed_status = 0;
+				event_status = event_pending = 1;
+			}
 
 			if (event_reload && single_db->salts)
 				crk_reload_pot();


### PR DESCRIPTION
Make keypress 'd' special: It will also emit a status line, but not until the current batch has been ran against all salts.  Under some circumstances that make take a good while.

Some reasons to wanting this is you'll get a correct p/s figure as early as possible, or you can just get a feel for just how long each batch of candidates takes to process.