### PR TITLE
7z2john.pl: Avoid crash when a stream has "no methods"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,10 @@ tab_width = 8
 indent_style = space
 indent_size = 2
 
+[7z2john.pl]
+indent_style = space
+indent_size = 2
+
 # M4 is a bastard
 [*.{ac,m4}]
 indent_style = space

--- a/run/7z2john.pl
+++ b/run/7z2john.pl
@@ -1430,6 +1430,8 @@ sub extract_hash_from_archive
 
             for (my $coders_idx = 0; $coders_idx < $number_coders; $coders_idx++)
             {
+              next unless defined @$coders[$coders_idx];
+
               my $codec_id = @$coders[$coders_idx]->{'codec_id'};
 
               if ($codec_id eq $SEVEN_ZIP_AES)


### PR DESCRIPTION
While there may be more to this issue (#4496) this patch can't do any harm for now.