### PR TITLE
DES_bs: Cleanup Deepika's "single DES encryption with no salt"

### DIFF
--- a/src/DES_bs.c
+++ b/src/DES_bs.c
@@ -503,7 +503,6 @@ int DES_bs_cmp_all(uint32_t *binary, int count)
 		mask = b[0] START ^ -(value & 1);
 		mask |= b[1] START ^ -((value >> 1) & 1);
 		mask |= b[2] START ^ -((value >> 2) & 1);
-		if (mask == ~(ARCH_WORD)0) goto next_depth;
 		mask |= b[3] START ^ -((value >> 3) & 1);
 		if (mask == ~(ARCH_WORD)0) goto next_depth;
 		value >>= 4;

--- a/src/DES_bs.c
+++ b/src/DES_bs.c
@@ -601,3 +601,18 @@ int DES_bs_get_hash_5t(int index)
 {
 	return DES_bs_get_hash(index, 27, 1);
 }
+
+void DES_bs_generate_plaintext(unsigned char *plaintext)
+{
+	int i;
+#if DES_BS_VECTOR
+	int depth;
+#endif
+
+	/* Set same plaintext for all bit layers */
+	for (i = 0; i < 64; i++) {
+		ARCH_WORD value = -(ARCH_WORD)((plaintext[i >> 3] >> (7 - (i & 7))) & 1);
+		for_each_depth()
+			DES_bs_P[i] DEPTH = value;
+	}
+}

--- a/src/DES_bs.h
+++ b/src/DES_bs.h
@@ -77,9 +77,8 @@ typedef struct {
 	DES_bs_vector *Ens[48];	/* Pointers into B[] for non-salted E */
 } DES_bs_combined;
 
-//store plaintext//
+/* Plaintext for single DES encryption with no salt */
 extern DES_bs_vector DES_bs_P[64];
-
 
 #if defined(_OPENMP) && !DES_BS_ASM
 #define DES_bs_mt			1

--- a/src/DES_bs_b.c
+++ b/src/DES_bs_b.c
@@ -1272,6 +1272,7 @@ next_batch:
 	return keys_count;
 }
 
+/* Single DES encryption with no salt */
 
 #if DES_bs_mt
 static MAYBE_INLINE void DES_bs_finalize_keys_plain(int t)
@@ -1284,44 +1285,22 @@ static MAYBE_INLINE void DES_bs_finalize_keys_plain(void)
 #endif
 
 	for_each_depth_k() {
-      DES_bs_vector *kp = (DES_bs_vector *)&DES_bs_all.K[0] DEPTH_K;
-      int ic;
-      for (ic = 0; ic < 8; ic++) {
-               DES_bs_vector *vp =
-               (DES_bs_vector *)&DES_bs_all.xkeys.v[ic][0] DEPTH_K;
-               LOAD_V
-               FINALIZE_NEXT_KEY_BIT_0
-               FINALIZE_NEXT_KEY_BIT_1
-               FINALIZE_NEXT_KEY_BIT_2
-               FINALIZE_NEXT_KEY_BIT_3
-               FINALIZE_NEXT_KEY_BIT_4
-               FINALIZE_NEXT_KEY_BIT_5
-               FINALIZE_NEXT_KEY_BIT_6
-              }
+		DES_bs_vector *kp = (DES_bs_vector *)&DES_bs_all.K[0] DEPTH_K;
+		int ic;
+		for (ic = 0; ic < 8; ic++) {
+			DES_bs_vector *vp =
+			    (DES_bs_vector *)&DES_bs_all.xkeys.v[ic][0] DEPTH_K;
+			LOAD_V
+			FINALIZE_NEXT_KEY_BIT_0
+			FINALIZE_NEXT_KEY_BIT_1
+			FINALIZE_NEXT_KEY_BIT_2
+			FINALIZE_NEXT_KEY_BIT_3
+			FINALIZE_NEXT_KEY_BIT_4
+			FINALIZE_NEXT_KEY_BIT_5
+			FINALIZE_NEXT_KEY_BIT_6
+		}
 	}
 }
