### PR TITLE
Unicode substitution

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -723,7 +723,6 @@ DefaultCharset =
 (?a )?d /?d a0 'p Xpz0
 )?a (?d /?a a0 'p Xpz0
 
-
 # "Single crack" mode rules
 [List.Rules:Single]
 # Simple rules come first...
@@ -1167,6 +1166,9 @@ b1 ]
 .include [List.Rules:Extra]
 .include [List.Rules:OldOffice]
 
+# Unicode substitution rules
+.include <unisubst.conf>
+
 # For Wordlist mode and very fast hashes
 [List.Rules:Jumbo]
 .include [List.Rules:Single-Extra]
@@ -1174,6 +1176,7 @@ b1 ]
 .include [List.Rules:ShiftToggle]
 .include [List.Rules:Multiword]
 .include [List.Rules:best64]
+.include [List.Rules:UnicodeSubstitution]
 
 # KoreLogic rules
 .include <korelogic.conf>

--- a/run/unisubst.conf
+++ b/run/unisubst.conf
@@ -1,0 +1,648 @@
+# These are good rules on sites where a user ID is forced to be written as an
+# ASCII string while the real user name or firstname would have an alternative
+# Unicode form.
+# An optimization is used by overstriking the ascii char with the second byte
+# of unicode and then inserting the first one
+# For each letters, we attempt a replacement of first, second, and third
+# occurrences and up to all three occurrences.
+# There are cases too complex to be covered, for example the Icelandic
+# firstname adalradur would have the d's substituted with eth and the third a
+# with acute, we are only dealing with single letter substitution here.
+[List.Rules:LowerUnicodeSubstitution]
+# Latin small letter n with tilde
+-u /n op\xb1 ip\xc3
+-u %2n op\xb1 ip\xc3
+-u %3n op\xb1 ip\xc3
+-u /n op\xb1 ip\xc3 /n op\xb1 ip\xc3
+-u /n op\xb1 ip\xc3 %2n op\xb1 ip\xc3
+-u %2n op\xb1 ip\xc3 %2n op\xb1 ip\xc3
+-u /n op\xb1 ip\xc3 /n op\xb1 ip\xc3 /n op\xb1 ip\xc3
+# Latin small letter u with diaeresis
+-u /u op\xbc ip\xc3
+-u %2u op\xbc ip\xc3
+-u %3u op\xbc ip\xc3
+-u /u op\xbc ip\xc3 /u op\xbc ip\xc3
+-u /u op\xbc ip\xc3 %2u op\xbc ip\xc3
+-u %2u op\xbc ip\xc3 %2u op\xbc ip\xc3
+-u /u op\xbc ip\xc3 /u op\xbc ip\xc3 /u op\xbc ip\xc3
+# Latin small letter o with diaeresis
+-u /o op\xb6 ip\xc3
+-u %2o op\xb6 ip\xc3
+-u %3o op\xb6 ip\xc3
+-u /o op\xb6 ip\xc3 /o op\xb6 ip\xc3
+-u /o op\xb6 ip\xc3 %2o op\xb6 ip\xc3
+-u %2o op\xb6 ip\xc3 %2o op\xb6 ip\xc3
+-u /o op\xb6 ip\xc3 /o op\xb6 ip\xc3 /o op\xb6 ip\xc3
+# Latin small letter e with acute
+-u /e op\xa9 ip\xc3
+-u %2e op\xa9 ip\xc3
+-u %3e op\xa9 ip\xc3
+-u /e op\xa9 ip\xc3 /e op\xa9 ip\xc3
+-u /e op\xa9 ip\xc3 %2e op\xa9 ip\xc3
+-u %2e op\xa9 ip\xc3 %2e op\xa9 ip\xc3
+-u /e op\xa9 ip\xc3 /e op\xa9 ip\xc3 /e op\xa9 ip\xc3
+# Latin small letter a with diaeresis
+-u /a op\xa4 ip\xc3
+-u %2a op\xa4 ip\xc3
+-u %3a op\xa4 ip\xc3
+-u /a op\xa4 ip\xc3 /a op\xa4 ip\xc3
+-u /a op\xa4 ip\xc3 %2a op\xa4 ip\xc3
+-u %2a op\xa4 ip\xc3 %2a op\xa4 ip\xc3
+-u /a op\xa4 ip\xc3 /a op\xa4 ip\xc3 /a op\xa4 ip\xc3
+# Latin small letter c with cedilla
+-u /c op\xa7 ip\xc3
+-u %2c op\xa7 ip\xc3
+-u %3c op\xa7 ip\xc3
+-u /c op\xa7 ip\xc3 /c op\xa7 ip\xc3
+-u /c op\xa7 ip\xc3 %2c op\xa7 ip\xc3
+-u %2c op\xa7 ip\xc3 %2c op\xa7 ip\xc3
+-u /c op\xa7 ip\xc3 /c op\xa7 ip\xc3 /c op\xa7 ip\xc3
+# Latin small letter a with acute
+-u /a op\xa1 ip\xc3
+-u %2a op\xa1 ip\xc3
+-u %3a op\xa1 ip\xc3
+-u /a op\xa1 ip\xc3 /a op\xa1 ip\xc3
+-u /a op\xa1 ip\xc3 %2a op\xa1 ip\xc3
+-u %2a op\xa1 ip\xc3 %2a op\xa1 ip\xc3
+-u /a op\xa1 ip\xc3 /a op\xa1 ip\xc3 /a op\xa1 ip\xc3
+# Latin small letter o with stroke
+-u /o op\xb8 ip\xc3
+-u %2o op\xb8 ip\xc3
+-u %3o op\xb8 ip\xc3
+-u /o op\xb8 ip\xc3 /o op\xb8 ip\xc3
+-u /o op\xb8 ip\xc3 %2o op\xb8 ip\xc3
+-u %2o op\xb8 ip\xc3 %2o op\xb8 ip\xc3
+-u /o op\xb8 ip\xc3 /o op\xb8 ip\xc3 /o op\xb8 ip\xc3
+# Latin small letter a with ring above
+-u /a op\xa5 ip\xc3
+-u %2a op\xa5 ip\xc3
+-u %3a op\xa5 ip\xc3
+-u /a op\xa5 ip\xc3 /a op\xa5 ip\xc3
+-u /a op\xa5 ip\xc3 %2a op\xa5 ip\xc3
+-u %2a op\xa5 ip\xc3 %2a op\xa5 ip\xc3
+-u /a op\xa5 ip\xc3 /a op\xa5 ip\xc3 /a op\xa5 ip\xc3
+# Latin small letter o with acute
+-u /o op\xb3 ip\xc3
+-u %2o op\xb3 ip\xc3
+-u %3o op\xb3 ip\xc3
+-u /o op\xb3 ip\xc3 /o op\xb3 ip\xc3
+-u /o op\xb3 ip\xc3 %2o op\xb3 ip\xc3
+-u %2o op\xb3 ip\xc3 %2o op\xb3 ip\xc3
+-u /o op\xb3 ip\xc3 /o op\xb3 ip\xc3 /o op\xb3 ip\xc3
+# Latin small letter sharp s
+-u %2s vap1 =as oa\xc3 op\x9f
+-u %3s vap1 =as oa\xc3 op\x9f
+# Latin small letter e with grave
+-u /e op\xa8 ip\xc3
+-u %2e op\xa8 ip\xc3
+-u %3e op\xa8 ip\xc3
+-u /e op\xa8 ip\xc3 /e op\xa8 ip\xc3
+-u /e op\xa8 ip\xc3 %2e op\xa8 ip\xc3
+-u %2e op\xa8 ip\xc3 %2e op\xa8 ip\xc3
+-u /e op\xa8 ip\xc3 /e op\xa8 ip\xc3 /e op\xa8 ip\xc3
+# Latin small letter i with acute
+-u /i op\xad ip\xc3
+-u %2i op\xad ip\xc3
+-u %3i op\xad ip\xc3
+-u /i op\xad ip\xc3 /i op\xad ip\xc3
+-u /i op\xad ip\xc3 %2i op\xad ip\xc3
+-u %2i op\xad ip\xc3 %2i op\xad ip\xc3
+-u /i op\xad ip\xc3 /i op\xad ip\xc3 /i op\xad ip\xc3
+# Latin small letter a with tilde
+-u /a op\xa3 ip\xc3
+-u %2a op\xa3 ip\xc3
+-u %3a op\xa3 ip\xc3
+-u /a op\xa3 ip\xc3 /a op\xa3 ip\xc3
+-u /a op\xa3 ip\xc3 %2a op\xa3 ip\xc3
+-u %2a op\xa3 ip\xc3 %2a op\xa3 ip\xc3
+-u /a op\xa3 ip\xc3 /a op\xa3 ip\xc3 /a op\xa3 ip\xc3
+# Latin small letter a with grave
+-u /a op\xa0 ip\xc3
+-u %2a op\xa0 ip\xc3
+-u %3a op\xa0 ip\xc3
+-u /a op\xa0 ip\xc3 /a op\xa0 ip\xc3
+-u /a op\xa0 ip\xc3 %2a op\xa0 ip\xc3
+-u %2a op\xa0 ip\xc3 %2a op\xa0 ip\xc3
+-u /a op\xa0 ip\xc3 /a op\xa0 ip\xc3 /a op\xa0 ip\xc3
+# Latin small letter u with acute
+-u /u op\xba ip\xc3
+-u %2u op\xba ip\xc3
+-u %3u op\xba ip\xc3
+-u /u op\xba ip\xc3 /u op\xba ip\xc3
+-u /u op\xba ip\xc3 %2u op\xba ip\xc3
+-u %2u op\xba ip\xc3 %2u op\xba ip\xc3
+-u /u op\xba ip\xc3 /u op\xba ip\xc3 /u op\xba ip\xc3
+# Latin small letter s with caron
+-u /s op\xa1 ip\xc5
+-u %2s op\xa1 ip\xc5
+-u %3s op\xa1 ip\xc5
+-u /s op\xa1 ip\xc5 /s op\xa1 ip\xc5
+-u /s op\xa1 ip\xc5 %2s op\xa1 ip\xc5
+-u %2s op\xa1 ip\xc5 %2s op\xa1 ip\xc5
+-u /s op\xa1 ip\xc5 /s op\xa1 ip\xc5 /s op\xa1 ip\xc5
+# section separator
+-u /s op\xa7 ip\xc2
+-u %2s op\xa7 ip\xc2
+-u %3s op\xa7 ip\xc2
+-u /s op\xa7 ip\xc2 /s op\xa7 ip\xc2
+-u /s op\xa7 ip\xc2 %2s op\xa7 ip\xc2
+-u %2s op\xa7 ip\xc2 %2s op\xa7 ip\xc2
+-u /s op\xa7 ip\xc2 /s op\xa7 ip\xc2 /s op\xa7 ip\xc2
+# Latin small letter ae
+-u /e vap1 =aa oa\xc3 op\xa6
+-u %2e vap1 =aa oa\xc3 op\xa6
+-u %3e vap1 =aa oa\xc3 op\xa6
+# Latin small letter y with acute
+-u /y op\xbd ip\xc3
+-u %2y op\xbd ip\xc3
+-u %3y op\xbd ip\xc3
+-u /y op\xbd ip\xc3 /y op\xbd ip\xc3
+-u /y op\xbd ip\xc3 %2y op\xbd ip\xc3
+-u %2y op\xbd ip\xc3 %2y op\xbd ip\xc3
+-u /y op\xbd ip\xc3 /y op\xbd ip\xc3 /y op\xbd ip\xc3
+# Latin small letter u with grave
+-u /u op\xb9 ip\xc3
+-u %2u op\xb9 ip\xc3
+-u %3u op\xb9 ip\xc3
+-u /u op\xb9 ip\xc3 /u op\xb9 ip\xc3
+-u /u op\xb9 ip\xc3 %2u op\xb9 ip\xc3
+-u %2u op\xb9 ip\xc3 %2u op\xb9 ip\xc3
+-u /u op\xb9 ip\xc3 /u op\xb9 ip\xc3 /u op\xb9 ip\xc3
+# Latin small letter o with grave
+-u /o op\xb2 ip\xc3
+-u %2o op\xb2 ip\xc3
+-u %3o op\xb2 ip\xc3
+-u /o op\xb2 ip\xc3 /o op\xb2 ip\xc3
+-u /o op\xb2 ip\xc3 %2o op\xb2 ip\xc3
+-u %2o op\xb2 ip\xc3 %2o op\xb2 ip\xc3
+-u /o op\xb2 ip\xc3 /o op\xb2 ip\xc3 /o op\xb2 ip\xc3
+# Latin small letter e with circumflex
+-u /e op\xaa ip\xc3
+-u %2e op\xaa ip\xc3
+-u %3e op\xaa ip\xc3
+-u /e op\xaa ip\xc3 /e op\xaa ip\xc3
+-u /e op\xaa ip\xc3 %2e op\xaa ip\xc3
+-u %2e op\xaa ip\xc3 %2e op\xaa ip\xc3
+-u /e op\xaa ip\xc3 /e op\xaa ip\xc3 /e op\xaa ip\xc3
+# Latin small letter i with grave
+-u /i op\xac ip\xc3
+-u %2i op\xac ip\xc3
+-u %3i op\xac ip\xc3
+-u /i op\xac ip\xc3 /i op\xac ip\xc3
+-u /i op\xac ip\xc3 %2i op\xac ip\xc3
+-u %2i op\xac ip\xc3 %2i op\xac ip\xc3
+-u /i op\xac ip\xc3 /i op\xac ip\xc3 /i op\xa2 ip\xc3
+# Latin small letter z with caron
+-u /z op\xbe ip\xc5
+-u %2z op\xbe ip\xc5
+-u %3z op\xbe ip\xc5
+-u /z op\xbe ip\xc5 /z op\xbe ip\xc5
+-u /z op\xbe ip\xc5 %2z op\xbe ip\xc5
+-u %2z op\xbe ip\xc5 %2z op\xbe ip\xc5
+-u /z op\xbe ip\xc5 /z op\xbe ip\xc5 /z op\xbe ip\xc5
+# Euro sign (e replacement)
+-u /e op\xac ip\x82 ip\xe2
+-u %2e op\xac ip\x82 ip\xe2
+-u %3e op\xac ip\x82 ip\xe2
+-u /e op\xac ip\x82 ip\xe2 /e op\xac ip\x82 ip\xe2
+-u /e op\xac ip\x82 ip\xe2 %2e op\xac ip\x82 ip\xe2
+-u %2e op\xac ip\x82 ip\xe2 %2e op\xac ip\x82 ip\xe2
+-u /e op\xac ip\x82 ip\xe2 /e op\xac ip\x82 ip\xe2 /e op\xac ip\x82 ip\xe2
+# Latin small letter a with circumflex
+-u /a op\xa2 ip\xc3
+-u %2a op\xa2 ip\xc3
+-u %3a op\xa2 ip\xc3
+-u /a op\xa2 ip\xc3 /a op\xa2 ip\xc3
+-u /a op\xa2 ip\xc3 %2a op\xa2 ip\xc3
+-u %2a op\xa2 ip\xc3 %2a op\xa2 ip\xc3
+-u /a op\xa2 ip\xc3 /a op\xa2 ip\xc3 /a op\xa2 ip\xc3
+# Latin small letter o with circumflex
+-u /o op\xb4 ip\xc3
+-u %2o op\xb4 ip\xc3
+-u %3o op\xb4 ip\xc3
+-u /o op\xb4 ip\xc3 /o op\xb4 ip\xc3
+-u /o op\xb4 ip\xc3 %2o op\xb4 ip\xc3
+-u %2o op\xb4 ip\xc3 %2o op\xb4 ip\xc3
+-u /o op\xb4 ip\xc3 /o op\xb4 ip\xc3 /o op\xb4 ip\xc3
+# Latin small letter eth (d)
+-u /d op\xb0 ip\xc3
+-u %2d op\xb0 ip\xc3
+-u %3d op\xb0 ip\xc3
+-u /d op\xb0 ip\xc3 /d op\xb0 ip\xc3
+-u /d op\xb0 ip\xc3 %2d op\xb0 ip\xc3
+-u %2d op\xb0 ip\xc3 %2d op\xb0 ip\xc3
+-u /d op\xb0 ip\xc3 /d op\xb0 ip\xc3 /d op\xb0 ip\xc3
+# Latin small letter thorn
+-u /h vap1 =at oa\xc3 op\xbe
+-u %2h vap1 =at oa\xc3 op\xbe
+-u %3h vap1 =at oa\xc3 op\xbe
+# Latin small letter o with tilde
+-u /o op\xb5 ip\xc3
+-u %2o op\xb5 ip\xc3
+-u %3o op\xb5 ip\xc3
+-u /o op\xb5 ip\xc3 /o op\xb5 ip\xc3
+-u /o op\xb5 ip\xc3 %2o op\xb5 ip\xc3
+-u %2o op\xb5 ip\xc3 %2o op\xb5 ip\xc3
+-u /o op\xb5 ip\xc3 /o op\xb5 ip\xc3 /o op\xb5 ip\xc3
+# Latin small letter i with diaeresis
+-u /i op\xaf ip\xc3
+-u %2i op\xaf ip\xc3
+-u %3i op\xaf ip\xc3
+-u /i op\xaf ip\xc3 /i op\xaf ip\xc3
+-u /i op\xaf ip\xc3 %2i op\xaf ip\xc3
+-u %2i op\xaf ip\xc3 %2i op\xaf ip\xc3
+-u /i op\xaf ip\xc3 /i op\xaf ip\xc3 /i op\xaf ip\xc3
+# Latin small letter e with diaeresis
+-u /e op\xab ip\xc3
+-u %2e op\xab ip\xc3
+-u %3e op\xab ip\xc3
+-u /e op\xab ip\xc3 /e op\xab ip\xc3
+-u /e op\xab ip\xc3 %2e op\xab ip\xc3
+-u %2e op\xab ip\xc3 %2e op\xab ip\xc3
+-u /e op\xab ip\xc3 /e op\xab ip\xc3 /e op\xab ip\xc3
+# Latin small letter g with caron
+-u /g op\x9f ip\xc4
+-u %2g op\x9f ip\xc4
+-u %3g op\x9f ip\xc4
+-u /g op\x9f ip\xc4 /g op\x9f ip\xc4
+-u /g op\x9f ip\xc4 %2g op\x9f ip\xc4
+-u %2g op\x9f ip\xc4 %2g op\x9f ip\xc4
+-u /g op\x9f ip\xc4 /g op\x9f ip\xc4 /g op\x9f ip\xc4
+# Latin small letter c with caron
+-u /c op\x8d ip\xc4
+-u %2c op\x8d ip\xc4
+-u %3c op\x8d ip\xc4
+-u /c op\x8d ip\xc4 /c op\x8d ip\xc4
+-u /c op\x8d ip\xc4 %2c op\x8d ip\xc4
+-u %2c op\x8d ip\xc4 %2c op\x8d ip\xc4
+-u /c op\x8d ip\xc4 /c op\x8d ip\xc4 /c op\x8d ip\xc4
+# Latin small letter i with circumflex
+-u /i op\xae ip\xc3
+-u %2i op\xae ip\xc3
+-u %3i op\xae ip\xc3
+-u /i op\xae ip\xc3 /i op\xae ip\xc3
+-u /i op\xae ip\xc3 %2i op\xae ip\xc3
+-u %2i op\xae ip\xc3 %2i op\xae ip\xc3
+-u /i op\xae ip\xc3 /i op\xae ip\xc3 /i op\xae ip\xc3
+# Latin small letter mu (replacing m)
+-u /m op\xb5 ip\xc2
+-u %2m op\xb5 ip\xc2
+-u %3m op\xb5 ip\xc2
+-u /m op\xb5 ip\xc2 /m op\xb5 ip\xc2
+-u /m op\xb5 ip\xc2 %2m op\xb5 ip\xc2
+-u %2m op\xb5 ip\xc2 %2m op\xb5 ip\xc2
+-u /m op\xb5 ip\xc2 /m op\xb5 ip\xc2 /m op\xb5 ip\xc2
+# Latin small letter mu (replacing u)
+-u /u op\xb5 ip\xc2
+-u %2u op\xb5 ip\xc2
+-u %3u op\xb5 ip\xc2
+-u /u op\xb5 ip\xc2 /u op\xb5 ip\xc2
+-u /u op\xb5 ip\xc2 %2u op\xb5 ip\xc2
+-u %2u op\xb5 ip\xc2 %2u op\xb5 ip\xc2
+-u /u op\xb5 ip\xc2 /u op\xb5 ip\xc2 /u op\xb5 ip\xc2
+# Latin small letter u with circumflex
+-u /u op\xbb ip\xc3
+-u %2u op\xbb ip\xc3
+-u %3u op\xbb ip\xc3
+-u /u op\xbb ip\xc3 /u op\xbb ip\xc3
+-u /u op\xbb ip\xc3 %2u op\xbb ip\xc3
+-u %2u op\xbb ip\xc3 %2u op\xbb ip\xc3
+-u /u op\xbb ip\xc3 /u op\xbb ip\xc3 /u op\xbb ip\xc3
+# circled r
+-u /r op\xae ip\xc2
+-u %2r op\xae ip\xc2
+-u %3r op\xae ip\xc2
+-u /r op\xae ip\xc2 /r op\xae ip\xc2
+-u /r op\xae ip\xc2 %2r op\xae ip\xc2
+-u %2r op\xae ip\xc2 %2r op\xae ip\xc2
+-u /r op\xae ip\xc2 /r op\xae ip\xc2 /r op\xae ip\xc2
+# circled c
+-u /c op\xa9 ip\xc2
+-u %2c op\xa9 ip\xc2
+-u %3c op\xa9 ip\xc2
+-u /c op\xa9 ip\xc2 /c op\xa9 ip\xc2
+-u /c op\xa9 ip\xc2 %2c op\xa9 ip\xc2
+-u %2c op\xa9 ip\xc2 %2c op\xa9 ip\xc2
+-u /c op\xa9 ip\xc2 /c op\xa9 ip\xc2 /c op\xa9 ip\xc2
+# Latin small letter y with diaeresis
+-u /y op\xbf ip\xc3
+-u %2y op\xbf ip\xc3
+-u %3y op\xbf ip\xc3
+-u /y op\xbf ip\xc3 /y op\xbf ip\xc3
+-u /y op\xbf ip\xc3 %2y op\xbf ip\xc3
+-u %2y op\xbf ip\xc3 %2y op\xbf ip\xc3
+-u /y op\xbf ip\xc3 /y op\xbf ip\xc3 /y op\xbf ip\xc3
+
+[List.Rules:UpperUnicodeSubstitution]
+# Latin capital letter n with tilde
+-u /N op\x91 ip\xc3
+-u %2N op\x91 ip\xc3
+-u %3N op\x91 ip\xc3
+-u /N op\x91 ip\xc3 /N op\x91 ip\xc3
+-u /N op\x91 ip\xc3 %2N op\x91 ip\xc3
+-u %2N op\x91 ip\xc3 %2N op\x91 ip\xc3
+-u /N op\x91 ip\xc3 /N op\x91 ip\xc3 /N op\x91 ip\xc3
+# Latin capital letter u with diaeresis
+-u /U op\x9c ip\xc3
+-u %2U op\x9c ip\xc3
+-u %3U op\x9c ip\xc3
+-u /U op\x9c ip\xc3 /U op\x9c ip\xc3
+-u /U op\x9c ip\xc3 %2U op\x9c ip\xc3
+-u %2U op\x9c ip\xc3 %2U op\x9c ip\xc3
+-u /U op\x9c ip\xc3 /U op\x9c ip\xc3 /U op\x9c ip\xc3
+# Latin capital letter o with diaeresis
+-u /O op\x96 ip\xc3
+-u %2O op\x96 ip\xc3
+-u %3O op\x96 ip\xc3
+-u /O op\x96 ip\xc3 /O op\x96 ip\xc3
+-u /O op\x96 ip\xc3 %2O op\x96 ip\xc3
+-u %2O op\x96 ip\xc3 %2O op\x96 ip\xc3
+-u /O op\x96 ip\xc3 /O op\x96 ip\xc3 /O op\x96 ip\xc3
+# Latin capital letter e with acute
+-u /E op\x89 ip\xc3
+-u %2E op\x89 ip\xc3
+-u %3E op\x89 ip\xc3
+-u /E op\x89 ip\xc3 /E op\x89 ip\xc3
+-u /E op\x89 ip\xc3 %2E op\x89 ip\xc3
+-u %2E op\x89 ip\xc3 %2E op\x89 ip\xc3
+-u %2E op\x89 ip\xc3 %2E op\x89 ip\xc3
+-u /E op\x89 ip\xc3 /E op\x89 ip\xc3 /E op\x89 ip\xc3
+# Latin capital letter a with diaeresis
+-u /A op\x84 ip\xc3
+-u %2A op\x84 ip\xc3
+-u %3A op\x84 ip\xc3
+-u /A op\x84 ip\xc3 /A op\x84 ip\xc3
+-u /A op\x84 ip\xc3 %2A op\x84 ip\xc3
+-u %2A op\x84 ip\xc3 %2A op\x84 ip\xc3
+-u /A op\x84 ip\xc3 /A op\x84 ip\xc3 /A op\x84 ip\xc3
+# Latin capital letter c with cedilla
+-u /C op\x87 ip\xc3
+-u %2C op\x87 ip\xc3
+-u %3C op\x87 ip\xc3
+-u /C op\x87 ip\xc3 /C op\x87 ip\xc3
+-u /C op\x87 ip\xc3 %2C op\x87 ip\xc3
+-u %2C op\x87 ip\xc3 %2C op\x87 ip\xc3
+-u /C op\x87 ip\xc3 /C op\x87 ip\xc3 /C op\x87 ip\xc3
+# Latin capital letter a with acute
+-u /A op\x81 ip\xc3
+-u %2A op\x81 ip\xc3
+-u %3A op\x81 ip\xc3
+-u /A op\x81 ip\xc3 /A op\x81 ip\xc3
+-u /A op\x81 ip\xc3 %2A op\x81 ip\xc3
+-u %2A op\x81 ip\xc3 %2A op\x81 ip\xc3
+-u /A op\x81 ip\xc3 /A op\x81 ip\xc3 /A op\x81 ip\xc3
+# Latin capital letter o with stroke
+-u /O op\x98 ip\xc3
+-u %2O op\x98 ip\xc3
+-u %3O op\x98 ip\xc3
+-u /O op\x98 ip\xc3 /O op\x98 ip\xc3
+-u /O op\x98 ip\xc3 %2O op\x98 ip\xc3
+-u %2O op\x98 ip\xc3 %2O op\x98 ip\xc3
+-u /O op\x98 ip\xc3 /O op\x98 ip\xc3 /O op\x98 ip\xc3
+# Latin capital letter a with ring above
+-u /A op\x85 ip\xc3
+-u %2A op\x85 ip\xc3
+-u %3A op\x85 ip\xc3
+-u /A op\x85 ip\xc3 /A op\x85 ip\xc3
+-u /A op\x85 ip\xc3 %2A op\x85 ip\xc3
+-u %2A op\x85 ip\xc3 %2A op\x85 ip\xc3
+-u /A op\x85 ip\xc3 /A op\x85 ip\xc3 /A op\x85 ip\xc3
+# Latin capital letter o with acute
+-u /O op\x93 ip\xc3
+-u %2O op\x93 ip\xc3
+-u %3O op\x93 ip\xc3
+-u /O op\x93 ip\xc3 /O op\x93 ip\xc3
+-u /O op\x93 ip\xc3 %2O op\x93 ip\xc3
+-u %2O op\x93 ip\xc3 %2O op\x93 ip\xc3
+-u /O op\x93 ip\xc3 /O op\x93 ip\xc3 /O op\x93 ip\xc3
+# Latin capital letter sharp s
+-u %2S vap1 =aS oa\xc3 op\x9f
+-u %3S vap1 =aS oa\xc3 op\x9f
+# Latin capital letter e with grave
+-u /E op\x88 ip\xc3
+-u %2E op\x88 ip\xc3
+-u %3E op\x88 ip\xc3
+-u /E op\x88 ip\xc3 /E op\x88 ip\xc3
+-u /E op\x88 ip\xc3 %2E op\x88 ip\xc3
+-u %2E op\x88 ip\xc3 %2E op\x88 ip\xc3
+-u /E op\x88 ip\xc3 /E op\x88 ip\xc3 /E op\x88 ip\xc3
+# Latin capital letter i with acute
+-u /I op\x8d ip\xc3
+-u %2I op\x8d ip\xc3
+-u %3I op\x8d ip\xc3
+-u /I op\x8d ip\xc3 /I op\x8d ip\xc3
+-u /I op\x8d ip\xc3 %2I op\x8d ip\xc3
+-u %2I op\x8d ip\xc3 %2I op\x8d ip\xc3
+-u /I op\x8d ip\xc3 /I op\x8d ip\xc3 /I op\x8d ip\xc3
+# Latin capital letter a with tilde
+-u /A op\x83 ip\xc3
+-u %2A op\x83 ip\xc3
+-u %3A op\x83 ip\xc3
+-u /A op\x83 ip\xc3 /A op\x83 ip\xc3
+-u /A op\x83 ip\xc3 %2A op\x83 ip\xc3
+-u %2A op\x83 ip\xc3 %2A op\x83 ip\xc3
+-u /A op\x83 ip\xc3 /A op\x83 ip\xc3 /A op\x83 ip\xc3
+# Latin capital letter a with grave
+-u /A op\x80 ip\xc3
+-u %2A op\x80 ip\xc3
+-u %3A op\x80 ip\xc3
+-u /A op\x80 ip\xc3 /A op\x80 ip\xc3
+-u /A op\x80 ip\xc3 %2A op\x80 ip\xc3
+-u %2A op\x80 ip\xc3 %2A op\x80 ip\xc3
+-u /A op\x80 ip\xc3 /A op\x80 ip\xc3 /A op\x80 ip\xc3
+# Latin capital letter u with acute
+-u /U op\x9a ip\xc3
+-u %2U op\x9a ip\xc3
+-u %3U op\x9a ip\xc3
+-u /U op\x9a ip\xc3 /U op\x9a ip\xc3
+-u /U op\x9a ip\xc3 %2U op\x9a ip\xc3
+-u %2U op\x9a ip\xc3 %2U op\x9a ip\xc3
+-u /U op\x9a ip\xc3 /U op\x9a ip\xc3 /U op\x9a ip\xc3
+# Latin capital letter s with caron
+-u /S op\xa0 ip\xc5
+-u %2S op\xa0 ip\xc5
+-u %3S op\xa0 ip\xc5
+-u /S op\xa0 ip\xc5 /S op\xa0 ip\xc5
+-u /S op\xa0 ip\xc5 %2S op\xa0 ip\xc5
+-u %2S op\xa0 ip\xc5 %2S op\xa0 ip\xc5
+-u /S op\xa0 ip\xc5 /S op\xa0 ip\xc5 /S op\xa0 ip\xc5
+# Latin capital letter ae
+-u /E vap1 =aA oa\xc3 op\x86
+-u %2E vap1 =aA oa\xc3 op\x86
+-u %3E vap1 =aA oa\xc3 op\x86
+# Latin capital letter y with acute
+-u /Y op\x9d ip\xc3
+-u %2Y op\x9d ip\xc3
+-u %3Y op\x9d ip\xc3
+-u /Y op\x9d ip\xc3 /Y op\x9d ip\xc3
+-u /Y op\x9d ip\xc3 %2Y op\x9d ip\xc3
+-u %2Y op\x9d ip\xc3 %2Y op\x9d ip\xc3
+-u /Y op\x9d ip\xc3 /Y op\x9d ip\xc3 /Y op\x9d ip\xc3
+# Latin capital letter u with grave
+-u /U op\x99 ip\xc3
+-u %2U op\x99 ip\xc3
+-u %3U op\x99 ip\xc3
+-u /U op\x99 ip\xc3 /U op\x99 ip\xc3
+-u /U op\x99 ip\xc3 %2U op\x99 ip\xc3
+-u %2U op\x99 ip\xc3 %2U op\x99 ip\xc3
+-u /U op\x99 ip\xc3 /U op\x99 ip\xc3 /U op\x99 ip\xc3
+# Latin capital letter o with grave
+-u /O op\x92 ip\xc3
+-u %2O op\x92 ip\xc3
+-u %3O op\x92 ip\xc3
+-u /O op\x92 ip\xc3 /O op\x92 ip\xc3
+-u /O op\x92 ip\xc3 %2O op\x92 ip\xc3
+-u %2O op\x92 ip\xc3 %2O op\x92 ip\xc3
+-u /O op\x92 ip\xc3 /O op\x92 ip\xc3 /O op\x92 ip\xc3
+# Latin capital letter e with circumflex
+-u /E op\x8a ip\xc3
+-u %2E op\x8a ip\xc3
+-u %3E op\x8a ip\xc3
+-u /E op\x8a ip\xc3 /E op\x8a ip\xc3
+-u /E op\x8a ip\xc3 %2E op\x8a ip\xc3
+-u %2E op\x8a ip\xc3 %2E op\x8a ip\xc3
+-u /E op\x8a ip\xc3 /E op\x8a ip\xc3 /E op\x8a ip\xc3
+# Latin capital letter i with grave
+-u /I op\x8c ip\xc3
+-u %2I op\x8c ip\xc3
+-u %3I op\x8c ip\xc3
+-u /I op\x8c ip\xc3 /I op\x8c ip\xc3
+-u /I op\x8c ip\xc3 %2I op\x8c ip\xc3
+-u %2I op\x8c ip\xc3 %2I op\x8c ip\xc3
+-u /I op\x8c ip\xc3 /I op\x8c ip\xc3 /I op\x82 ip\xc3
+# Latin capital letter z with caron
+-u /Z op\xbd ip\xc5
+-u %2Z op\xbd ip\xc5
+-u %3Z op\xbd ip\xc5
+-u /Z op\xbd ip\xc5 /Z op\xbd ip\xc5
+-u /Z op\xbd ip\xc5 %2Z op\xbd ip\xc5
+-u %2Z op\xbd ip\xc5 %2Z op\xbd ip\xc5
+-u /Z op\xbd ip\xc5 /Z op\xbd ip\xc5 /Z op\xbd ip\xc5
+# Euro sign (e replacement)
+-u /E op\xac ip\x82 ip\xe2
+-u %2E op\xac ip\x82 ip\xe2
+-u %3E op\xac ip\x82 ip\xe2
+-u /E op\xac ip\x82 ip\xe2 /E op\xac ip\x82 ip\xe2
+-u /E op\xac ip\x82 ip\xe2 %2E op\xac ip\x82 ip\xe2
+-u %2E op\xac ip\x82 ip\xe2 %2E op\xac ip\x82 ip\xe2
+-u /E op\xac ip\x82 ip\xe2 /E op\xac ip\x82 ip\xe2 /E op\xac ip\x82 ip\xe2
+# Latin capital letter a with circumflex
+-u /A op\x82 ip\xc3
+-u %2A op\x82 ip\xc3
+-u %3A op\x82 ip\xc3
+-u /A op\x82 ip\xc3 /A op\x82 ip\xc3
+-u /A op\x82 ip\xc3 %2A op\x82 ip\xc3
+-u %2A op\x82 ip\xc3 %2A op\x82 ip\xc3
+-u /A op\x82 ip\xc3 /A op\x82 ip\xc3 /A op\x82 ip\xc3
+# Latin capital letter o with circumflex
+-u /O op\x94 ip\xc3
+-u %2O op\x94 ip\xc3
+-u %3O op\x94 ip\xc3
+-u /O op\x94 ip\xc3 /O op\x94 ip\xc3
+-u /O op\x94 ip\xc3 %2O op\x94 ip\xc3
+-u %2O op\x94 ip\xc3 %2O op\x94 ip\xc3
+-u /O op\x94 ip\xc3 /O op\x94 ip\xc3 /O op\x94 ip\xc3
+# Latin capital letter eth (d)
+-u /D op\x90 ip\xc3
+-u %2D op\x90 ip\xc3
+-u %3D op\x90 ip\xc3
+-u /D op\x90 ip\xc3 /D op\x90 ip\xc3
+-u /D op\x90 ip\xc3 %2D op\x90 ip\xc3
+-u %2D op\x90 ip\xc3 %2D op\x90 ip\xc3
+-u /D op\x90 ip\xc3 /D op\x90 ip\xc3 /D op\x90 ip\xc3
+# Latin capital letter thorn
+-u /H vap1 =aT oa\xc3 op\x9e
+-u %2H vap1 =aT oa\xc3 op\x9e
+-u %3H vap1 =aT oa\xc3 op\x9e
+# Latin capital letter o with tilde
+-u /O op\x95 ip\xc3
+-u %2O op\x95 ip\xc3
+-u %3O op\x95 ip\xc3
+-u /O op\x95 ip\xc3 /O op\x95 ip\xc3
+-u /O op\x95 ip\xc3 %2O op\x95 ip\xc3
+-u %2O op\x95 ip\xc3 %2O op\x95 ip\xc3
+-u /O op\x95 ip\xc3 /O op\x95 ip\xc3 /O op\x95 ip\xc3
+# Latin capital letter i with diaeresis
+-u /I op\x8f ip\xc3
+-u %2I op\x8f ip\xc3
+-u %3I op\x8f ip\xc3
+-u /I op\x8f ip\xc3 /I op\x8f ip\xc3
+-u /I op\x8f ip\xc3 %2I op\x8f ip\xc3
+-u %2I op\x8f ip\xc3 %2I op\x8f ip\xc3
+-u /I op\x8f ip\xc3 /I op\x8f ip\xc3 /I op\x8f ip\xc3
+# Latin capital letter e with diaeresis
+-u /E op\x8b ip\xc3
+-u %2E op\x8b ip\xc3
+-u %3E op\x8b ip\xc3
+-u /E op\x8b ip\xc3 /E op\x8b ip\xc3
+-u /E op\x8b ip\xc3 %2E op\x8b ip\xc3
+-u %2E op\x8b ip\xc3 %2E op\x8b ip\xc3
+-u /E op\x8b ip\xc3 /E op\x8b ip\xc3 /E op\x8b ip\xc3
+# Latin capital letter g with caron
+-u /G op\x9f ip\xc4
+-u %2G op\x9f ip\xc4
+-u %3G op\x9f ip\xc4
+-u /G op\x9f ip\xc4 /G op\x9f ip\xc4
+-u /G op\x9f ip\xc4 %2G op\x9f ip\xc4
+-u %2G op\x9f ip\xc4 %2G op\x9f ip\xc4
+-u /G op\x9f ip\xc4 /G op\x9f ip\xc4 /G op\x9f ip\xc4
+# Latin capital letter c with caron
+-u /C op\x8d ip\xc4
+-u %2C op\x8d ip\xc4
+-u %3C op\x8d ip\xc4
+-u /C op\x8d ip\xc4 /C op\x8d ip\xc4
+-u /C op\x8d ip\xc4 %2C op\x8d ip\xc4
+-u %2C op\x8d ip\xc4 %2C op\x8d ip\xc4
+-u /C op\x8d ip\xc4 /C op\x8d ip\xc4 /C op\x8d ip\xc4
+# Latin capital letter i with circumflex
+-u /I op\x8e ip\xc3
+-u %2I op\x8e ip\xc3
+-u %3I op\x8e ip\xc3
+-u /I op\x8e ip\xc3 /I op\x8e ip\xc3
+-u /I op\x8e ip\xc3 %2I op\x8e ip\xc3
+-u %2I op\x8e ip\xc3 %2I op\x8e ip\xc3
+-u /I op\x8e ip\xc3 /I op\x8e ip\xc3 /I op\x8e ip\xc3
+# letter mu (replacing M)
+-u /M op\xb5 ip\xc2
+-u %2M op\xb5 ip\xc2
+-u %3M op\xb5 ip\xc2
+-u /M op\xb5 ip\xc2 /M op\xb5 ip\xc2
+-u /M op\xb5 ip\xc2 %2M op\xb5 ip\xc2
+-u %2M op\xb5 ip\xc2 %2M op\xb5 ip\xc2
+-u /M op\xb5 ip\xc2 /M op\xb5 ip\xc2 /M op\xb5 ip\xc2
+# letter mu (replacing U)
+-u /U op\xb5 ip\xc2
+-u %2U op\xb5 ip\xc2
+-u %3U op\xb5 ip\xc2
+-u /U op\xb5 ip\xc2 /U op\xb5 ip\xc2
+-u /U op\xb5 ip\xc2 %2U op\xb5 ip\xc2
+-u %2U op\xb5 ip\xc2 %2U op\xb5 ip\xc2
+-u /U op\xb5 ip\xc2 /U op\xb5 ip\xc2 /U op\xb5 ip\xc2
+# Latin capital letter u with circumflex
+-u /U op\x9b ip\xc3
+-u %2U op\x9b ip\xc3
+-u %3U op\x9b ip\xc3
+-u /U op\x9b ip\xc3 /U op\x9b ip\xc3
+-u /U op\x9b ip\xc3 %2U op\x9b ip\xc3
+-u %2U op\x9b ip\xc3 %2U op\x9b ip\xc3
+-u /U op\x9b ip\xc3 /U op\x9b ip\xc3 /U op\x9b ip\xc3
+# circled r
+-u /R op\xae ip\xc2
+-u %2R op\xae ip\xc2
+-u %3R op\xae ip\xc2
+-u /R op\xae ip\xc2 /R op\xae ip\xc2
+-u /R op\xae ip\xc2 %2R op\xae ip\xc2
+-u %2R op\xae ip\xc2 %2R op\xae ip\xc2
+-u /R op\xae ip\xc2 /R op\xae ip\xc2 /R op\xae ip\xc2
+# circled c
+-u /C op\xa9 ip\xc2
+-u %2C op\xa9 ip\xc2
+-u %3C op\xa9 ip\xc2
+-u /C op\xa9 ip\xc2 /C op\xa9 ip\xc2
+-u /C op\xa9 ip\xc2 %2C op\xa9 ip\xc2
+-u %2C op\xa9 ip\xc2 %2C op\xa9 ip\xc2
+-u /C op\xa9 ip\xc2 /C op\xa9 ip\xc2 /C op\xa9 ip\xc2
+
+[List.Rules:UnicodeSubstitution]
+.include [List.Rules:LowerUnicodeSubstitution]
+.include [List.Rules:UpperUnicodeSubstitution]


### PR DESCRIPTION
These are good rules on sites where a user ID is forced to be written as an ASCII string while the real user name or firstname would have an alternative Unicode form.
An optimization is used by overwriting the ASCII character with the second byte of Unicode and then inserting the first one
For each letters, we attempt a replacement of first, second, and third occurrences and up to all three occurrences.
There are cases too complex to be covered, for example the Icelandic firstname adalradur would have the d's substituted with eth and the third a with acute, we are only dealing with single letter substitution here.