### PR TITLE
timer: Add sTimer_GetNano, and drop obsolete fallback, for lower overhead

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -370,7 +370,7 @@ bitlocker2john.o:	bitlocker2john.c autoconfig.h arch.h missing_getopt.h jumbo.h 
 
 list.o:	list.c memory.h arch.h list.h os.h os-autoconf.h autoconfig.h jumbo.h
 
-listconf.o:	listconf.c autoconfig.h os.h os-autoconf.h jumbo.h arch.h simd-intrinsics.h common.h memory.h pseudo_intrinsics.h aligned.h simd-intrinsics-load-flags.h params.h path.h formats.h misc.h options.h list.h loader.h getopt.h unicode.h dynamic.h dynamic_types.h config.h regex.h john_build_rule.h $(CL_COMMON_HEADER) $(CL_DEVICE_HEADER) version.h listconf.h
+listconf.o:	listconf.c autoconfig.h os.h os-autoconf.h jumbo.h arch.h simd-intrinsics.h common.h memory.h pseudo_intrinsics.h aligned.h simd-intrinsics-load-flags.h params.h path.h formats.h misc.h options.h list.h loader.h getopt.h unicode.h dynamic.h dynamic_types.h config.h regex.h john_build_rule.h $(CL_COMMON_HEADER) $(CL_DEVICE_HEADER) version.h listconf.h timer.h
 
 LM_fmt.o:	LM_fmt.c arch.h misc.h jumbo.h autoconfig.h memory.h DES_bs.h common.h loader.h params.h list.h formats.h os.h os-autoconf.h
 

--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -1716,7 +1716,7 @@ generic.h:
 bench: $(BENCH_OBJS)
 	$(LD) $(BENCH_OBJS) $(LDFLAGS) -o bench
 
-listconf.o: version.h listconf.h listconf.c
+listconf.o: version.h listconf.h listconf.c timer.h
 
 dynamic_big_crypt.c: dynamic_big_crypt_hash.cin dynamic_big_crypt_header.cin dynamic_big_crypt_generator.sh dynamic_big_crypt_chopper.pl unused/dynamic_big_crypt.c
 	$(shell ./dynamic_big_crypt_generator.sh)

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -142,10 +142,6 @@ static void listconf_list_build_info(void)
 #ifdef __GNU_MP_VERSION
 	int gmp_major, gmp_minor, gmp_patchlevel;
 #endif
-	sTimer test;
-
-	sTimer_Init(&test);
-
 	puts("Version: " JTR_GIT_VERSION);
 	puts("Build: " JOHN_BLD _MP_VERSION DEBUG_STRING ASAN_STRING UBSAN_STRING);
 #ifdef SIMD_COEF_32
@@ -323,13 +319,15 @@ static void listconf_list_build_info(void)
 	printf("times(2) CLK_TCK is %ld\n", clk_tck);
 #endif
 #if defined (__MINGW32__) || defined (_MSC_VER)
-	printf("Using clock(3) for timers, claimed resolution %ss, observed %ss\n",
-	       human_prefix_small(1.0 / CLOCKS_PER_SEC),
-	       human_prefix_small(1.0 / sm_cPrecision));
+	printf("Using clock(3) for timers, resolution %ss\n", human_prefix_small(1.0 / CLOCKS_PER_SEC));
 #else
 	printf("Using times(2) for timers, resolution %ss\n", human_prefix_small(1.0 / clk_tck));
 #endif
-	printf("HR timer claimed resolution %ss, observed %ss\n", human_prefix_small(1.0 / sm_HRTicksPerSec), human_prefix_small(1.0 / sm_hrPrecision));
+	int latency;
+	uint64_t precision = john_timer_stats(&latency);
+
+	printf("HR timer: %s, %s %ss\n", john_nano_clock, latency ? "latency" : "resolution",
+	       human_prefix_small(precision / 1000000000.0));
 
 	int64_t total_mem = host_total_mem();
 

--- a/src/omp_autotune.c
+++ b/src/omp_autotune.c
@@ -19,8 +19,8 @@
 #define CONF_SECTION SECTION_OPTIONS, ":CPUtune"
 
 static int use_preset, max_no_progress;
-static double sample_time, req_gain, max_tune_time;
-
+static double req_gain, max_tune_time;
+static uint64_t sample_time;
 static struct fmt_main *fmt;
 static int omp_autotune_running;
 static int mkpc;
