### PR TITLE
Add support for RACF RVARY command password hashes

### DIFF
--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -53,80 +53,80 @@ john_register_one(&fmt_rvary);
 #endif
 
 static const unsigned char a2e[256] = {
-	0,  1,  2,  3, 55, 45, 46, 47, 22,  5, 37, 11, 12, 13, 14, 15,
-	16, 17, 18, 19, 60, 61, 50, 38, 24, 25, 63, 39, 28, 29, 30, 31,
-	64, 79,127,123, 91,108, 80,125, 77, 93, 92, 78,107, 96, 75, 97,
-	240,241,242,243,244,245,246,247,248,249,122, 94, 76,126,110,111,
-	124,193,194,195,196,197,198,199,200,201,209,210,211,212,213,214,
-	215,216,217,226,227,228,229,230,231,232,233, 74,224, 90, 95,109,
-	121,129,130,131,132,133,134,135,136,137,145,146,147,148,149,150,
-	151,152,153,162,163,164,165,166,167,168,169,192,106,208,161,  7,
-	32, 33, 34, 35, 36, 21,  6, 23, 40, 41, 42, 43, 44,  9, 10, 27,
-	48, 49, 26, 51, 52, 53, 54,  8, 56, 57, 58, 59,  4, 20, 62,225,
-	65, 66, 67, 68, 69, 70, 71, 72, 73, 81, 82, 83, 84, 85, 86, 87,
-	88, 89, 98, 99,100,101,102,103,104,105,112,113,114,115,116,117,
-	118,119,120,128,138,139,140,141,142,143,144,154,155,156,157,158,
-	159,160,170,171,172,173,174,175,176,177,178,179,180,181,182,183,
-	184,185,186,187,188,189,190,191,202,203,204,205,206,207,218,219,
-	220,221,222,223,234,235,236,237,238,239,250,251,252,253,254,255
+    0,  1,  2,  3, 55, 45, 46, 47, 22,  5, 37, 11, 12, 13, 14, 15,
+    16, 17, 18, 19, 60, 61, 50, 38, 24, 25, 63, 39, 28, 29, 30, 31,
+    64, 79,127,123, 91,108, 80,125, 77, 93, 92, 78,107, 96, 75, 97,
+    240,241,242,243,244,245,246,247,248,249,122, 94, 76,126,110,111,
+    124,193,194,195,196,197,198,199,200,201,209,210,211,212,213,214,
+    215,216,217,226,227,228,229,230,231,232,233, 74,224, 90, 95,109,
+    121,129,130,131,132,133,134,135,136,137,145,146,147,148,149,150,
+    151,152,153,162,163,164,165,166,167,168,169,192,106,208,161,  7,
+    32, 33, 34, 35, 36, 21,  6, 23, 40, 41, 42, 43, 44,  9, 10, 27,
+    48, 49, 26, 51, 52, 53, 54,  8, 56, 57, 58, 59,  4, 20, 62,225,
+    65, 66, 67, 68, 69, 70, 71, 72, 73, 81, 82, 83, 84, 85, 86, 87,
+    88, 89, 98, 99,100,101,102,103,104,105,112,113,114,115,116,117,
+    118,119,120,128,138,139,140,141,142,143,144,154,155,156,157,158,
+    159,160,170,171,172,173,174,175,176,177,178,179,180,181,182,183,
+    184,185,186,187,188,189,190,191,202,203,204,205,206,207,218,219,
+    220,221,222,223,234,235,236,237,238,239,250,251,252,253,254,255
 };
 
 /* This is a2e[] with each entry XOR 0x55, left-shifted one bit
    and finally with odd parity so that DES_set_key_unchecked
    can be used directly.  This provides about 15% speed up.    */
 static const unsigned char a2e_precomputed[256] = {
-	 171, 168, 174, 173, 196, 241, 247, 244, 134, 161, 224, 188, 179, 176, 182, 181,
-	 138, 137, 143, 140, 211, 208, 206, 230, 155, 152, 213, 229, 146, 145, 151, 148,
-	  42,  52,  84,  93,  28, 115,  11,  81,  49,  16,  19,  55, 124, 107,  61, 104,
-	  74,  73,  79,  76,  67,  64,  70,  69,  91,  88,  94,  22,  50,  87, 118, 117,
-	  82,  41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,
-	   4,  26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  62, 107,  31,  21, 112,
-	  88, 168, 174, 173, 162, 161, 167, 164, 186, 185, 137, 143, 140, 131, 128, 134,
-	 133, 155, 152, 239, 236, 227, 224, 230, 229, 251, 248,  42, 127,  11, 233, 164,
-	 234, 233, 239, 236, 227, 128, 167, 133, 251, 248, 254, 253, 242, 185, 191, 157,
-	 203, 200, 158, 205, 194, 193, 199, 186, 218, 217, 223, 220, 162, 131, 214, 104,
-	  41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,   4,
-	  26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  74,  73,  79,  76,  67,  64,
-	  70,  69,  91, 171, 191, 188, 179, 176, 182, 181, 138, 158, 157, 146, 145, 151,
-	 148, 234, 254, 253, 242, 241, 247, 244, 203, 200, 206, 205, 194, 193, 199, 196,
-	 218, 217, 223, 220, 211, 208, 214, 213,  62,  61,  50,  49,  55,  52,  31,  28,
-	  19,  16,  22,  21, 127, 124, 115, 112, 118, 117,  94,  93,  82,  81,  87,  84
+    171, 168, 174, 173, 196, 241, 247, 244, 134, 161, 224, 188, 179, 176, 182, 181,
+    138, 137, 143, 140, 211, 208, 206, 230, 155, 152, 213, 229, 146, 145, 151, 148,
+    42,  52,  84,  93,  28, 115,  11,  81,  49,  16,  19,  55, 124, 107,  61, 104,
+    74,  73,  79,  76,  67,  64,  70,  69,  91,  88,  94,  22,  50,  87, 118, 117,
+    82,  41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,
+    4,  26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  62, 107,  31,  21, 112,
+    88, 168, 174, 173, 162, 161, 167, 164, 186, 185, 137, 143, 140, 131, 128, 134,
+    133, 155, 152, 239, 236, 227, 224, 230, 229, 251, 248,  42, 127,  11, 233, 164,
+    234, 233, 239, 236, 227, 128, 167, 133, 251, 248, 254, 253, 242, 185, 191, 157,
+    203, 200, 158, 205, 194, 193, 199, 186, 218, 217, 223, 220, 162, 131, 214, 104,
+    41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,   4,
+    26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  74,  73,  79,  76,  67,  64,
+    70,  69,  91, 171, 191, 188, 179, 176, 182, 181, 138, 158, 157, 146, 145, 151,
+    148, 234, 254, 253, 242, 241, 247, 244, 203, 200, 206, 205, 194, 193, 199, 196,
+    218, 217, 223, 220, 211, 208, 214, 213,  62,  61,  50,  49,  55,  52,  31,  28,
+    19,  16,  22,  21, 127, 124, 115, 112, 118, 117,  94,  93,  82,  81,  87,  84
 };
 
 /* in-place ascii2ebcdic conversion */
 static void ascii2ebcdic(unsigned char *str)
 {
-	int i;
-	int n = strlen((const char*)str);
-	for (i = 0; i < n; ++i)
-		str[i] = a2e[str[i]];
+    int i;
+    int n = strlen((const char*)str);
+    for (i = 0; i < n; ++i)
+        str[i] = a2e[str[i]];
 }
 
 /* Pad input string with EBCDIC spaces (0x40) up to eight bytes */
 static void ebcdic_padding(unsigned char *str)
 {
-	int i;
-	for (i = strlen((const char*)str); i < 9; ++i)
-		str[i] = 0x40;
-	str[9] = 0; /* terminate string */
+    int i;
+    for (i = strlen((const char*)str); i < 9; ++i)
+        str[i] = 0x40;
+    str[9] = 0; /* terminate string */
 }
 
 #ifdef RVARY_DEBUG
 static void print_hex(unsigned char *str, int len)
 {
-	int i;
-	for (i = 0; i < len; ++i)
-		printf("%02x", str[i]);
-	printf("\n");
+    int i;
+    for (i = 0; i < len; ++i)
+        printf("%02x", str[i]);
+    printf("\n");
 }
 #endif
 
 static struct fmt_tests rvary_tests[] = {
-	{"$rvary$**5AA70358A9C369E0", "QWERTY1"},
-	{"$rvary$**EB59EE07FC74AE77", "PASSWORD"},
-	{"$rvary$**062314297C496E0E", "AAAAAAAA"},
-	{"$rvary$**0FF48804F759193F", "TESTTEST"},
-	{NULL}
+    {"$rvary$**5AA70358A9C369E0", "QWERTY1"},
+    {"$rvary$**EB59EE07FC74AE77", "PASSWORD"},
+    {"$rvary$**062314297C496E0E", "AAAAAAAA"},
+    {"$rvary$**0FF48804F759193F", "TESTTEST"},
+    {NULL}
 };
 
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
@@ -136,64 +136,64 @@ static int dirty;
 
 static void init(struct fmt_main *self)
 {
-	omp_autotune(self, OMP_SCALE);
+    omp_autotune(self, OMP_SCALE);
 
-	saved_key = mem_calloc(self->params.max_keys_per_crypt,
-	                       sizeof(*saved_key));
-	crypt_out = mem_calloc(self->params.max_keys_per_crypt,
-	                       sizeof(*crypt_out));
-	schedules = mem_calloc(self->params.max_keys_per_crypt,
-	                       sizeof(*schedules));
+    saved_key = mem_calloc(self->params.max_keys_per_crypt,
+            sizeof(*saved_key));
+    crypt_out = mem_calloc(self->params.max_keys_per_crypt,
+            sizeof(*crypt_out));
+    schedules = mem_calloc(self->params.max_keys_per_crypt,
+            sizeof(*schedules));
 }
 
 static void done(void)
 {
-	MEM_FREE(schedules);
-	MEM_FREE(crypt_out);
-	MEM_FREE(saved_key);
+    MEM_FREE(schedules);
+    MEM_FREE(crypt_out);
+    MEM_FREE(saved_key);
 }
 
 static int valid(char *ciphertext, struct fmt_main *self)
 {
-	char *ctcopy;
-	char *keeptr;
-	int extra;
+    char *ctcopy;
+    char *keeptr;
+    int extra;
 
-	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
-		return 0;
-	ctcopy = strdup(ciphertext);
-	keeptr = ctcopy;
-	ctcopy += FORMAT_TAG_LEN;
-	ctcopy += 1; /* Skip empty salt */
-	if (hexlenu(ctcopy, &extra) != CIPHERTEXT_LENGTH || extra)
-		goto err;
-	MEM_FREE(keeptr);
-	return 1;
+    if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+        return 0;
+    ctcopy = strdup(ciphertext);
+    keeptr = ctcopy;
+    ctcopy += FORMAT_TAG_LEN;
+    ctcopy += 1; /* Skip empty salt */
+    if (hexlenu(ctcopy, &extra) != CIPHERTEXT_LENGTH || extra)
+        goto err;
+    MEM_FREE(keeptr);
+    return 1;
 
 err:
-	MEM_FREE(keeptr);
-	return 0;
+    MEM_FREE(keeptr);
+    return 0;
 }
 
 static void *get_binary(char *ciphertext)
 {
-	static union {
-		unsigned char c[BINARY_SIZE+1];
-		ARCH_WORD dummy;
-	} buf;
-	unsigned char *out = buf.c;
-	char *p;
-	int i;
+    static union {
+        unsigned char c[BINARY_SIZE+1];
+        ARCH_WORD dummy;
+    } buf;
+    unsigned char *out = buf.c;
+    char *p;
+    int i;
 
-	p = strrchr(ciphertext, '*') + 1;
-		for (i = 0; i < BINARY_SIZE; i++) {
-		out[i] =
-		    (atoi16[ARCH_INDEX(*p)] << 4) |
-		    atoi16[ARCH_INDEX(p[1])];
-		p += 2;
-	}
+    p = strrchr(ciphertext, '*') + 1;
+    for (i = 0; i < BINARY_SIZE; i++) {
+        out[i] =
+            (atoi16[ARCH_INDEX(*p)] << 4) |
+            atoi16[ARCH_INDEX(p[1])];
+        p += 2;
+    }
 
-	return out;
+    return out;
 }
 
 #define COMMON_GET_HASH_VAR crypt_out
