### PR TITLE
Travis CI: conditionally skip some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: c
 dist: bionic
+os: linux
 
-matrix:
+jobs:
   include:
 
   # #### CPU formats test (gcc)
@@ -56,16 +57,6 @@ matrix:
   - os: osx
     osx_image: xcode9.4
     env: OPENCL="yes"
-
-  # #########################################
-  # #### Extra Testing Scheme
-  # #########################################
-
-  # #### Intel OpenCL runtime Docker based testing
-  - if: branch = bleeding-jumbo AND env(TRAVIS_PULL_REQUEST) = false
-    os: linux
-    compiler: gcc
-    env: DOCKER="yes" OPENCL="yes"
 
 script:
   - .travis/travis-ci.sh

--- a/.travis/travis-ci.sh
+++ b/.travis/travis-ci.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+# if requested, run all tests
+if [[ "$TRAVIS_PULL_REQUEST_BRANCH" != "force-travis" ]]; then
+
+    # on the main branch, run all tests
+    if [[ "$TRAVIS_BRANCH" != "bleeding-jumbo" || "$TRAVIS_PULL_REQUEST" =~ ^[0-9]+$ ]]; then
+
+#        # otherwise, run only Linux jobs for now
+#        if [[ "$TRAVIS_OS_NAME" != "linux" ]]; then
+            echo '---------------------------------- Skipping CI ---------------------------------'
+            echo 'In order to spare resources, skip Travis CI build.'
+            echo '--------------------------------------------------------------------------------'
+
+            # Nothing to do.
+            exit 0
+#        fi
+    fi
+fi
+
 # Need a docker image to run the tests
 if [[ "$DOCKER" == "yes" ]]; then
     docker run --cap-add SYS_PTRACE -v "$(pwd)":/cwd claudioandre/john:opencl sh -c \


### PR DESCRIPTION
Based on Claudio's changes proposed in #4484

Claudio, why did you propose to exclude "Extra Testing Scheme", which was testing with Intel OpenCL in Docker, and which we only ran on already merged PRs (IIUC)? Is this only to spare resources (roughly how much, e.g. what portion of our total usage of Travis?), or were you planning to retire that Docker image for other reasons (why?), or something else? I do include this change of yours in here right now, but we might want to exclude it, depending on your answers.

I think ideally we should be able to manually trigger Travis runs for PRs when we need them - perhaps when we're deciding on merging a PR that makes code changes (not just documentation or such). With Circle, there's a way to have tests run only once a pull request is approved - this isn't exactly what I just described, but it's close. Is there a similar feature with Travis?

No luck getting an "OSS allotment" from them yet, although they did reply. My impression (they didn't say so explicitly) is they're probably struggling financially. So Travis won't run yet, but I am considering paying them for some credits (will need to figure this out first), at which point these changes would matter.

BTW, testing on macOS costs 5x more credits than testing on Linux.