### PR TITLE
HR Timer: Revert (obviously) to using double for sTimer_GetSecs()

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -122,9 +122,9 @@ void sTimer_ClearTime(sTimer *t)
 	t->m_fRunning = 0;
 }
 
-uint64_t sTimer_GetSecs(sTimer *t)
+double sTimer_GetSecs(sTimer *t)
 {
-	uint64_t retval;
+	double retval;
 
 	if (t->m_fRunning) {
 		if (sm_HRTicksPerSec)
@@ -134,7 +134,7 @@ uint64_t sTimer_GetSecs(sTimer *t)
 	}
 	if (!sm_HRTicksPerSec) {
 		// This is process time
-		uint64_t d = (t->m_cEndTime - t->m_cStartTime);
+		double d = (t->m_cEndTime - t->m_cStartTime);
 
 		if (d > 0)
 			retval = d / CLOCKS_PER_SEC;
@@ -143,7 +143,7 @@ uint64_t sTimer_GetSecs(sTimer *t)
 	}
 	else {
 		// This is wall-clock time
-		uint64_t d = (HRGETTICKS(t->m_hrEndTime) - HRGETTICKS(t->m_hrStartTime));
+		double d = (HRGETTICKS(t->m_hrEndTime) - HRGETTICKS(t->m_hrStartTime));
 
 		if (d > 0)
 			retval = d / sm_HRTicksPerSec;

--- a/src/timer.h
+++ b/src/timer.h
@@ -85,16 +85,16 @@ typedef struct sTimer_s {
 	clock_t m_cEndTime;
 	hr_timer m_hrStartTime;
 	hr_timer m_hrEndTime;
-	uint64_t m_dAccumSeconds;
+	double m_dAccumSeconds;
 } sTimer;
 
 extern void sTimer_Init(sTimer *t);      // Init
 extern void sTimer_Start(sTimer *t, int bClear /*=true*/);  // Start the timer
 extern void sTimer_Stop(sTimer *t);      // Stop the timer
 extern void sTimer_ClearTime(sTimer *t); // Clears out the time to 0
-extern uint64_t sTimer_GetSecs(sTimer *t); // If timer running returns elapsed;
-                                           // if stopped returns timed interval;
-                                           // if not started returns 0.
+extern double sTimer_GetSecs(sTimer *t); // If timer running returns elapsed;
+                                         // if stopped returns timed interval;
+                                         // if not started returns 0.
 
 extern uint64_t sm_HRTicksPerSec;  // HR ticks per second (claimed)
 extern uint64_t sm_hrPrecision;    // HR ticks per second (observed, guess)


### PR DESCRIPTION
This bug had impact on current OMP auto-tune.
We'll add sTimer_GetNanoSecs() once I need what I was thinking of back in 7c4ac6c.  I never realized the unfinished work had any impact.

Closes #4489