@@ -42,7 +42,7 @@ void omp_autotune_init(void)
 #endif
 	if ((ci = cfg_get_int(CONF_SECTION, "AutoTuneSampleTime")) < 0)
 		ci = 10;
-	sample_time = (double)ci / 1000.0;
+	sample_time = ci * 1000000ULL;
 	if ((ci = cfg_get_int(CONF_SECTION, "AutoTuneReqGain")) < 0)
 		ci = 5;
 	req_gain = (double)ci / 100.0 + 1.0;
@@ -108,7 +108,7 @@ void omp_autotune_run(struct db_main *db)
 	int tune_cost;
 	void *salt;
 	char key[PLAINTEXT_BUFFER_SIZE] = "tUne0000";
-	sTimer timer;
+	uint64_t start, end;
 	double duration;
 
 	if (!fmt || omp_scale == 1 || tune_preset)
@@ -143,7 +143,6 @@ void omp_autotune_run(struct db_main *db)
 		printf("\n");
 	}
 
-	sTimer_Init(&timer);
 	do {
 		int i;
 		int min_kpc = fmt->params.min_keys_per_crypt;
@@ -180,18 +179,18 @@ void omp_autotune_run(struct db_main *db)
 		// Tell format this is a speed test
 		benchmark_running++;
 
-		sTimer_Start(&timer, 1);
+		start = john_get_nano();
 		do {
 			int count = this_kpc;
 
 			fmt->methods.crypt_all(&count, NULL);
 			crypts += count;
-		} while (crypts < min_crypts || sTimer_GetSecs(&timer) < sample_time);
-		sTimer_Stop(&timer);
+			end = john_get_nano();
+		} while (crypts < min_crypts || (end - start) < sample_time);
 
 		benchmark_running--;
 
