### PR TITLE
More bug fixes for stacked rules

### DIFF
--- a/src/batch.c
+++ b/src/batch.c
@@ -16,14 +16,17 @@
 #include "loader.h"
 #include "status.h"
 #include "config.h"
+#include "options.h"
 #include "single.h"
 #include "wordlist.h"
 #include "inc.h"
 
 static void do_single_pass(struct db_main *db)
 {
+	options.flags |= FLG_SINGLE_CHK; /* Make tests elsewhere easier/safer */
 	do_single_crack(db);
 	db->options->flags &= ~DB_WORDS; /* Might speed up pot sync */
+	options.flags &= ~FLG_SINGLE_CHK;
 }
 
 static void do_wordlist_pass(struct db_main *db)

--- a/src/cracker.c
+++ b/src/cracker.c
@@ -240,12 +240,11 @@ void crk_init(struct db_main *db, void (*fix_state)(void),
 		kpc_warn_limit = CRK_KPC_WARN;
 
 	if (!(options.flags & FLG_SINGLE_CHK))
-		crk_stacked_rule_count =
-			rules_init_stack(options.rule_stack, &crk_rule_stack, db);
+		rules_stacked_after = !!(crk_stacked_rule_count = rules_init_stack(options.rule_stack, &crk_rule_stack, db));
 	else
 		crk_stacked_rule_count = 0;
 
-	if (!(rules_stacked_after = (crk_stacked_rule_count > 0)))
+	if (crk_stacked_rule_count == 0)
 		crk_stacked_rule_count = 1;
 
 	if (rules_stacked_after)

--- a/src/rules.c
+++ b/src/rules.c
@@ -611,7 +611,7 @@ int rules_init_stack(char *ruleset, rule_stack *stack_ctx,
 			log_event("- No stacked rules");
 	}
 
-	rules_stacked_after = rule_count && (options.flags & FLG_RULES_CHK);
+	rules_stacked_after = rule_count && (options.flags & (FLG_RULES_CHK | FLG_SINGLE_CHK));
 
 	return rule_count;
 }
@@ -639,7 +639,7 @@ void rules_init(struct db_main *db, int max_length)
 	}
 	rules_init_length(max_length);
 
-	rules_stacked_after = (options.flags & FLG_RULES_CHK) && (options.flags & FLG_RULES_STACK_CHK);
+	rules_stacked_after = options.flags & (FLG_RULES_CHK | FLG_SINGLE_CHK) && (options.flags & FLG_RULES_STACK_CHK);
 }
 
 char *rules_reject(char *rule, int split, char *last, struct db_main *db)
@@ -1863,7 +1863,7 @@ char *rules_process_stack(char *key, rule_stack *ctx)
 	if ((word = rules_apply(key, ctx->rule->data, -1, last)))
 		last = word;
 
-	rules_stacked_after = !!(options.flags & FLG_RULES_CHK);
+	rules_stacked_after = !!(options.flags & (FLG_RULES_CHK | FLG_SINGLE_CHK));
 
 	return word;
 }
@@ -1903,7 +1903,7 @@ char *rules_process_stack_all(char *key, rule_stack *ctx)
 		}
 	}
 
-	rules_stacked_after = !!(options.flags & FLG_RULES_CHK);
+	rules_stacked_after = !!(options.flags & (FLG_RULES_CHK || FLG_SINGLE_CHK));
 
 	if (!stack_rules_mute && options.verbosity <= VERB_DEFAULT) {
 		stack_rules_mute = 1;


### PR DESCRIPTION
It hit me #4509 wasn't complete - I forgot about single mode, let alone batch mode.

Single mode and batch mode sometimes wouldn't have the rules_stacked_after variable "in sync".

Also adds a hack in batch.c making many existing Jumbo tests for single mode more reliable. For batch mode, changing the `cracker.c` test from `if (options.flags & FLG_SINGLE_CHK)` to `if (options.flags & (FLG_SINGLE_CHK | FLG_BATCH_CHK)` wouldn't cut it - it really needed to reflect if we're in single mode **right now**.