### PR TITLE
Fixes and tweaks

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -334,12 +334,12 @@ static void john_log_format2(void)
 	/* Messages require extra info not available in john_log_format().
 		These are delayed until mask_init(), fmt_reset() */
 	chunk = min_chunk = database.format->params.max_keys_per_crypt;
-	if (options.flags & (FLG_SINGLE_CHK | FLG_BATCH_CHK) &&
-	    chunk < SINGLE_HASH_MIN)
-			chunk = SINGLE_HASH_MIN;
+	if (options.force_maxkeys && options.force_maxkeys < chunk)
+		chunk = min_chunk = options.force_maxkeys;
+	if ((options.flags & (FLG_SINGLE_CHK | FLG_BATCH_CHK)) && chunk < SINGLE_HASH_MIN)
+		chunk = SINGLE_HASH_MIN;
 	if (chunk > 1)
-		log_event("- Candidate passwords %s be buffered and "
-			"tried in chunks of %d",
+		log_event("- Candidate passwords %s be buffered and tried in chunks of %d",
 			min_chunk > 1 ? "will" : "may",
 			chunk);
 }

--- a/src/mask.c
+++ b/src/mask.c
@@ -2130,6 +2130,12 @@ void mask_init(struct db_main *db, char *unprocessed_mask)
 	    !strcasecmp(mask_fmt->params.label, "lm-opencl"))
 		format_cannot_reset = 1;
 
+	/* Using "--mask" alone will use default mask and iterate over length */
+	if (!(options.flags & FLG_MASK_STACKED) && !unprocessed_mask &&
+	    options.req_minlength < 0 && !options.req_maxlength)
+		mask_increments_len = 1;
+
+	/* Specified length range given */
 	if ((options.req_minlength >= 0 || options.req_maxlength) &&
 	    (options.eff_minlength != options.eff_maxlength) &&
 	    !(options.flags & FLG_MASK_STACKED))


### PR DESCRIPTION
Two commits:

Have the "buffered and tried" log message reflect --mkpc option (#4511)

When `--mask` is given alone, a default mask of `?1?2?2?2?2?2?2?3?3?3?3?d?d?d?d` is used (same as hashcat's). That is barely of any use ever unless we iterate over length, so let's default to that. If you'd ever want the old behavior, just use `--len=15`.