@@ -201,125 +201,125 @@ static void *get_binary(char *ciphertext)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-	const int count = *pcount;
-	int index;
+    const int count = *pcount;
+    int index;
 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-	for (index = 0; index < count; index++) {
-		if (dirty) {
-			DES_cblock des_key;
-			int i;
+    for (index = 0; index < count; index++) {
+        if (dirty) {
+            DES_cblock des_key;
+            int i;
 
-			/* process key */
-			for (i = 0; saved_key[index][i]; i++)
-				des_key[i] = a2e_precomputed[ARCH_INDEX(saved_key[index][i])];
+            /* process key */
+            for (i = 0; saved_key[index][i]; i++)
+                des_key[i] = a2e_precomputed[ARCH_INDEX(saved_key[index][i])];
 
-			/* replace missing characters in userid by (EBCDIC space (0x40) XOR 0x55) << 1 */
-			while(i < 9)
-				des_key[i++] = 0x2a;
+            /* replace missing characters in userid by (EBCDIC space (0x40) XOR 0x55) << 1 */
+            while(i < 9)
+                des_key[i++] = 0x2a;
 
-			DES_set_key_unchecked(&des_key, &schedules[index]);
-		}
-		/* DES encrypt the password with the password itself by using the key as salt */
+            DES_set_key_unchecked(&des_key, &schedules[index]);
+        }
+        /* DES encrypt the password with the password itself by using the key as salt */
         char key[10];
         strnzcpy(key, saved_key[index], 9);
         key[9] = 0;
         ascii2ebcdic((unsigned char *)key);
         ebcdic_padding((unsigned char *)key);
-		DES_ecb_encrypt((const_DES_cblock*)key, (DES_cblock*)crypt_out[index], &schedules[index], DES_ENCRYPT);
-	}
-	dirty = 0;
+        DES_ecb_encrypt((const_DES_cblock*)key, (DES_cblock*)crypt_out[index], &schedules[index], DES_ENCRYPT);
+    }
+    dirty = 0;
 
