### PR TITLE
Assorted fixes after testing a linux-x86-64-clang legacy build

### DIFF
--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -771,10 +771,14 @@ linux-alpha-ccc:
 
 linux-sparc64:
 	$(LN) sparc64.h arch.h
-	$(MAKE) $(PROJ) \
+	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
+	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o" \
 		CFLAGS="$(CFLAGS) -m64 -mcpu=ultrasparc -DHAVE_CRYPT" \
 		LDFLAGS="$(LDFLAGS) -m64 -lcrypt"
+	@echo "Failing after this point just means some helper tools did not build:"
+	$(MAKE_ORIG) $(PROJ_PCAP)
+	@echo "All done"
 
 linux-sparc:
 	$(LN) sparc32.h arch.h

--- a/src/md4.h
+++ b/src/md4.h
@@ -26,7 +26,9 @@ typedef struct {
 	MD4_u32plus A, B, C, D;
 	MD4_u32plus lo, hi;
 	unsigned char buffer[64];
+#if !ARCH_ALLOWS_UNALIGNED
 	MD4_u32plus block[16];
+#endif
 } MD4_CTX;
 
 extern void MD4_Init(MD4_CTX *ctx);

--- a/src/md5.h
+++ b/src/md5.h
@@ -34,7 +34,9 @@ typedef struct {
 	MD5_u32plus A, B, C, D;
 	MD5_u32plus lo, hi;
 	unsigned char buffer[64];
+#if !ARCH_ALLOWS_UNALIGNED
 	MD5_u32plus block[16];
+#endif
 } MD5_CTX;
 
 extern void MD5_Init(MD5_CTX *ctx);

--- a/src/sip_fmt_plug.c
+++ b/src/sip_fmt_plug.c
@@ -198,7 +198,14 @@ static void *get_salt(char *ciphertext)
 	char static_hash[MD5_LEN_HEX+1];
 	char *saltcopy = saltBuf;
 
+/*
+ * Zeroize both structs so that any padding gaps have defined values and thus
+ * salt comparisons work reliably.  Note that we memcpy() md5_ctx into
+ * salt.ctx_dyna_data, which copies md5_ctx's padding gaps too.
+ */
 	memset(&salt, 0, sizeof(salt));
+	memset(&md5_ctx, 0, sizeof(md5_ctx));
+
 	strcpy(saltBuf, ciphertext);
 	saltcopy += FORMAT_TAG_LEN;	/* skip over "$sip$*" */
 	memset(&login, 0, sizeof(login_t));

--- a/src/ssh_common_plug.c
+++ b/src/ssh_common_plug.c
@@ -2,6 +2,12 @@
  * Common code for the SSH format.
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* for strcasestr() */
+#endif
+#include <string.h>
+#include <stdlib.h> /* for atoi() */
+
 #include "arch.h"
 #include "misc.h"
 #include "common.h"


### PR DESCRIPTION
This fixes #1990, implements the optimization for MD4 and MD5 I just described in #3917, and fixes a clang build warning for `ssh_common_plug.c`.