### PR TITLE
Enhance --salt option for optionally loading n best salts

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -148,6 +148,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Add command-line option --loader-dupecheck=<yes/no>, overriding config file.
   Mark the latter as deprecated in config file comments.  [magnum; 2020]
 
+- Add alternative syntax to --salts option for loading "N most populated
+  salts" as opposed to "salts having at least N hashes"  [magnum; 2020]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -145,6 +145,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   the current batch has been run among all salts.  Under some circumstances
   that make take a good while.  [magnum; 2020]
 
+- Add command-line option --loader-dupecheck=<yes/no>, overriding config file.
+  Mark the latter as deprecated in config file comments.  [magnum; 2020]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -270,15 +270,21 @@ In Jumbo, the --users/groups/shells options above allow a single wildcard
 text matching also becomes case insensitive.
 
 --salts=[-]N[:MAX]		load salts with[out] at least N passwords
+--salts=#M[-N]			load M [to N] most populated salts
 
-This is a feature which allows to achieve better performance in some
-special cases.  For example, you can crack only some salts using
-"--salts=2" faster and then crack the rest using "--salts=-2".  Total
-cracking time will be about the same, but you will likely get some
-passwords cracked earlier.  If MAX is listed, then no hashes are
-loaded where there are more than MAX salts.  This is so that if you
-have run --salts=25 and then later can run --salts=10:24 and none of
-the hashes that were already done from the --salts=25 will be re-done.
+This feature aids in exploiting re-used salts.  For example, you can attack
+all re-used salts using "--salts=2" faster and then crack the rest using
+"--salts=-2".  Total cracking time will be about the same but you will
+likely get some passwords cracked earlier.  If MAX is listed, then no
+salts having more than MAX hashes are loaded.  This is so that if you have
+run --salts=25 you can later run --salts=10:24 for excluding the salts
+already attacked.
+Alternative #M syntax:  Instead of requiring a certain number of hashes
+per salt, we simply say "load the most re-used salt" or "load the M to N
+most re-used salts".
+Regardless of syntax, the re-use counts are considered before sorting out
+already cracked hashes, so a resume or a later attack using same --salts
+option will pick the same set.
 
 --costs=[-]Cn[:Mn][,...]	load salts with[out] cost value Cn [to Mn]
 				for tunable cost parameters

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -50,6 +50,19 @@ this option would have the same result as having that word in the gecos
 field of all users named "root" in the input file.  If the wordlist is
 very large, sorting it will speed up loading.
 
+--single-retest-guess=BOOL
+
+Override config file setting for SingleRetestGuess.  Setting this to false
+stops Single mode from re-testing guessed plaintexts with all other salts.
+This is normally only needed for attacking massive, salted, input files
+eg. where you intend to use the --loopback option later instead.
+
+--loader-dupecheck=BOOL
+
+Disable the dupe checking when loading hashes.  This can be used when
+loading massive input files that you know don't contain any dupes, for
+speedup.
+
 --wordlist[=FILE]		wordlist mode, read words from FILE,
 --stdin				or from stdin
 --pipe				much like stdin, but supports rules
@@ -82,9 +95,12 @@ attacked.  Note that by default, some rules are applied too (see john.conf
 "LoopbackRules").  To disable that for a run, just use --rules=none.
 
 --encoding=NAME
+--input-encoding=NAME
+--target-encoding=NAME
+--internal-codepage=NAME
 
-Input data in a character encoding other than the default.  See also
-doc/ENCODINGS.  --list=encodings gives a list of supported encodings.
+Expect/use a character encoding other than the default.  See doc/ENCODINGS.
+Use --list=encodings for a list of supported encodings.
 
 --rules[=(SECTION[,..]|:rule[;..])]
 

--- a/run/john.conf
+++ b/run/john.conf
@@ -172,7 +172,8 @@ SingleSkipLogin = N
 SingleWordsPairMax = 6
 
 # Setting this to false stops Single mode from re-testing guessed plaintexts