-
-#undef v1
-#undef v2
-#undef v3
-#undef v5
-#undef v6
-#undef v7
-
-
-/* Single Des Encryption with no salt */
-#undef kd
-#if DES_BS_VECTOR_LOOPS
-#define kd				[depth]
-#else
-#define kd				[0]
-#endif
-
-#if DES_BS_VECTOR
-#define INDX [index]
-#else
-#define INDX
-#endif
 
 void DES_bs_crypt_plain(int keys_count)
 {
@@ -1329,28 +1308,25 @@ void DES_bs_crypt_plain(int keys_count)
 	int t, n = (keys_count + (DES_BS_DEPTH - 1)) / DES_BS_DEPTH;
 #endif
 
-
 #ifdef _OPENMP
-#pragma omp parallel for default(none) private(t) shared(n, DES_bs_all_p, keys_count, DES_bs_P)
+#pragma omp parallel for default(none) private(t) shared(n, DES_bs_all_p, DES_bs_P)
 #endif
 	for_each_t(n) {
-			ARCH_WORD **k;
-			int rounds;
-	#if DES_BS_VECTOR_LOOPS
-			int depth;
-	#endif
-			int i;
-	#if DES_BS_VECTOR
-		int index;
-	#endif
+		ARCH_WORD **k;
+		int rounds;
+#if DES_BS_VECTOR
+		int depth;
+#endif
+		int i;
 
-	for (i=0; i<64; i++)
-	{
-	#if DES_BS_VECTOR
-                for (index=0; index<DES_BS_VECTOR_SIZE; index++)
-	#endif
-			DES_bs_all.B[i]INDX = DES_bs_P[i]INDX;
-	}
+		for (i = 0; i < 64; i++) {
+#if DES_BS_VECTOR
+			for (depth = 0; depth < DES_BS_VECTOR; depth++)
+				DES_bs_all.B[i][depth] = DES_bs_P[i][depth];
+#else
+			DES_bs_all.B[i] = DES_bs_P[i];
+#endif
+		}
 
 #if DES_bs_mt
 		DES_bs_finalize_keys_plain(t);
@@ -1358,106 +1334,79 @@ void DES_bs_crypt_plain(int keys_count)
 		DES_bs_finalize_keys_plain();
 #endif
 
-	k = DES_bs_all.KS.p;
-	rounds = 8;
+		k = DES_bs_all.KS.p;
+		rounds = 8;
 
-	do {
-		for_each_depth()
-		s1(y(31, 0), y(0, 1), y(1, 2),
-			y(2, 3), y(3, 4), y(4, 5),
-			z(40), z(48), z(54), z(62));
-		for_each_depth()
-		s2(y(3, 6), y(4, 7), y(5, 8),
-			y(6, 9), y(7, 10), y(8, 11),
-			z(44), z(59), z(33), z(49));
-		for_each_depth()
-		s3(y(7, 12), y(8, 13), y(9, 14),
-			y(10, 15), y(11, 16), y(12, 17),
-			z(55), z(47), z(61), z(37));
-		for_each_depth()
-		s4(y(11, 18), y(12, 19), y(13, 20),
-			y(14, 21), y(15, 22), y(16, 23),
-			z(57), z(51), z(41), z(32));
-		for_each_depth()
-		s5(y(15, 24), y(16, 25), y(17, 26),
-			y(18, 27), y(19, 28), y(20, 29),
-			z(39), z(45), z(56), z(34));
-		for_each_depth()
-		s6(y(19, 30), y(20, 31), y(21, 32),
-			y(22, 33), y(23, 34), y(24, 35),
-			z(35), z(60), z(42), z(50));
-		for_each_depth()
-		s7(y(23, 36), y(24, 37), y(25, 38),
-			y(26, 39), y(27, 40), y(28, 41),
-			z(63), z(43), z(53), z(38));
-		for_each_depth()
-		s8(y(27, 42), y(28, 43), y(29, 44),
-			y(30, 45), y(31, 46), y(0, 47),
-			z(36), z(58), z(46), z(52));
+		do {
+			for_each_depth()
+			s1(y(31, 0), y(0, 1), y(1, 2),
+				y(2, 3), y(3, 4), y(4, 5),
+				z(40), z(48), z(54), z(62));
+			for_each_depth()
+			s2(y(3, 6), y(4, 7), y(5, 8),
+				y(6, 9), y(7, 10), y(8, 11),
+				z(44), z(59), z(33), z(49));
+			for_each_depth()
+			s3(y(7, 12), y(8, 13), y(9, 14),
+				y(10, 15), y(11, 16), y(12, 17),
+				z(55), z(47), z(61), z(37));
+			for_each_depth()
+			s4(y(11, 18), y(12, 19), y(13, 20),
+				y(14, 21), y(15, 22), y(16, 23),
+				z(57), z(51), z(41), z(32));
+			for_each_depth()
+			s5(y(15, 24), y(16, 25), y(17, 26),
+				y(18, 27), y(19, 28), y(20, 29),
+				z(39), z(45), z(56), z(34));
+			for_each_depth()
+			s6(y(19, 30), y(20, 31), y(21, 32),
+				y(22, 33), y(23, 34), y(24, 35),
+				z(35), z(60), z(42), z(50));
+			for_each_depth()
+			s7(y(23, 36), y(24, 37), y(25, 38),
+				y(26, 39), y(27, 40), y(28, 41),
+				z(63), z(43), z(53), z(38));
+			for_each_depth()
+			s8(y(27, 42), y(28, 43), y(29, 44),
+				y(30, 45), y(31, 46), y(0, 47),
+				z(36), z(58), z(46), z(52));
 
-		for_each_depth()
-		s1(y(63, 48), y(32, 49), y(33, 50),
-			y(34, 51), y(35, 52), y(36, 53),
-			z(8), z(16), z(22), z(30));
-		for_each_depth()
-		s2(y(35, 54), y(36, 55), y(37, 56),
-			y(38, 57), y(39, 58), y(40, 59),
-			z(12), z(27), z(1), z(17));
-		for_each_depth()
-		s3(y(39, 60), y(40, 61), y(41, 62),
-			y(42, 63), y(43, 64), y(44, 65),
-			z(23), z(15), z(29), z(5));
-		for_each_depth()
-		s4(y(43, 66), y(44, 67), y(45, 68),
-			y(46, 69), y(47, 70), y(48, 71),
-			z(25), z(19), z(9), z(0));
-		for_each_depth()
-		s5(y(47, 72), y(48, 73), y(49, 74),
-			y(50, 75), y(51, 76), y(52, 77),
-			z(7), z(13), z(24), z(2));
-		for_each_depth()
-		s6(y(51, 78), y(52, 79), y(53, 80),
-			y(54, 81), y(55, 82), y(56, 83),
-			z(3), z(28), z(10), z(18));
-		for_each_depth()
-		s7(y(55, 84), y(56, 85), y(57, 86),
-			y(58, 87), y(59, 88), y(60, 89),
-			z(31), z(11), z(21), z(6));
-		for_each_depth()
-		s8(y(59, 90), y(60, 91), y(61, 92),
-			y(62, 93), y(63, 94), y(32, 95),
-			z(4), z(26), z(14), z(20));
+			for_each_depth()
+			s1(y(63, 48), y(32, 49), y(33, 50),
+				y(34, 51), y(35, 52), y(36, 53),
+				z(8), z(16), z(22), z(30));
+			for_each_depth()
+			s2(y(35, 54), y(36, 55), y(37, 56),
+				y(38, 57), y(39, 58), y(40, 59),
+				z(12), z(27), z(1), z(17));
+			for_each_depth()
+			s3(y(39, 60), y(40, 61), y(41, 62),
+				y(42, 63), y(43, 64), y(44, 65),
+				z(23), z(15), z(29), z(5));
+			for_each_depth()
+			s4(y(43, 66), y(44, 67), y(45, 68),
+				y(46, 69), y(47, 70), y(48, 71),
+				z(25), z(19), z(9), z(0));
+			for_each_depth()
+			s5(y(47, 72), y(48, 73), y(49, 74),
+				y(50, 75), y(51, 76), y(52, 77),
+				z(7), z(13), z(24), z(2));
+			for_each_depth()
+			s6(y(51, 78), y(52, 79), y(53, 80),
+				y(54, 81), y(55, 82), y(56, 83),
+				z(3), z(28), z(10), z(18));
+			for_each_depth()
+			s7(y(55, 84), y(56, 85), y(57, 86),
+				y(58, 87), y(59, 88), y(60, 89),
+				z(31), z(11), z(21), z(6));
+			for_each_depth()
+			s8(y(59, 90), y(60, 91), y(61, 92),
+				y(62, 93), y(63, 94), y(32, 95),
+				z(4), z(26), z(14), z(20));
 
-		k += 96;
-	} while (--rounds);
-}}
-#endif
-
-#ifdef INDX
-#undef INDX
-#endif
-
-#if DES_BS_VECTOR
-#define INDX [k]
-#else
-#define INDX
-#endif
-
-void DES_bs_generate_plaintext(unsigned char *plaintext)
-{
-	int i, j;
-#if DES_BS_VECTOR
-	int k;
-#endif
-
-	/* Set same plaintext for all bit layers */
-	for (i = 0; i < 64; i++) {
-		j = (int) (plaintext[i/8] >> (7-(i%8))) & 0x01;
-		if (j==1)
-				j = -1;
-#if DES_BS_VECTOR
-		for (k=0; k<DES_BS_VECTOR_SIZE; k++)
-#endif
-			DES_bs_P[i]INDX = j;
-		}
+			k += 96;
+		} while (--rounds);
+	}
 }
+
+#endif


### PR DESCRIPTION
I also included "DES_bs_cmp_all(): Drop early reject check after 3 bits (too unlikely)" in here.

Tested the cleanups by `-test -form=mschapv2-naive` and `-test -form=netntlm-naive` in a certain build. (Also made sure my deliberate breaking of this code would make those tests fail, so the code is being used there.) Let's have CI test this some more.

On a related note, it's weird we're only using this in the two "naive" formats, but are not using it for Oracle 10 yet.