-	return count;
+    return count;
 }
 
 static int cmp_all(void *binary, int count)
 {
-	int index;
+    int index;
 
-	for (index = 0; index < count; index++)
-		if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
-			return 1;
-	return 0;
+    for (index = 0; index < count; index++)
+        if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
+            return 1;
+    return 0;
 }
 
 static int cmp_one(void *binary, int index)
 {
-	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+    return !memcmp(binary, crypt_out[index], BINARY_SIZE);
 }
 
 static int cmp_exact(char *source, int index)
 {
-	return 1;
+    return 1;
 }
 
 static void rvary_set_key(char *key, int index)
 {
-	strnzcpy(saved_key[index], key, sizeof(*saved_key));
-	dirty = 1;
+    strnzcpy(saved_key[index], key, sizeof(*saved_key));
+    dirty = 1;
 }
 
 static char *get_key(int index)
 {
-	return saved_key[index];
+    return saved_key[index];
 }
 
 struct fmt_main fmt_rvary = {
-	{
-		FORMAT_LABEL,
-		FORMAT_NAME,
-		ALGORITHM_NAME,
-		BENCHMARK_COMMENT,
-		BENCHMARK_LENGTH,
-		0,
-		PLAINTEXT_LENGTH,
-		BINARY_SIZE,
-		BINARY_ALIGN,
-		SALT_SIZE,
-		SALT_ALIGN,
-		MIN_KEYS_PER_CRYPT,
-		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_TRUNC | FMT_8_BIT | FMT_OMP | FMT_OMP_BAD,
-		{ NULL },
-		{ FORMAT_TAG },
-		rvary_tests
-	}, {
-		init,
-		done,
-		fmt_default_reset,
-		fmt_default_prepare,
-		valid,
-		fmt_default_split,
-		get_binary,
-		fmt_default_salt,
-		{ NULL },
-		fmt_default_source,
-		{
-			fmt_default_binary_hash_0,
-			fmt_default_binary_hash_1,
-			fmt_default_binary_hash_2,
-			fmt_default_binary_hash_3,
-			fmt_default_binary_hash_4,
-			fmt_default_binary_hash_5,
-			fmt_default_binary_hash_6
-		},
-		fmt_default_salt_hash,
-		NULL,
-		fmt_default_set_salt,
-		rvary_set_key,
-		get_key,
-		fmt_default_clear_keys,
-		crypt_all,
-		{
+    {
+        FORMAT_LABEL,
+        FORMAT_NAME,
+        ALGORITHM_NAME,
+        BENCHMARK_COMMENT,
+        BENCHMARK_LENGTH,
+        0,
+        PLAINTEXT_LENGTH,
+        BINARY_SIZE,
+        BINARY_ALIGN,
+        SALT_SIZE,
+        SALT_ALIGN,
+        MIN_KEYS_PER_CRYPT,
+        MAX_KEYS_PER_CRYPT,
+        FMT_CASE | FMT_TRUNC | FMT_8_BIT | FMT_OMP | FMT_OMP_BAD,
+        { NULL },
+        { FORMAT_TAG },
+        rvary_tests
+    }, {
+        init,
+        done,
+        fmt_default_reset,
+        fmt_default_prepare,
+        valid,
+        fmt_default_split,
+        get_binary,
+        fmt_default_salt,
+        { NULL },
+        fmt_default_source,
+        {
+            fmt_default_binary_hash_0,
+            fmt_default_binary_hash_1,
+            fmt_default_binary_hash_2,
+            fmt_default_binary_hash_3,
+            fmt_default_binary_hash_4,
+            fmt_default_binary_hash_5,
+            fmt_default_binary_hash_6
+        },
+        fmt_default_salt_hash,
+        NULL,
+        fmt_default_set_salt,
+        rvary_set_key,
+        get_key,
+        fmt_default_clear_keys,
+        crypt_all,
+        {
 #define COMMON_GET_HASH_LINK
 #include "common-get-hash.h"
-		},
-		cmp_all,
-		cmp_one,
-		cmp_exact
-	}
+        },
+        cmp_all,
+        cmp_one,
+        cmp_exact
+    }
 };
 
 #endif /* plugin stanza */

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -6,7 +6,7 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  *
- * Dump format: $rvary$*hash
+ * Dump format: $rvary$hash
  *
  */
 
@@ -33,7 +33,7 @@ john_register_one(&fmt_rvary);
 
 #define FORMAT_LABEL            "RVARY"
 #define FORMAT_NAME             ""
-#define FORMAT_TAG              "$rvary$*"
+#define FORMAT_TAG              "$rvary$"
 #define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
 #define ALGORITHM_NAME          "DES 32/" ARCH_BITS_STR
 #define BENCHMARK_COMMENT       ""
@@ -122,10 +122,10 @@ static void print_hex(unsigned char *str, int len)
 #endif
 
 static struct fmt_tests rvary_tests[] = {
-	{"$rvary$*5AA70358A9C369E0", "QWERTY1"},
-	{"$rvary$*EB59EE07FC74AE77", "PASSWORD"},
-	{"$rvary$*062314297C496E0E", "AAAAAAAA"},
-	{"$rvary$*0FF48804F759193F", "TESTTEST"},
+	{"$rvary$5AA70358A9C369E0", "QWERTY1"},
+	{"$rvary$EB59EE07FC74AE77", "PASSWORD"},
+	{"$rvary$062314297C496E0E", "AAAAAAAA"},
+	{"$rvary$0FF48804F759193F", "TESTTEST"},
 	{NULL}
 };
 