-		duration = sTimer_GetSecs(&timer);
+		duration = (end - start) / 1E9;
 		cps = crypts / duration;
 
 		if (john_main_process && options.verbosity >= VERB_MAX) {

--- a/src/timer.h
+++ b/src/timer.h
@@ -1,122 +1,16 @@
 /*
- * This file is
- * Copyright (c) 2009 by Jim Fougeron jfoug AT cox dot net
- * Copyright (c) 2019 by magnum
+ * This file is Copyright (c) 2021 by magnum
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
- *
- * Portable hi-res timer.  Was a nice C++ class. Downgraded to C for john.
  */
 
-#ifndef _HAVE_TIMER_H
-#define _HAVE_TIMER_H
+#ifndef _JOHN_TIMER_H
+#define _JOHN_TIMER_H
 
-#include <time.h>
+extern const char* john_nano_clock;
 
-/* Windows - use provided hi-res timer */
-#if defined (_MSC_VER) || defined (__MINGW32__) || defined (__CYGWIN32__)
+extern uint64_t john_get_nano(void);            // Get a nanosecond timestamp
+extern uint64_t john_timer_stats(int *latency); // Return resolution/latency
 
-#include <sys/timeb.h>      /* for ftime(), which is not used */
-#undef MEM_FREE
-#include <windows.h>
-#undef MEM_FREE
-typedef LARGE_INTEGER hr_timer;
-
-#define HRZERO(X)             (X).HighPart = (X).LowPart = 0
-#define HRSETCURRENT(X)       QueryPerformanceCounter(&(X))
-#define HRGETTICKS(X)         ((uint64_t)(X).HighPart * 4294967296ULL + \
-                               (uint64_t)(X).LowPart)
-#define HRGETTICKS_PER_SEC(X) {	  \
-		LARGE_INTEGER large; \
-		if (QueryPerformanceFrequency (&large)) \
-			(X) = (uint64_t)large.HighPart*4294967296ULL + (uint64_t)large.LowPart; \
-		else \
-			(X) = 0; \
-	}
-
-#elif __MACH__ /* OSX / macOS, monotonic nanosecond */
-
-#include <mach/mach_time.h>
-
-typedef struct timespec hr_timer;
-#define HRZERO(X)             (X).tv_sec = (X).tv_nsec = 0
-#define HRSETCURRENT(X)       do { int64_t tmp = mach_absolute_time() * sm_timebase; (X).tv_sec = tmp / 1000000000ULL; (X).tv_nsec = tmp - (X).tv_sec * 1000000000ULL; } while (0)
-#define HRGETTICKS(X)         ((uint64_t)(X).tv_sec * 1000000000ULL + (uint64_t)(X).tv_nsec)
-#define HRGETTICKS_PER_SEC(X) { mach_timebase_info_data_t tb; mach_timebase_info(&tb); sm_timebase = tb.numer; sm_timebase /= tb.denom; (X) = sm_timebase * 1000000000ULL; }
-
-#else /* Linux, POSIX */
-
-#include <unistd.h>
-
-/* Do we seem to have a (hopefully) nanosecond monotonic clock? */
-#if _POSIX_TIMERS && defined(_POSIX_MONOTONIC_CLOCK)
-
-#ifdef CLOCK_MONOTONIC_RAW
-#define BEST_MONOTONIC CLOCK_MONOTONIC_RAW
-#else
-#define BEST_MONOTONIC CLOCK_MONOTONIC
-#endif
-
-typedef struct timespec hr_timer;
-#define HRZERO(X)             (X).tv_sec = (X).tv_nsec = 0
-#define HRSETCURRENT(X)       clock_gettime(BEST_MONOTONIC, &(X))
-#define HRGETTICKS(X)         ((uint64_t)(X).tv_sec * 1000000000ULL + (uint64_t)(X).tv_nsec)
-#define HRGETTICKS_PER_SEC(X) { hr_timer r; clock_getres(BEST_MONOTONIC, &r); if (r.tv_sec < 0) clock_getres(CLOCK_MONOTONIC, &r); (X) = r.tv_sec + 1000000000ULL / r.tv_nsec; }
-
-#else /* Fallback to microsecond non-monotonic clock that should be available */
-
-#include <sys/time.h>
-
-typedef struct timeval hr_timer;
-#define HRZERO(X)             (X).tv_sec = (X).tv_usec = 0
-#define HRSETCURRENT(X)       gettimeofday(&(X), NULL)
-#define HRGETTICKS(X)         ((uint64_t)(X).tv_sec * 1000000 +	\
-                               (uint64_t)(X).tv_usec)
-#define HRGETTICKS_PER_SEC(X) (X) = 1000000
-
-#endif
-
-#endif /* Windows or Unix */
-
-typedef struct sTimer_s {
-	int m_fRunning;     // true if we are running
-	clock_t m_cStartTime;
-	clock_t m_cEndTime;
-	hr_timer m_hrStartTime;
-	hr_timer m_hrEndTime;
-	double m_dAccumSeconds;
-} sTimer;
-
-extern void sTimer_Init(sTimer *t);      // Init
-extern void sTimer_Start(sTimer *t, int bClear /*=true*/);  // Start the timer
-extern void sTimer_Stop(sTimer *t);      // Stop the timer
-extern void sTimer_ClearTime(sTimer *t); // Clears out the time to 0
-extern double sTimer_GetSecs(sTimer *t); // If timer running returns elapsed;
-                                         // if stopped returns timed interval;
-                                         // if not started returns 0.
-
-extern uint64_t sm_HRTicksPerSec;  // HR ticks per second (claimed)
-extern uint64_t sm_hrPrecision;    // HR ticks per second (observed, guess)
-extern uint64_t sm_cPrecision;     // clocks (ticks) per second (observed, guess)
-
-#define sTimer_Start_noclear(t) \
-    do { \
-    if (sm_HRTicksPerSec) { HRSETCURRENT ((t)->m_hrStartTime); } \
-    else { (t)->m_cStartTime = clock(); } \
-    (t)->m_fRunning = 1; \
-    } while (0)
-
-#define sTimer_Pause(t) \
-    do { \
-    (t)->m_dAccumSeconds = sTimer_GetSecs(t); \
-    (t)->m_fRunning=0; \
-    } while (0)
-
-#define sTimer_Resume(t) \
-    do { \
-    if (!(t)->m_fRunning) \
-        sTimer_Start_noclear(t); \
-    } while (0)
-
-#endif /* _HAVE_TIMER_H */
+#endif /* _JOHN_TIMER_H */


### PR DESCRIPTION
Also drops obsolete fallbacks to clock(3), simplifying code. They would only possibly be needed for Windows **pre** XP.  In the unlikely case anyone actually would need that, we could of course put it back with #ifdef's.

See #4519, although this commit is only about the "portable HR-timer" which *might* be used for that.

Closes #3991 