### PR TITLE
Bugfixes for --rules-stack

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -563,6 +563,8 @@ int rules_init_stack(char *ruleset, rule_stack *stack_ctx,
 		rules_init(db, options.eff_maxlength + mask_add_len);
 		rule_count = rules_count(&ctx, -1);
 
+		rules_stacked_after = 0;
+
 		if (john_main_process)
 			log_event("- %d preprocessed stacked rules", rule_count);
 
@@ -609,6 +611,8 @@ int rules_init_stack(char *ruleset, rule_stack *stack_ctx,
 			log_event("- No stacked rules");
 	}
 
+	rules_stacked_after = rule_count && (options.flags & FLG_RULES_CHK);
+
 	return rule_count;
 }
 
@@ -634,6 +638,8 @@ void rules_init(struct db_main *db, int max_length)
 		rules_init_convs();
 	}
 	rules_init_length(max_length);
+
+	rules_stacked_after = (options.flags & FLG_RULES_CHK) && (options.flags & FLG_RULES_STACK_CHK);
 }
 
 char *rules_reject(char *rule, int split, char *last, struct db_main *db)
@@ -1857,7 +1863,7 @@ char *rules_process_stack(char *key, rule_stack *ctx)
 	if ((word = rules_apply(key, ctx->rule->data, -1, last)))
 		last = word;
 
-	rules_stacked_after = 1;
+	rules_stacked_after = !!(options.flags & FLG_RULES_CHK);
 
 	return word;
 }
@@ -1897,7 +1903,7 @@ char *rules_process_stack_all(char *key, rule_stack *ctx)
 		}
 	}
 
-	rules_stacked_after = 1;
+	rules_stacked_after = !!(options.flags & FLG_RULES_CHK);
 
 	if (!stack_rules_mute && options.verbosity <= VERB_DEFAULT) {
 		stack_rules_mute = 1;


### PR DESCRIPTION
While experimenting with "stacked rules reject flags" (#4508) I noticed the rules_stacked_after variable wasn't always "in sync" due to how/when various modes reject/accept rules, and other things.

I'm not sure the bug actually manifested itself much but among other things things there could have been some problems with ignoring max. lengths when we know more rules will be applied later, things like that.