@@ -181,15 +181,14 @@ static void *get_binary(char *ciphertext)
 		ARCH_WORD dummy;
 	} buf;
 	unsigned char *out = buf.c;
-	char *p;
 	int i;
 
-	p = strrchr(ciphertext, '*') + 1;
+	ciphertext += FORMAT_TAG_LEN;
 	for (i = 0; i < BINARY_SIZE; i++) {
 		out[i] =
-			(atoi16[ARCH_INDEX(*p)] << 4) |
-			atoi16[ARCH_INDEX(p[1])];
-		p += 2;
+			(atoi16[ARCH_INDEX(*ciphertext)] << 4) |
+			atoi16[ARCH_INDEX(ciphertext[1])];
+		ciphertext += 2;
 	}
 
 	return out;

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -6,7 +6,7 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  *
- * Dump format: $rvary$**hash
+ * Dump format: $rvary$*hash
  *
  */
 
@@ -16,12 +16,19 @@ extern struct fmt_main fmt_rvary;
 john_register_one(&fmt_rvary);
 #else
 
+#include <string.h>
 #include <openssl/des.h>
 
 #ifdef _OPENMP
 #include <omp.h>
 #endif
 
+#include "arch.h"
+#include "crc32.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
 #include "options.h"
 
 #define FORMAT_LABEL            "RVARY"
@@ -45,146 +52,147 @@ john_register_one(&fmt_rvary);
 #define OMP_SCALE               4
 #endif
 
-static struct fmt_tests rvary_tests[] = {
-    {"$rvary$*5AA70358A9C369E0", "QWERTY1"},
-    {"$rvary$*EB59EE07FC74AE77", "PASSWORD"},
-    {"$rvary$*062314297C496E0E", "AAAAAAAA"},
-    {"$rvary$*0FF48804F759193F", "TESTTEST"},
-    {NULL}
-};
-
-static char (*saved_key)[PLAINTEXT_LENGTH + 1];
-static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
-static DES_key_schedule (*schedules);
-
 static const unsigned char a2e[256] = {
-    0,  1,  2,  3, 55, 45, 46, 47, 22,  5, 37, 11, 12, 13, 14, 15,
-    16, 17, 18, 19, 60, 61, 50, 38, 24, 25, 63, 39, 28, 29, 30, 31,
-    64, 79,127,123, 91,108, 80,125, 77, 93, 92, 78,107, 96, 75, 97,
-    240,241,242,243,244,245,246,247,248,249,122, 94, 76,126,110,111,
-    124,193,194,195,196,197,198,199,200,201,209,210,211,212,213,214,
-    215,216,217,226,227,228,229,230,231,232,233, 74,224, 90, 95,109,
-    121,129,130,131,132,133,134,135,136,137,145,146,147,148,149,150,
-    151,152,153,162,163,164,165,166,167,168,169,192,106,208,161,  7,
-    32, 33, 34, 35, 36, 21,  6, 23, 40, 41, 42, 43, 44,  9, 10, 27,
-    48, 49, 26, 51, 52, 53, 54,  8, 56, 57, 58, 59,  4, 20, 62,225,
-    65, 66, 67, 68, 69, 70, 71, 72, 73, 81, 82, 83, 84, 85, 86, 87,
-    88, 89, 98, 99,100,101,102,103,104,105,112,113,114,115,116,117,
-    118,119,120,128,138,139,140,141,142,143,144,154,155,156,157,158,
-    159,160,170,171,172,173,174,175,176,177,178,179,180,181,182,183,
-    184,185,186,187,188,189,190,191,202,203,204,205,206,207,218,219,
-    220,221,222,223,234,235,236,237,238,239,250,251,252,253,254,255
+	0,  1,  2,  3, 55, 45, 46, 47, 22,  5, 37, 11, 12, 13, 14, 15,
+	16, 17, 18, 19, 60, 61, 50, 38, 24, 25, 63, 39, 28, 29, 30, 31,
+	64, 79,127,123, 91,108, 80,125, 77, 93, 92, 78,107, 96, 75, 97,
+	240,241,242,243,244,245,246,247,248,249,122, 94, 76,126,110,111,
+	124,193,194,195,196,197,198,199,200,201,209,210,211,212,213,214,
+	215,216,217,226,227,228,229,230,231,232,233, 74,224, 90, 95,109,
+	121,129,130,131,132,133,134,135,136,137,145,146,147,148,149,150,
+	151,152,153,162,163,164,165,166,167,168,169,192,106,208,161,  7,
+	32, 33, 34, 35, 36, 21,  6, 23, 40, 41, 42, 43, 44,  9, 10, 27,
+	48, 49, 26, 51, 52, 53, 54,  8, 56, 57, 58, 59,  4, 20, 62,225,
+	65, 66, 67, 68, 69, 70, 71, 72, 73, 81, 82, 83, 84, 85, 86, 87,
+	88, 89, 98, 99,100,101,102,103,104,105,112,113,114,115,116,117,
+	118,119,120,128,138,139,140,141,142,143,144,154,155,156,157,158,
+	159,160,170,171,172,173,174,175,176,177,178,179,180,181,182,183,
+	184,185,186,187,188,189,190,191,202,203,204,205,206,207,218,219,
+	220,221,222,223,234,235,236,237,238,239,250,251,252,253,254,255
 };
 
 /* This is a2e[] with each entry XOR 0x55, left-shifted one bit
    and finally with odd parity so that DES_set_key_unchecked
    can be used directly.  This provides about 15% speed up.    */
 static const unsigned char a2e_precomputed[256] = {
-    171, 168, 174, 173, 196, 241, 247, 244, 134, 161, 224, 188, 179, 176, 182, 181,
-    138, 137, 143, 140, 211, 208, 206, 230, 155, 152, 213, 229, 146, 145, 151, 148,
-    42,  52,  84,  93,  28, 115,  11,  81,  49,  16,  19,  55, 124, 107,  61, 104,
-    74,  73,  79,  76,  67,  64,  70,  69,  91,  88,  94,  22,  50,  87, 118, 117,
-    82,  41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,
-    4,  26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  62, 107,  31,  21, 112,
-    88, 168, 174, 173, 162, 161, 167, 164, 186, 185, 137, 143, 140, 131, 128, 134,
-    133, 155, 152, 239, 236, 227, 224, 230, 229, 251, 248,  42, 127,  11, 233, 164,
-    234, 233, 239, 236, 227, 128, 167, 133, 251, 248, 254, 253, 242, 185, 191, 157,
-    203, 200, 158, 205, 194, 193, 199, 186, 218, 217, 223, 220, 162, 131, 214, 104,
-    41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,   4,
-    26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  74,  73,  79,  76,  67,  64,
-    70,  69,  91, 171, 191, 188, 179, 176, 182, 181, 138, 158, 157, 146, 145, 151,
-    148, 234, 254, 253, 242, 241, 247, 244, 203, 200, 206, 205, 194, 193, 199, 196,
-    218, 217, 223, 220, 211, 208, 214, 213,  62,  61,  50,  49,  55,  52,  31,  28,
-    19,  16,  22,  21, 127, 124, 115, 112, 118, 117,  94,  93,  82,  81,  87,  84
+	 171, 168, 174, 173, 196, 241, 247, 244, 134, 161, 224, 188, 179, 176, 182, 181,
+	 138, 137, 143, 140, 211, 208, 206, 230, 155, 152, 213, 229, 146, 145, 151, 148,
+	  42,  52,  84,  93,  28, 115,  11,  81,  49,  16,  19,  55, 124, 107,  61, 104,
+	  74,  73,  79,  76,  67,  64,  70,  69,  91,  88,  94,  22,  50,  87, 118, 117,
+	  82,  41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,
+	   4,  26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  62, 107,  31,  21, 112,
+	  88, 168, 174, 173, 162, 161, 167, 164, 186, 185, 137, 143, 140, 131, 128, 134,
+	 133, 155, 152, 239, 236, 227, 224, 230, 229, 251, 248,  42, 127,  11, 233, 164,
+	 234, 233, 239, 236, 227, 128, 167, 133, 251, 248, 254, 253, 242, 185, 191, 157,
+	 203, 200, 158, 205, 194, 193, 199, 186, 218, 217, 223, 220, 162, 131, 214, 104,
+	  41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,   4,
+	  26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  74,  73,  79,  76,  67,  64,
+	  70,  69,  91, 171, 191, 188, 179, 176, 182, 181, 138, 158, 157, 146, 145, 151,
+	 148, 234, 254, 253, 242, 241, 247, 244, 203, 200, 206, 205, 194, 193, 199, 196,
+	 218, 217, 223, 220, 211, 208, 214, 213,  62,  61,  50,  49,  55,  52,  31,  28,
+	  19,  16,  22,  21, 127, 124, 115, 112, 118, 117,  94,  93,  82,  81,  87,  84
 };
 
 /* in-place ascii2ebcdic conversion */
 static void ascii2ebcdic(unsigned char *str)
 {
-    int i;
-    int n = strlen((const char*)str);
-    for (i = 0; i < n; ++i)
-        str[i] = a2e[str[i]];
+	int i;
+	int n = strlen((const char*)str);
+	for (i = 0; i < n; ++i)
+		str[i] = a2e[str[i]];
 }
 
 /* Pad input string with EBCDIC spaces (0x40) up to eight bytes */
 static void ebcdic_padding(unsigned char *str)
 {
-    int i;
-    for (i = strlen((const char*)str); i < 9; ++i)
-        str[i] = 0x40;
-    str[9] = 0; /* terminate string */
+	int i;
+	for (i = strlen((const char*)str); i < 9; ++i)
+		str[i] = 0x40;
+	str[9] = 0; /* terminate string */
 }
 
 #ifdef RVARY_DEBUG
 static void print_hex(unsigned char *str, int len)
 {
-    int i;
-    for (i = 0; i < len; ++i)
-        printf("%02x", str[i]);
-    printf("\n");
+	int i;
+	for (i = 0; i < len; ++i)
+		printf("%02x", str[i]);
+	printf("\n");
 }
 #endif
 
