### PR TITLE
New rule-reject flags for stacked (or not) rules

### DIFF
--- a/doc/RULES
+++ b/doc/RULES
@@ -28,6 +28,8 @@ natively.  Those additional commands may also be useful on their own.
 -8	reject this rule unless current hash type uses 8-bit characters
 -s	reject this rule unless some password hashes were split at loading
 -p	reject this rule unless word pair commands are currently allowed
+-R	reject this rule unless stacked rules will be applied later
+-S	reject this rule if stacked rules will be applied later
 -u	reject this rule if an internal codepage is configured (doc/ENCODINGS)
 -U	reject this rule unless an internal codepage is configured
 ->N	reject this rule unless length N or longer is supported

--- a/src/rules.c
+++ b/src/rules.c
@@ -724,6 +724,13 @@ char *rules_reject(char *rule, int split, char *last, struct db_main *db)
 			if (options.internal_cp != UTF_8 && options.internal_cp != ENC_RAW) continue;
 			return NULL;
 
+		case 'R':
+			if (rules_stacked_after) continue;
+			return NULL;
+
+		case 'S':
+			if (!rules_stacked_after) continue;
+			return NULL;
 /*
  * Any failed UTF-8-to-codepage translations change '-U' to '--' in
  * rpp_process_rule(), as an "always reject" hack.


### PR DESCRIPTION
-R      reject this rule unless stacked rules will be applied later
-S      reject this rule if stacked rules will be applied later

```
cat <<EOL > test.conf
.include <john.conf>
[List.Rules:teststack]
# This rule only applied if stacked rules come later
-R Az"_addR"
# This rule *not* applied if stacked rules come later
-S Az"_addS"
EOL
$ echo magnum > words

$ ../run/john -conf:test.conf -stdout -w:words -rules:teststack
magnum_addS

$ ../run/john -conf:test.conf -stdout -w:words -rules-stack:teststack
magnum_addS

$ ../run/john -conf:test.conf -stdout -w:words -rules:teststack -rules-stack:teststack
magnum_addR_addS

$ ../run/john -conf:test.conf -stdout -mask:magnum -rules-stack:teststack
magnum_addS

$ ../run/john -conf:test.conf -stdout --prince:words -max-len=16 -rules:teststack
magnum_addS

$ ../run/john -conf:test.conf -stdout --prince:words -max-len=16 -rules-stack:teststack
magnum_addS

$ ../run/john -conf:test.conf -stdout --prince:words -max-len=16 -rules:teststack -rules-stack:teststack
magnum_addR_addS
```