### PR TITLE
docs: fix simple typo, rouines -> routines

### DIFF
--- a/src/idea-JtR.h
+++ b/src/idea-JtR.h
@@ -32,7 +32,7 @@
  *    must display the following acknowledgment:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgment:

--- a/src/idea_plug.c
+++ b/src/idea_plug.c
@@ -32,7 +32,7 @@
  *    must display the following acknowledgment:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgment:
@@ -481,7 +481,7 @@ void JtR_idea_encrypt(unsigned long *d, IDEA_KEY_SCHEDULE *key)
  *    must display the following acknowledgment:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgment:
@@ -600,7 +600,7 @@ void JtR_idea_cfb64_encrypt(const unsigned char *in, unsigned char *out,
  *    must display the following acknowledgment:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgment:
@@ -680,7 +680,7 @@ void JtR_idea_ecb_encrypt(const unsigned char *in, unsigned char *out,
  *    must display the following acknowledgment:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgment:
@@ -788,7 +788,7 @@ void JtR_idea_ofb64_encrypt(const unsigned char *in, unsigned char *out,
  *    must display the following acknowledgment:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgment:

--- a/src/mdc2-JtR.h
+++ b/src/mdc2-JtR.h
@@ -32,7 +32,7 @@
  *    must display the following acknowledgment:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgment:

--- a/src/mdc2dgst_plug.c
+++ b/src/mdc2dgst_plug.c
@@ -32,7 +32,7 @@
  *    must display the following acknowledgment:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgment:


### PR DESCRIPTION
There is a small typo in src/idea-JtR.h, src/idea_plug.c, src/mdc2-JtR.h, src/mdc2dgst_plug.c.

Should read `routines` rather than `rouines`.