+static struct fmt_tests rvary_tests[] = {
+	{"$rvary$*5AA70358A9C369E0", "QWERTY1"},
+	{"$rvary$*EB59EE07FC74AE77", "PASSWORD"},
+	{"$rvary$*062314297C496E0E", "AAAAAAAA"},
+	{"$rvary$*0FF48804F759193F", "TESTTEST"},
+	{NULL}
+};
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+static DES_key_schedule (*schedules);
+static int dirty;
+
 static void init(struct fmt_main *self)
 {
-    omp_autotune(self, OMP_SCALE);
+	omp_autotune(self, OMP_SCALE);
 
-    saved_key = mem_calloc(self->params.max_keys_per_crypt,
-            sizeof(*saved_key));
-    crypt_out = mem_calloc(self->params.max_keys_per_crypt,
-            sizeof(*crypt_out));
-    schedules = mem_calloc(self->params.max_keys_per_crypt,
-            sizeof(*schedules));
+	saved_key = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*saved_key));
+	crypt_out = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*crypt_out));
+	schedules = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*schedules));
 }
 
 static void done(void)
 {
-    MEM_FREE(schedules);
-    MEM_FREE(crypt_out);
-    MEM_FREE(saved_key);
+	MEM_FREE(schedules);
+	MEM_FREE(crypt_out);
+	MEM_FREE(saved_key);
 }
 
 static int valid(char *ciphertext, struct fmt_main *self)
 {
-    char *ctcopy;
-    char *keeptr;
-    int extra;
+	char *ctcopy;
+	char *keeptr;
+	int extra;
 
-    if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
-        return 0;
-    ctcopy = strdup(ciphertext);
-    keeptr = ctcopy;
-    ctcopy += FORMAT_TAG_LEN;
-    if (hexlenu(ctcopy, &extra) != CIPHERTEXT_LENGTH || extra)
-        goto err;
-    MEM_FREE(keeptr);
-    return 1;
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+		return 0;
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LEN;
+	if (hexlenu(ctcopy, &extra) != CIPHERTEXT_LENGTH || extra)
+		goto err;
+	MEM_FREE(keeptr);
+	return 1;
 
 err:
-    MEM_FREE(keeptr);
-    return 0;
+	MEM_FREE(keeptr);
+	return 0;
 }
 
 static void *get_binary(char *ciphertext)
 {
-    static union {
-        unsigned char c[BINARY_SIZE+1];
-        ARCH_WORD dummy;
-    } buf;
-    unsigned char *out = buf.c;
-    char *p;
-    int i;
+	static union {
+		unsigned char c[BINARY_SIZE+1];
+		ARCH_WORD dummy;
+	} buf;
+	unsigned char *out = buf.c;
+	char *p;
+	int i;
 
-    p = strrchr(ciphertext, '*') + 1;
-    for (i = 0; i < BINARY_SIZE; i++) {
-        out[i] =
-            (atoi16[ARCH_INDEX(*p)] << 4) |
-            atoi16[ARCH_INDEX(p[1])];
-        p += 2;
-    }
+	p = strrchr(ciphertext, '*') + 1;
+	for (i = 0; i < BINARY_SIZE; i++) {
+		out[i] =
+			(atoi16[ARCH_INDEX(*p)] << 4) |
+			atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
 
-    return out;
+	return out;
 }
 
 #define COMMON_GET_HASH_VAR crypt_out
@@ -192,120 +200,124 @@ static void *get_binary(char *ciphertext)
 
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
-    const int count = *pcount;
-    int index;
+	const int count = *pcount;
+	int index;
 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-    for (index = 0; index < count; index++) {
-        DES_cblock des_key;
-        int i;
+	for (index = 0; index < count; index++) {
+		if (dirty) {
+			DES_cblock des_key;
+			int i;
 
-        /* process key */
-        for (i = 0; saved_key[index][i]; i++)
-            des_key[i] = a2e_precomputed[ARCH_INDEX(saved_key[index][i])];
+			/* process key */
+			for (i = 0; saved_key[index][i]; i++)
+				des_key[i] = a2e_precomputed[ARCH_INDEX(saved_key[index][i])];
 
-        /* replace missing characters in the password with (EBCDIC space (0x40) XOR 0x55) << 1 */
-        while (i < 8)
-            des_key[i++] = 0x2a;
+			/* replace missing characters in userid by (EBCDIC space (0x40) XOR 0x55) << 1 */
+			while (i < 8)
+				des_key[i++] = 0x2a;
 
-        DES_set_key_unchecked(&des_key, &schedules[index]);
-        /* DES encrypt the password with the password itself by using the key as salt */
-        char key[10];
-        strnzcpy(key, saved_key[index], 9);
-        ascii2ebcdic((unsigned char *)key);
-        ebcdic_padding((unsigned char *)key);
-        DES_ecb_encrypt((const_DES_cblock*)key, (DES_cblock*)crypt_out[index], &schedules[index], DES_ENCRYPT);
-    }
+			DES_set_key_unchecked(&des_key, &schedules[index]);
+		}
+		/* DES encrypt the password with the password itself by using the key as salt */
+		char key[10];
+		strnzcpy(key, saved_key[index], 9);
+		ascii2ebcdic((unsigned char *)key);
+		ebcdic_padding((unsigned char *)key);
+		DES_ecb_encrypt((const_DES_cblock*)key, (DES_cblock*)crypt_out[index], &schedules[index], DES_ENCRYPT);
+	}
+	dirty = 0;
 
-    return count;
+	return count;
 }
 
 static int cmp_all(void *binary, int count)
 {
-    int index;
+	int index;
 
-    for (index = 0; index < count; index++)
-        if (!memcmp(binary, crypt_out[index], BINARY_SIZE))
-            return 1;
-    return 0;
+	for (index = 0; index < count; index++)
+		if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
+			return 1;
+	return 0;
 }
 
 static int cmp_one(void *binary, int index)
 {
-    return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
 }
 
 static int cmp_exact(char *source, int index)
 {
-    return 1;
+	return 1;
 }
 
 static void rvary_set_key(char *key, int index)
 {
-    strnzcpy(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
+	dirty = 1;
 }
 
 static char *get_key(int index)
 {
-    return saved_key[index];
+	return saved_key[index];
 }
 
 struct fmt_main fmt_rvary = {
-    {
-        FORMAT_LABEL,
-        FORMAT_NAME,
-        ALGORITHM_NAME,
-        BENCHMARK_COMMENT,
-        BENCHMARK_LENGTH,
-        0,
-        PLAINTEXT_LENGTH,
-        BINARY_SIZE,
-        BINARY_ALIGN,
-        SALT_SIZE,
-        SALT_ALIGN,
-        MIN_KEYS_PER_CRYPT,
-        MAX_KEYS_PER_CRYPT,
-        FMT_CASE | FMT_TRUNC | FMT_8_BIT | FMT_OMP | FMT_OMP_BAD,
-        { NULL },
-        { FORMAT_TAG },
-        rvary_tests
-    }, {
-        init,
-        done,
-        fmt_default_reset,
-        fmt_default_prepare,
-        valid,
-        fmt_default_split,
-        get_binary,
-        fmt_default_salt,
-        { NULL },
-        fmt_default_source,
-        {
-            fmt_default_binary_hash_0,
-            fmt_default_binary_hash_1,
-            fmt_default_binary_hash_2,
-            fmt_default_binary_hash_3,
-            fmt_default_binary_hash_4,
-            fmt_default_binary_hash_5,
-            fmt_default_binary_hash_6
-        },
-        fmt_default_salt_hash,
-        NULL,
-        fmt_default_set_salt,
-        rvary_set_key,
-        get_key,
-        fmt_default_clear_keys,
-        crypt_all,
-        {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_TRUNC | FMT_8_BIT | FMT_OMP | FMT_OMP_BAD,
+		{ NULL },
+		{ FORMAT_TAG },
+		rvary_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		valid,
+		fmt_default_split,
+		get_binary,
+		fmt_default_salt,
+		{ NULL },
+		fmt_default_source,
+		{
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
+		},
+		fmt_default_salt_hash,
+		NULL,
+		fmt_default_set_salt,
+		rvary_set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
 #define COMMON_GET_HASH_LINK
 #include "common-get-hash.h"
-        },
-        cmp_all,
-        cmp_one,
-        cmp_exact
-    }
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
 };
 
 #endif /* plugin stanza */

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -210,7 +210,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
                 des_key[i] = a2e_precomputed[ARCH_INDEX(saved_key[index][i])];
 
             /* replace missing characters in userid by (EBCDIC space (0x40) XOR 0x55) << 1 */
-            while (i < 9)
+            while (i < 8)
                 des_key[i++] = 0x2a;
 
             DES_set_key_unchecked(&des_key, &schedules[index]);

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -233,7 +233,7 @@ static int cmp_all(void *binary, int count)
     int index;
 
     for (index = 0; index < count; index++)
-        if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
+        if (!memcmp(binary, crypt_out[index], BINARY_SIZE))
             return 1;
     return 0;
 }

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -214,7 +214,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
         /* DES encrypt the password with the password itself by using the key as salt */
         char key[10];
         strnzcpy(key, saved_key[index], 9);
