### PR TITLE
Loopback mode: Speed up loading of LM halves

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -161,7 +161,7 @@ struct db_main *ldr_init_test_db(struct fmt_main *format, struct db_main *real)
 }
 
 // lol, who cares about memory leaks here.  This is just the benchmark builder
-void ldr_free_test_db(struct db_main *db)
+void ldr_free_db(struct db_main, int)
 {
 }
 #endif
@@ -1066,7 +1066,7 @@ next:
 			error();
 #endif
 		fflush(stdout);
-		ldr_free_test_db(test_db);
+		ldr_free_db(test_db, 1);
 		fmt_done(format);
 #ifndef BENCH_BUILD
 		if (options.flags & FLG_MASK_CHK) {

--- a/src/loader.c
+++ b/src/loader.c
@@ -1329,7 +1329,7 @@ struct db_main *ldr_init_test_db(struct fmt_main *format, struct db_main *real)
 	return testdb;
 }
 
-void ldr_free_test_db(struct db_main *db)
+void ldr_free_db(struct db_main *db, int base)
 {
 	if (db) {
 		if (db->format &&
@@ -1353,7 +1353,8 @@ void ldr_free_test_db(struct db_main *db)
 		}
 		MEM_FREE(db->salt_hash);
 		MEM_FREE(db->cracked_hash);
-		MEM_FREE(db);
+		if (base)
+			MEM_FREE(db);
 	}
 }
 

--- a/src/loader.h
+++ b/src/loader.h
@@ -315,9 +315,9 @@ extern struct db_main *ldr_init_test_db(struct fmt_main *format,
                                         struct db_main *real);
 
 /*
- * Destroy a fake database.
+ * Destroy a database. If 'base' is true, then also frees the db pointer
  */
-extern void ldr_free_test_db(struct db_main *db);
+extern void ldr_free_db(struct db_main *db, int base);
 
 /*
  * Loads cracked passwords into the database.


### PR DESCRIPTION
Ensures that we're only checking the pot file for actual LM hashes when assembling LM halves. Also drops some duplicated loader code from john.c.