### PR TITLE
Shared OpenCL HMAC-SHA1: Fix benign problems

### DIFF
--- a/run/opencl/opencl_hmac_md5.h
+++ b/run/opencl/opencl_hmac_md5.h
@@ -1,12 +1,12 @@
 /*
- * This software is Copyright (c) 2018 magnum
+ * This software is Copyright (c) 2020 magnum
  * and it is hereby released to the general public under the following terms:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  */
 
-#include "opencl_sha2_ctx.h"
+#include "opencl_md5_ctx.h"
 
 #ifdef HMAC_KEY_TYPE
 #define USE_KEY_BUF
@@ -24,45 +24,41 @@
 #define HMAC_OUT_TYPE __private
 #endif
 
-inline void hmac_sha256(HMAC_KEY_TYPE const void *_key, uint key_len,
-                        HMAC_MSG_TYPE void *_data, uint data_len,
-                        HMAC_OUT_TYPE void *_digest, uint digest_len)
+inline void hmac_md5(HMAC_KEY_TYPE const void *_key, uint key_len,
+                     HMAC_MSG_TYPE void *_data, uint data_len,
+                     HMAC_OUT_TYPE void *_digest, uint digest_len)
 {
 	HMAC_KEY_TYPE const uchar *key = _key;
 	HMAC_MSG_TYPE uchar *data = _data;
 	HMAC_OUT_TYPE uchar *digest = _digest;
 	uint pW[16];
 	uchar *buf = (uchar*)pW;
-	uchar local_digest[32];
-	SHA256_CTX ctx;
+	uchar local_digest[16];
+	SHA_CTX ctx;
 	uint i;
 
 #if HMAC_KEY_GT_64
 	if (key_len > 64) {
-		SHA256_Init(&ctx);
+		MD5_Init(&ctx);
 #ifdef USE_KEY_BUF
 		while (key_len) {
 			uchar pbuf[64];
 			uint len = MIN(key_len, (uint)sizeof(pbuf));
 
 			memcpy_macro(pbuf, key, len);
-			SHA256_Update(&ctx, pbuf, len);
+			MD5_Update(&ctx, pbuf, len);
 			data_len -= len;
 			key += len;
 		}
 #else
-		SHA256_Update(&ctx, key, key_len);
+		MD5_Update(&ctx, key, key_len);
 #endif
-		SHA256_Final(buf, &ctx);
+		MD5_Final(buf, &ctx);
 		pW[0] ^= 0x36363636;
 		pW[1] ^= 0x36363636;
 		pW[2] ^= 0x36363636;
 		pW[3] ^= 0x36363636;
-		pW[4] ^= 0x36363636;
-		pW[5] ^= 0x36363636;
-		pW[6] ^= 0x36363636;
-		pW[7] ^= 0x36363636;
-		memset_p(&buf[32], 0x36, 64 - 32);
+		memset_p(&buf[16], 0x36, 64 - 16);
 	} else
 #endif
 	{
@@ -71,28 +67,28 @@ inline void hmac_sha256(HMAC_KEY_TYPE const void *_key, uint key_len,
 		for (i = 0; i < 16; i++)
 			pW[i] ^= 0x36363636;
 	}
-	SHA256_Init(&ctx);
-	SHA256_Update(&ctx, buf, 64);
+	MD5_Init(&ctx);
+	MD5_Update(&ctx, buf, 64);
 #ifdef USE_DATA_BUF
 	while (data_len) {
 		uchar pbuf[64];
 		uint len = MIN(data_len, (uint)sizeof(pbuf));
 
 		memcpy_macro(pbuf, data, len);
-		SHA256_Update(&ctx, pbuf, len);
+		MD5_Update(&ctx, pbuf, len);
 		data_len -= len;
 		data += len;
 	}
 #else
-	SHA256_Update(&ctx, data, data_len);
+	MD5_Update(&ctx, data, data_len);
 #endif
-	SHA256_Final(local_digest, &ctx);
+	MD5_Final(local_digest, &ctx);
 	for (i = 0; i < 16; i++)
 		pW[i] ^= (0x36363636 ^ 0x5c5c5c5c);
-	SHA256_Init(&ctx);
-	SHA256_Update(&ctx, buf, 64);
-	SHA256_Update(&ctx, local_digest, 32);
-	SHA256_Final(local_digest, &ctx);
+	MD5_Init(&ctx);
+	MD5_Update(&ctx, buf, 64);
+	MD5_Update(&ctx, local_digest, 16);
+	MD5_Final(local_digest, &ctx);
 
 	memcpy_macro(digest, local_digest, digest_len);
 }

--- a/run/opencl/opencl_hmac_sha1.h
+++ b/run/opencl/opencl_hmac_sha1.h
@@ -17,7 +17,7 @@
 #ifdef HMAC_MSG_TYPE
 #define USE_DATA_BUF
 #else
-#define HMAC_MSG_TYPE __private
+#define HMAC_MSG_TYPE __private const
 #endif
 
 #ifndef HMAC_OUT_TYPE
@@ -25,11 +25,11 @@
 #endif
 
 inline void hmac_sha1(HMAC_KEY_TYPE const void *_key, uint key_len,
-                      HMAC_MSG_TYPE const void *_data, uint data_len,
+                      HMAC_MSG_TYPE void *_data, uint data_len,
                       HMAC_OUT_TYPE void *_digest, uint digest_len)
 {
 	HMAC_KEY_TYPE const uchar *key = _key;
-	HMAC_MSG_TYPE const uchar *data = _data;
+	HMAC_MSG_TYPE uchar *data = _data;
 	HMAC_OUT_TYPE uchar *digest = _digest;
 	uint pW[16];
 	uchar *buf = (uchar*)pW;
@@ -59,7 +59,7 @@ inline void hmac_sha1(HMAC_KEY_TYPE const void *_key, uint key_len,
 		pW[2] ^= 0x36363636;
 		pW[3] ^= 0x36363636;
 		pW[4] ^= 0x36363636;
-		memset_p(&buf[20], 0x36, 44);
+		memset_p(&buf[20], 0x36, 64 - 20);
 	} else
 #endif
 	{

--- a/run/opencl/opencl_hmac_sha512.h
+++ b/run/opencl/opencl_hmac_sha512.h
@@ -17,7 +17,7 @@
 #ifdef HMAC_MSG_TYPE
 #define USE_DATA_BUF
 #else
-#define HMAC_MSG_TYPE __private
+#define HMAC_MSG_TYPE __private const
 #endif
 
 #ifndef HMAC_OUT_TYPE
@@ -25,11 +25,11 @@
 #endif
 
 inline void hmac_sha512(HMAC_KEY_TYPE const void *_key, uint key_len,
-                        HMAC_MSG_TYPE const void *_data, uint data_len,
+                        HMAC_MSG_TYPE void *_data, uint data_len,
                         HMAC_OUT_TYPE void *_digest, uint digest_len)
 {
 	HMAC_KEY_TYPE const uchar *key = _key;
-	HMAC_MSG_TYPE const uchar *data = _data;
+	HMAC_MSG_TYPE uchar *data = _data;
 	HMAC_OUT_TYPE uchar *digest = _digest;
 	ulong pW[16];
 	uchar *buf = (uchar*)pW;
@@ -62,7 +62,7 @@ inline void hmac_sha512(HMAC_KEY_TYPE const void *_key, uint key_len,
 		pW[5] ^= 0x3636363636363636;
 		pW[6] ^= 0x3636363636363636;
 		pW[7] ^= 0x3636363636363636;
-		memset_p(&buf[64], 0x36, 64);
+		memset_p(&buf[64], 0x36, 128 - 64);
 	} else
 #endif
 	{


### PR DESCRIPTION
Seen on Travis-CI: "warning: duplicate 'const' declaration specifier"

While at it, I added a shared OpenCL HMAC-MD5 for use later.