-        key[9] = 0;
         ascii2ebcdic((unsigned char *)key);
         ebcdic_padding((unsigned char *)key);
         DES_ecb_encrypt((const_DES_cblock*)key, (DES_cblock*)crypt_out[index], &schedules[index], DES_ENCRYPT);

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -16,19 +16,12 @@ extern struct fmt_main fmt_rvary;
 john_register_one(&fmt_rvary);
 #else
 
-#include <string.h>
 #include <openssl/des.h>
 
 #ifdef _OPENMP
 #include <omp.h>
 #endif
 
-#include "arch.h"
-#include "crc32.h"
-#include "misc.h"
-#include "common.h"
-#include "formats.h"
-#include "params.h"
 #include "options.h"
 
 #define FORMAT_LABEL            "RVARY"

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -45,6 +45,19 @@ john_register_one(&fmt_rvary);
 #define OMP_SCALE               4
 #endif
 
+static struct fmt_tests rvary_tests[] = {
+    {"$rvary$**5AA70358A9C369E0", "QWERTY1"},
+    {"$rvary$**EB59EE07FC74AE77", "PASSWORD"},
+    {"$rvary$**062314297C496E0E", "AAAAAAAA"},
+    {"$rvary$**0FF48804F759193F", "TESTTEST"},
+    {NULL}
+};
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+static DES_key_schedule (*schedules);
+static int dirty;
+
 static const unsigned char a2e[256] = {
     0,  1,  2,  3, 55, 45, 46, 47, 22,  5, 37, 11, 12, 13, 14, 15,
     16, 17, 18, 19, 60, 61, 50, 38, 24, 25, 63, 39, 28, 29, 30, 31,
@@ -113,19 +126,6 @@ static void print_hex(unsigned char *str, int len)
     printf("\n");
 }
 #endif
