### PR TITLE
eapmd5tojohn: Optionally build without DLT_TZSP and/or DLT_PRISM_HEADER

### DIFF
--- a/src/eapmd5tojohn.c
+++ b/src/eapmd5tojohn.c
@@ -1128,13 +1128,17 @@ int main(int argc, char *argv[])
 			offset = DOT11_OFFSET_DOT11;
 			break;
 
+#ifdef DLT_TZSP
 		case DLT_TZSP:
 			offset = DOT11_OFFSET_TZSP;
 			break;
+#endif
 
+#ifdef DLT_PRISM_HEADER
 		case DLT_PRISM_HEADER:
 			offset = DOT11_OFFSET_PRISMAVS;
 			break;
+#endif
 
 		default:
 			fprintf(stderr, "Unrecognized datalink type %d.\n", datalink);


### PR DESCRIPTION
Should fix the issue reported for building with OpenBSD's(?) libpcap here: https://github.com/openwall/john/issues/1990#issuecomment-733019473

I've verified that these two are `#define` macros on a system where they're present, so this way of checking for their presence is appropriate.