### PR TITLE
Improve "stdin vs. keyboard vs. message"

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -136,6 +136,11 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   a legacy internal codepage, convert them to that codepage.  Mask mode already
   had the corresponding feature.  [magnum; 2020]
 
+- Improve handling of using stdin or pipe vs. reading keystrokes.  This
+  includes a new option --force-keys that will set the terminal up for
+  reading status/quit keystrokes even if we're not the foreground process.
+  [magnum; 2020]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -57,6 +57,12 @@ very large, sorting it will speed up loading.
 These are used to enable the wordlist mode.  If FILE is not specified,
 the one defined in john.conf will be used.
 
+--force-keys
+
+Set the terminal up for reading status/quit keystrokes even if we're not
+the foreground process.  The downside is we might get race conditions so
+you may end up with strange problems hard to reproduce.
+
 --dupe-suppression		suppress all duplicates from wordlist
 
 Normally, consecutive duplicates are ignored when reading a wordlist file.

--- a/src/cracker.c
+++ b/src/cracker.c
@@ -66,6 +66,7 @@
 #include "gpu_common.h"
 #endif
 #include "rules.h"
+#include "tty.h"
 
 #ifdef index
 #undef index
@@ -125,9 +126,13 @@ static void crk_init_salt(void)
 static void crk_help(void)
 {
 	static int printed = 0;
-	if (!john_main_process || printed ||
-	    ((options.flags & FLG_STDOUT) && isatty(fileno(stdout))))
+
+	if (!john_main_process || printed)
 		return;
+
+	if ((options.flags & FLG_STDOUT) && isatty(fileno(stdout)))
+		return;
+
 #ifdef HAVE_MPI
 	if (mpi_p > 1 || getenv("OMPI_COMM_WORLD_SIZE"))
 #ifdef SIGUSR1
@@ -137,16 +142,16 @@ static void crk_help(void)
 #endif
 	else
 #endif
-	if ((options.flags & FLG_STDIN_CHK) || (options.flags & FLG_PIPE_CHK))
+	if (tty_has_keyboard())
+		fprintf(stderr, "Press 'q' or Ctrl-C to abort, almost any other key for status\n");
+	else
 		fprintf(stderr, "Press Ctrl-C to abort, "
 #ifdef SIGUSR1
 		        "or send SIGUSR1 to john process for status\n");
 #else
 		        "or send SIGHUP to john process for status\n");
 #endif
-	else
-	fprintf(stderr, "Press 'q' or Ctrl-C to abort, "
-	    "almost any other key for status\n");
+
 	printed = 1;
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -290,6 +290,7 @@ static struct opt_entry opt_list[] = {
 		~FLG_MASK_CHK & ~OPT_REQ_PARAM, "%d", &benchmark_time},
 	{"tune", FLG_ZERO, 0, 0, OPT_REQ_PARAM,
 		OPT_FMT_STR_ALLOC, &options.tune},
+	{"force-keys", FLG_FORCE_KEYS},
 	{NULL}
 };
 
@@ -441,7 +442,9 @@ JOHN_USAGE_FORK \
 "--input-encoding=NAME      input encoding (alias for --encoding)\n" \
 "--internal-codepage=NAME   codepage used in rules/masks (see doc/ENCODINGS)\n" \
 "--target-encoding=NAME     output encoding (used by format, see doc/ENCODINGS)\n" \
-"--tune=HOW                 tuning options (auto/report/N)\n"
+"--tune=HOW                 tuning options (auto/report/N)\n" \
+"--force-keys               set up terminal for reading keystrokes even if we're\n" \
+"                           not the foreground process\n"
 
 #define JOHN_USAGE_FORMAT \
 "--format=[NAME|CLASS][,..] force hash of type NAME. The supported formats can\n" \

--- a/src/options.h
+++ b/src/options.h
@@ -189,6 +189,8 @@
 /* Ignore NOP rules */
 #define FLG_RULE_SKIP_NOP		0x0800000000000000ULL
 #define FLG_NO_MASK_BENCH		0x1000000000000000ULL
+/* Configure terminal for reading keystrokes even if we're not the foreground process */
+#define FLG_FORCE_KEYS			0x2000000000000000ULL
 
 /*
  * Macro for getting correct node number regardless of if MPI or not

--- a/src/tty.h
+++ b/src/tty.h
@@ -17,6 +17,11 @@
 #include "options.h"
 
 /*
+ * Returns true if we set up terminal for reading keystrokes
+ */
+extern int tty_has_keyboard(void);
+
+/*
  * Initializes the terminal for unbuffered non-blocking input. Also registers
  * tty_done() via atexit().
  * stdin_mode indicates whether we're running with "--stdin" (reading candidate


### PR DESCRIPTION
Add option --force-keys for enabling it even if we're not the foreground process, for use with pipes and inside front-end scripts. Ensure the "Press 'q' to abort (...)" message really reflects whether we have the terminal set up for reading keystrokes or not.

Closes #4403