-# with all other salts.
+# with all other salts.  This is deprecated: Use command-line per-session
+# option --single-retest-guess=no instead.
 SingleRetestGuessed = Y
 
 # Max recursion depth for SingleRetestGuessed, so we don't blow the stack
@@ -239,6 +240,7 @@ ShowRemainOnStatus = N
 LogCrackedPasswords = N
 
 # Disable the dupe checking when loading hashes. For testing purposes only!
+# This is deprecated: Use per-session option --loader-dupecheck=no instead.
 NoLoaderDupeCheck = N
 
 # Default encoding for input files (ie. login/GECOS fields) and wordlists

--- a/src/jumbo.h
+++ b/src/jumbo.h
@@ -438,7 +438,7 @@ extern int check_pkcs_pad(const unsigned char* data, size_t len, int blocksize);
  * Parse string for boolean. Case insensitive:
  * y/yes/true/1: return 1
  * n/no/false/0: return 0
- * None of the above: return -1
+ * None of the above (including string == NULL): return -1
  */
 extern int parse_bool(char *string);
 

--- a/src/loader.h
+++ b/src/loader.h
@@ -197,8 +197,11 @@ struct db_options {
 /* Filters to use while loading */
 	struct list_main *users, *groups, *shells;
 
-/* Requested passwords per salt */
+/* Requested passwords per salt (load salts having at least [M:]N hashes) */
 	int min_pps, max_pps;
+
+/* If this is true, min/max_pps refers to "best counts" (load the [M-]N most used salts) */
+	int best_pps;
 
 #ifndef BENCH_BUILD
 /* Requested cost values */

--- a/src/options.c
+++ b/src/options.c
@@ -240,6 +240,8 @@ static struct opt_entry opt_list[] = {
 		OPT_FMT_STR_ALLOC, &field_sep_char_str},
 	{"config", FLG_ZERO, 0, 0, OPT_REQ_PARAM,
 		OPT_FMT_STR_ALLOC, &options.config},
+	{"loader-dupecheck", FLG_ZERO, 0, 0, OPT_REQ_PARAM,
+		OPT_FMT_STR_ALLOC, &options.loader_dupecheck},
 	{"nolog", FLG_NOLOG, FLG_NOLOG}, // Deprecated!
 	{"no-log", FLG_NOLOG, FLG_NOLOG},
 	{"no-mask", FLG_NO_MASK_BENCH, FLG_NO_MASK_BENCH, FLG_TEST_CHK,
@@ -424,6 +426,7 @@ JOHN_USAGE_REGEX \
 "--fix-state-delay=N        performance tweak, see doc/OPTIONS\n" \
 "--config=FILE              use FILE instead of john.conf or john.ini\n" \
 "--log-stderr               log to screen instead of file\n"             \
+"--loader-dupecheck=yes     disable the dupe checking when loading hashes\n" \
 "--verbosity=N              change verbosity (1-%u or %u for debug, default %u)\n" \
 "--no-log                   disables creation and writing to john.log file\n"      \
 "--bare-always-valid=Y      treat bare hashes as valid (Y/N)\n" \

--- a/src/options.h
+++ b/src/options.h
@@ -260,6 +260,9 @@ struct options_main {
 /* Override config's SingleRetestGuess */
 	char *single_retest_guess;
 
+/* Override (deprecated) NoLoaderDupeCheck config option */
+	char *loader_dupecheck;
+
 /* Configuration file name */
 	char *config;
 


### PR DESCRIPTION
```
--salts=#M[-N]			load M [to N] most populated salts
```

Alternative #M syntax:  Instead of requiring a certain number of hashes per salt, we simply say "load the most re-used salt" or "load the M to N most re-used salts".

Regardless of old or new syntax, the re-use counts are considered before sorting out already cracked hashes, so a resume or a later attack using same --salts option will pick the same set. (Edit: this fact is not new)

Closes #4407 