-
-static struct fmt_tests rvary_tests[] = {
-    {"$rvary$**5AA70358A9C369E0", "QWERTY1"},
-    {"$rvary$**EB59EE07FC74AE77", "PASSWORD"},
-    {"$rvary$**062314297C496E0E", "AAAAAAAA"},
-    {"$rvary$**0FF48804F759193F", "TESTTEST"},
-    {NULL}
-};
-
-static char (*saved_key)[PLAINTEXT_LENGTH + 1];
-static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
-static DES_key_schedule (*schedules);
-static int dirty;
 
 static void init(struct fmt_main *self)
 {

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -1,0 +1,325 @@
+/*
+ * Cracker for RVARY STATUS and RVARY SWITCH commands of RACF
+ *
+ * This software is Copyright (c) 2020 Davide Girardi <davidegirardi smtpgoogle>,
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * Dump format: $rvary$**hash
+ *
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_rvary;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_rvary);
+#else
+
+#include <string.h>
+#include <openssl/des.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "arch.h"
+#include "crc32.h"
+#include "misc.h"
+#include "common.h"
+#include "formats.h"
+#include "params.h"
+#include "options.h"
+
+#define FORMAT_LABEL            "RVARY"
+#define FORMAT_NAME             ""
+#define FORMAT_TAG              "$rvary$*"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME          "DES 32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        7
+#define PLAINTEXT_LENGTH        8
+#define CIPHERTEXT_LENGTH       16
+#define BINARY_SIZE             8
+#define SALT_SIZE               0
+#define BINARY_ALIGN            sizeof(uint32_t)
+#define SALT_ALIGN              1
+
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      256
+
+#ifndef OMP_SCALE
+#define OMP_SCALE               4 // Tuned w/ MKPC for super
+#endif
+
+static const unsigned char a2e[256] = {
+	0,  1,  2,  3, 55, 45, 46, 47, 22,  5, 37, 11, 12, 13, 14, 15,
+	16, 17, 18, 19, 60, 61, 50, 38, 24, 25, 63, 39, 28, 29, 30, 31,
+	64, 79,127,123, 91,108, 80,125, 77, 93, 92, 78,107, 96, 75, 97,
+	240,241,242,243,244,245,246,247,248,249,122, 94, 76,126,110,111,
+	124,193,194,195,196,197,198,199,200,201,209,210,211,212,213,214,
+	215,216,217,226,227,228,229,230,231,232,233, 74,224, 90, 95,109,
+	121,129,130,131,132,133,134,135,136,137,145,146,147,148,149,150,
+	151,152,153,162,163,164,165,166,167,168,169,192,106,208,161,  7,
+	32, 33, 34, 35, 36, 21,  6, 23, 40, 41, 42, 43, 44,  9, 10, 27,
+	48, 49, 26, 51, 52, 53, 54,  8, 56, 57, 58, 59,  4, 20, 62,225,
+	65, 66, 67, 68, 69, 70, 71, 72, 73, 81, 82, 83, 84, 85, 86, 87,
+	88, 89, 98, 99,100,101,102,103,104,105,112,113,114,115,116,117,
+	118,119,120,128,138,139,140,141,142,143,144,154,155,156,157,158,
+	159,160,170,171,172,173,174,175,176,177,178,179,180,181,182,183,
+	184,185,186,187,188,189,190,191,202,203,204,205,206,207,218,219,
+	220,221,222,223,234,235,236,237,238,239,250,251,252,253,254,255
+};
+
+/* This is a2e[] with each entry XOR 0x55, left-shifted one bit
+   and finally with odd parity so that DES_set_key_unchecked
+   can be used directly.  This provides about 15% speed up.    */
+static const unsigned char a2e_precomputed[256] = {
+	 171, 168, 174, 173, 196, 241, 247, 244, 134, 161, 224, 188, 179, 176, 182, 181,
+	 138, 137, 143, 140, 211, 208, 206, 230, 155, 152, 213, 229, 146, 145, 151, 148,
+	  42,  52,  84,  93,  28, 115,  11,  81,  49,  16,  19,  55, 124, 107,  61, 104,
+	  74,  73,  79,  76,  67,  64,  70,  69,  91,  88,  94,  22,  50,  87, 118, 117,
+	  82,  41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,
+	   4,  26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  62, 107,  31,  21, 112,
+	  88, 168, 174, 173, 162, 161, 167, 164, 186, 185, 137, 143, 140, 131, 128, 134,
+	 133, 155, 152, 239, 236, 227, 224, 230, 229, 251, 248,  42, 127,  11, 233, 164,
+	 234, 233, 239, 236, 227, 128, 167, 133, 251, 248, 254, 253, 242, 185, 191, 157,
+	 203, 200, 158, 205, 194, 193, 199, 186, 218, 217, 223, 220, 162, 131, 214, 104,
+	  41,  47,  44,  35,  32,  38,  37,  59,  56,   8,  14,  13,   2,   1,   7,   4,
+	  26,  25, 110, 109,  98,  97, 103, 100, 122, 121,  74,  73,  79,  76,  67,  64,
+	  70,  69,  91, 171, 191, 188, 179, 176, 182, 181, 138, 158, 157, 146, 145, 151,
+	 148, 234, 254, 253, 242, 241, 247, 244, 203, 200, 206, 205, 194, 193, 199, 196,
+	 218, 217, 223, 220, 211, 208, 214, 213,  62,  61,  50,  49,  55,  52,  31,  28,
+	  19,  16,  22,  21, 127, 124, 115, 112, 118, 117,  94,  93,  82,  81,  87,  84
+};
+
+/* in-place ascii2ebcdic conversion */
+static void ascii2ebcdic(unsigned char *str)
+{
+	int i;
+	int n = strlen((const char*)str);
+	for (i = 0; i < n; ++i)
+		str[i] = a2e[str[i]];
+}
+
+/* Pad input string with EBCDIC spaces (0x40) up to eight bytes */
+static void ebcdic_padding(unsigned char *str)
+{
+	int i;
+	for (i = strlen((const char*)str); i < 9; ++i)
+		str[i] = 0x40;
+	str[9] = 0; /* terminate string */
+}
+
+#ifdef RVARY_DEBUG
+static void print_hex(unsigned char *str, int len)
+{
+	int i;
+	for (i = 0; i < len; ++i)
+		printf("%02x", str[i]);
+	printf("\n");
+}
+#endif
+
+static struct fmt_tests rvary_tests[] = {
+	{"$rvary$**5AA70358A9C369E0", "QWERTY1"},
+	{"$rvary$**EB59EE07FC74AE77", "PASSWORD"},
+	{"$rvary$**062314297C496E0E", "AAAAAAAA"},
+	{"$rvary$**0FF48804F759193F", "TESTTEST"},
+	{NULL}
+};
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+static DES_key_schedule (*schedules);
+static int dirty;
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+
+	saved_key = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*saved_key));
+	crypt_out = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*crypt_out));
+	schedules = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*schedules));
+}
+
+static void done(void)
+{
+	MEM_FREE(schedules);
+	MEM_FREE(crypt_out);
+	MEM_FREE(saved_key);
+}
+
+static int valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy;
+	char *keeptr;
+	int extra;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+		return 0;
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LEN;
+	ctcopy += 1; /* Skip empty salt */
+	if (hexlenu(ctcopy, &extra) != CIPHERTEXT_LENGTH || extra)
+		goto err;
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+static void *get_binary(char *ciphertext)
+{
+	static union {
+		unsigned char c[BINARY_SIZE+1];
+		ARCH_WORD dummy;
+	} buf;
+	unsigned char *out = buf.c;
+	char *p;
+	int i;
+
+	p = strrchr(ciphertext, '*') + 1;
+		for (i = 0; i < BINARY_SIZE; i++) {
+		out[i] =
+		    (atoi16[ARCH_INDEX(*p)] << 4) |
+		    atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+
+	return out;
+}
+
+#define COMMON_GET_HASH_VAR crypt_out
+#include "common-get-hash.h"
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index++) {
+		if (dirty) {
+			DES_cblock des_key;
+			int i;
+
+			/* process key */
+			for (i = 0; saved_key[index][i]; i++)
+				des_key[i] = a2e_precomputed[ARCH_INDEX(saved_key[index][i])];
+
+			/* replace missing characters in userid by (EBCDIC space (0x40) XOR 0x55) << 1 */
+			while(i < 9)
+				des_key[i++] = 0x2a;
+
+			DES_set_key_unchecked(&des_key, &schedules[index]);
+		}
+		/* DES encrypt the password with the password itself by using the key as salt */
+        char key[10];
+        strnzcpy(key, saved_key[index], 9);
+        key[9] = 0;
+        ascii2ebcdic((unsigned char *)key);
+        ebcdic_padding((unsigned char *)key);
+		DES_ecb_encrypt((const_DES_cblock*)key, (DES_cblock*)crypt_out[index], &schedules[index], DES_ENCRYPT);
+	}
+	dirty = 0;
+
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+static void rvary_set_key(char *key, int index)
+{
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
+	dirty = 1;
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+struct fmt_main fmt_rvary = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_TRUNC | FMT_8_BIT | FMT_OMP | FMT_OMP_BAD,
+		{ NULL },
+		{ FORMAT_TAG },
+		rvary_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		valid,
+		fmt_default_split,
+		get_binary,
+		fmt_default_salt,
+		{ NULL },
+		fmt_default_source,
+		{
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
+		},
+		fmt_default_salt_hash,
+		NULL,
+		fmt_default_set_salt,
+		rvary_set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+#define COMMON_GET_HASH_LINK
+#include "common-get-hash.h"
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -42,7 +42,7 @@ john_register_one(&fmt_rvary);
 #define MAX_KEYS_PER_CRYPT      256
 
 #ifndef OMP_SCALE
-#define OMP_SCALE               4 // Tuned w/ MKPC for super
+#define OMP_SCALE               4
 #endif
 
 static const unsigned char a2e[256] = {

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -210,7 +210,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
                 des_key[i] = a2e_precomputed[ARCH_INDEX(saved_key[index][i])];
 
             /* replace missing characters in userid by (EBCDIC space (0x40) XOR 0x55) << 1 */
-            while(i < 9)
+            while (i < 9)
                 des_key[i++] = 0x2a;
 
             DES_set_key_unchecked(&des_key, &schedules[index]);

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -46,10 +46,10 @@ john_register_one(&fmt_rvary);
 #endif
 
 static struct fmt_tests rvary_tests[] = {
-    {"$rvary$**5AA70358A9C369E0", "QWERTY1"},
-    {"$rvary$**EB59EE07FC74AE77", "PASSWORD"},
-    {"$rvary$**062314297C496E0E", "AAAAAAAA"},
-    {"$rvary$**0FF48804F759193F", "TESTTEST"},
+    {"$rvary$*5AA70358A9C369E0", "QWERTY1"},
+    {"$rvary$*EB59EE07FC74AE77", "PASSWORD"},
+    {"$rvary$*062314297C496E0E", "AAAAAAAA"},
+    {"$rvary$*0FF48804F759193F", "TESTTEST"},
     {NULL}
 };
 
@@ -156,7 +156,6 @@ static int valid(char *ciphertext, struct fmt_main *self)
     ctcopy = strdup(ciphertext);
     keeptr = ctcopy;
     ctcopy += FORMAT_TAG_LEN;
-    ctcopy += 1; /* Skip empty salt */
     if (hexlenu(ctcopy, &extra) != CIPHERTEXT_LENGTH || extra)
         goto err;
     MEM_FREE(keeptr);


### PR DESCRIPTION
Support cracking hashes found by tools like [Mainframed's ENUM](https://github.com/mainframed/Enumeration/blob/master/ENUM).

If a mainframe runs RACF, there are 2 subcommands to check the status of the RACF database and to switch between the primary and secondary databases. This PR enables JrR to crack those hashes.