### PR TITLE
only define swap32 and swap64 if they are not yet already defined.

### DIFF
--- a/src/int-util.h
+++ b/src/int-util.h
@@ -119,6 +119,11 @@ static inline uint32_t div128_32(uint64_t dividend_hi, uint64_t dividend_lo, uin
 static inline uint32_t ident32(uint32_t x) { return x; }
 static inline uint64_t ident64(uint64_t x) { return x; }
 
+#undef swap32
+#define swap32 john_swap32
+#undef swap64
+#define swap64 john_swap64
+
 static inline uint32_t swap32(uint32_t x) {
   x = ((x & 0x00ff00ff) << 8) | ((x & 0xff00ff00) >> 8);
   return (x << 16) | (x >> 16);


### PR DESCRIPTION
At least on OpenBSD, endian.h is pulled in, which already defines swap32 and swap64, and therefore build breaks.
So only redefine it when it's not already defined.