### PR TITLE
Rule-reject flag -u should only reject when internal codepage is used

### DIFF
--- a/doc/ENCODINGS
+++ b/doc/ENCODINGS
@@ -59,7 +59,7 @@ any command-line options.
 Some new reject rules and character classes are implemented, see doc/RULES.
 If you use rules without --internal-codepage, some wordlist rules may cut
 UTF-8 multibyte sequences in the middle, resulting in garbage. You can reject
-such rules with -U to have them in use only when UTF-8 is not used.
+such rules with -U to have them in use only when an internal codepage is used.
 
 Caveats:
 Please note that for convenience, any rule, mask or placeholder given in UTF-8

--- a/doc/RULES
+++ b/doc/RULES
@@ -28,9 +28,8 @@ natively.  Those additional commands may also be useful on their own.
 -8	reject this rule unless current hash type uses 8-bit characters
 -s	reject this rule unless some password hashes were split at loading
 -p	reject this rule unless word pair commands are currently allowed
--u	reject this rule unless the rules engine is running in UTF-8 mode (with
-	no internal codepage configured - see doc/ENCODINGS)
--U	reject this rule if the rules engine is running in UTF-8 mode
+-u	reject this rule if an internal codepage is configured (doc/ENCODINGS)
+-U	reject this rule unless an internal codepage is configured
 ->N	reject this rule unless length N or longer is supported
 -<N	reject this rule unless length N or shorter is supported (--min-length)
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -711,7 +711,7 @@ char *rules_reject(char *rule, int split, char *last, struct db_main *db)
 			return NULL;
 
 		case 'u':
-			if (options.internal_cp == UTF_8) continue;
+			if (options.internal_cp == UTF_8 || options.internal_cp == ASCII) continue;
 			return NULL;
 
 		case 'U':


### PR DESCRIPTION
The meaning of -u and -U has drifted (to the better) after we got more encoding options (first we only had --encoding, now we can also have a --target-encoding and optionally an --internal-codepage).

Closes #4472