### PR TITLE
getopt returns int, not signed chars.

### DIFF
--- a/src/cprepair.c
+++ b/src/cprepair.c
@@ -241,7 +241,7 @@ static int process_file(char *name)
 
 int main(int argc, char **argv)
 {
-	signed char c;
+	int c;
 
 	options.verbosity = VERB_DEFAULT;
 

--- a/src/tgtsnarf.c
+++ b/src/tgtsnarf.c
@@ -261,9 +261,8 @@ int
 main(int argc, char *argv[])
 #endif
 {
-  signed char c;
   char *p, *host, *realm, user[128];
-  int i;
+  int c, i;
 
   host = realm = NULL;
 


### PR DESCRIPTION
not much to say about, getopt returns int, so declare c as int.