### PR TITLE
Fix state delay

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -154,6 +154,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Add support for Telegram Desktop >= 2.2.0/2.1.14b, CPU-only for now.
   [philsmd, magnum; 2020]
 
+- Drop support for --fix-state-delay option, and instead do something better
+  in the cracker engine - by default, and for all modes.  [magnum; 2020]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -518,14 +518,6 @@ Other non-printable characters can be written in hex \xHH notation (the TAB
 character can also be specified with --field-separator-char=\x09).  Note that
 a side effect is that the pot file will get this field separator too.
 
---fix-state-delay=N		only determine the wordlist offset every N times
-
-This is an optimization for wordlist mode which helps on some systems.  This
-just limits the number of times that the ftell() call is performed.  The one
-side effect is that if John is aborted and later restarted it may redo more
-tests.  Thus, the use of this option is only sensible desirable for very fast
-hash types.
-
 --no-log			disable log file
 
 This will turn off logging to file (default john.log) in case you are sure

--- a/run/john.zsh_completion
+++ b/run/john.zsh_completion
@@ -61,7 +61,6 @@ _arguments -C -s \
   '(--max-length)'--max-length=-'[request a maximum candidate length in bytes]:number' \
   '(--length)'--length=-'[shortcut for --min-len=N --max-len=N]:number' \
   '(--field-separator-char)'--field-separator-char=-'[use "C" instead of ":" in input and pot files]:char' \
-  '(--fix-state-delay)'--fix-state-delay=-'[performance tweak, see doc/OPTIONS]:number' \
   '(--verbosity)'--verbosity=-'[change verbosity (1-5 or 6 for debug, default 3)]:number' \
   '(--show)'{--show,--show=LEFT}'[show cracked passwords (if =LEFT, then uncracked)]' \
   '(--format)'--format=-'[use specific format]:format to use:->list-formats' \

--- a/src/cracker.c
+++ b/src/cracker.c
@@ -72,7 +72,6 @@
 #undef index
 #endif
 
-static fix_state_fp fp_fix_state;
 static int crk_process_key_max_keys;
 static struct db_main *crk_db;
 static struct fmt_params *crk_params;
@@ -90,6 +89,7 @@ static struct db_keys *crk_guesses;
 static uint64_t *crk_timestamps;
 static char crk_stdout_key[PLAINTEXT_BUFFER_SIZE];
 static int kpc_warn, kpc_warn_limit, single_running;
+static fix_state_fp hybrid_fix_state;
 
 int crk_stacked_rule_count = 1;
 rule_stack crk_rule_stack;
@@ -795,9 +795,13 @@ static int crk_process_event(void)
 
 void crk_set_hybrid_fix_state_func_ptr(fix_state_fp fp)
 {
-	fp_fix_state = fp;
+	hybrid_fix_state = fp;
 }
 
+/*
+ * Called from crk_salt_loop for every salt or, when in Single mode, from
+ * crk_process_salt with just a specific salt.
+ */
 static int crk_password_loop(struct db_salt *salt)
 {
 	int count;
@@ -815,8 +819,14 @@ static int crk_password_loop(struct db_salt *salt)
 	if (event_pending && crk_process_event())
 		return -1;
 
-	if (fp_fix_state)
-		fp_fix_state();
+	/*
+	 * magnum, December 2020:
+	 * I can't fathom how/why this would be the correct place for this, but
+	 * it seems to work and just moving it to the others does break resume
+	 * for hybrid external so here it stays, until further research.
+	 */
+	if (hybrid_fix_state)
+		hybrid_fix_state();
 
 	if (kpc_warn_limit && crk_key_index < kpc_warn) {
 		static int last_warn_kpc, initial_value;
@@ -996,6 +1006,10 @@ static int crk_password_loop(struct db_salt *salt)
 	return 0;
 }
 
+/*
+ * When crk_process_key() has a complete batch, it calls this function
+ * to run the batch with all salts.
+ */
 static int crk_salt_loop(void)
 {
 	int sc = crk_db->salt_count;
@@ -1060,10 +1074,14 @@ static int crk_salt_loop(void)
 	crk_process_key_max_keys = 0; /* use slow path next time */
 	crk_key_index = 0;
 	crk_last_salt = NULL;
-	if (options.flags & FLG_MASK_STACKED)
-		mask_fix_state();
-	else
-	crk_fix_state();
+
+	if (event_fix_state) {
+		if (options.flags & FLG_MASK_STACKED)
+			mask_fix_state();
+		else
+			crk_fix_state();
+		event_fix_state = 0;
+	}
 
 	if (ext_abort)
 		event_abort = 1;
@@ -1077,6 +1095,10 @@ static int crk_salt_loop(void)
 	return ext_abort;
 }
 
+/*
+ * Process an incomplete batch; This is used by mask mode before
+ * resetting the format with a changed internal mask.
+ */
 int crk_process_buffer(void)
 {
 	if (crk_db->loaded && crk_key_index)
@@ -1097,6 +1119,10 @@ int crk_process_buffer(void)
 	return ext_abort;
 }
 
+/*
+ * All modes but Single call this function (as crk_process_key)
+ * for each candidate.
+ */
 static int process_key(char *key)
 {
 	if (crk_key_index < crk_process_key_max_keys) {
@@ -1149,10 +1175,13 @@ static int process_key(char *key)
 			event_abort = event_pending = 1;
 	}
 
-	if (options.flags & FLG_MASK_STACKED)
-		mask_fix_state();
-	else
-	crk_fix_state();
+	if (event_fix_state) {
+		if (options.flags & FLG_MASK_STACKED)
+			mask_fix_state();
+		else
+			crk_fix_state();
+		event_fix_state = 0;
+	}
 
 	if (ext_abort)
 		event_abort = 1;

--- a/src/options.c
+++ b/src/options.c
@@ -159,6 +159,9 @@ static struct opt_entry opt_list[] = {
 	{"list", FLG_ONCE, 0, 0, USUAL_REQ_CLR | FLG_STDOUT | OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &options.listconf},
 	{"mem-file-size", FLG_ONCE, 0, FLG_WORDLIST_CHK, FLG_DUPESUPP | FLG_STDIN_CHK | FLG_PIPE_CHK | OPT_REQ_PARAM, Zu, &options.max_wordfile_memory},
 	{"dupe-suppression", FLG_DUPESUPP, FLG_DUPESUPP, FLG_WORDLIST_CHK, FLG_STDIN_CHK | FLG_PIPE_CHK},
+/*
+ * --fix-state-delay=N is deprecated and ignored, drop support after releasing 1.9.0-Jumbo-2
+ */
 	{"fix-state-delay", FLG_ONCE, 0, FLG_CRACKING_CHK, OPT_REQ_PARAM, "%u", &options.max_fix_state_delay},
 	{"field-separator-char", FLG_ONCE, 0, FLG_PWD_SUP, OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &field_sep_char_str},
 	{"config", FLG_ONCE, 0, 0, USUAL_REQ_CLR | OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &options.config},
@@ -324,7 +327,6 @@ JOHN_USAGE_REGEX \
 "--max-length=N             request a maximum candidate length in bytes\n" \
 "--length=N                 shortcut for --min-len=N --max-len=N\n" \
 "--field-separator-char=C   use 'C' instead of the ':' in input and pot files\n" \
-"--fix-state-delay=N        performance tweak, see doc/OPTIONS\n" \
 "--config=FILE              use FILE instead of john.conf or john.ini\n" \
 "--log-stderr               log to screen instead of file\n"             \
 "--no-loader-dupecheck      disable the dupe checking when loading hashes\n" \

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -272,6 +272,14 @@ void rec_save(void)
 			else
 				*opt = "--no-single-retest-guess";
 		}
+		else
+		if (!strncmp(*opt, "--fix-state-delay", 17)) {
+			char **o = opt;
+			do
+				*o = o[1];
+			while (*++o);
+			rec_argc--;
+		}
 		/***********************************************/
 		else
 #if HAVE_MPI

--- a/src/signals.c
+++ b/src/signals.c
@@ -58,6 +58,7 @@ volatile int event_pending = 0, event_reload = 0;
 volatile int event_abort = 0, event_save = 0, event_status = 0, event_delayed_status = 0;
 volatile int event_ticksafety = 0;
 volatile int event_mpiprobe = 0, event_poll_files = 0;
+volatile int event_fix_state = 0;
 
 volatile int timer_abort = 0, timer_status = 0;
 static int timer_save_interval;
@@ -389,6 +390,9 @@ static void sig_handle_timer(int signum)
 		event_status = event_pending = 1;
 	}
 #endif /* OS_TIMER */
+
+	event_fix_state = 1;
+
 #endif /* !BENCH_BUILD */
 
 	if (!--timer_ticksafety_value) {

--- a/src/signals.h
+++ b/src/signals.h
@@ -37,6 +37,7 @@ extern volatile int event_save;		/* Save the crash recovery file */
 extern volatile int event_status;	/* Status display requested */
 extern volatile int event_delayed_status;	/* Status display requested after current batch */
 extern volatile int event_ticksafety;	/* System time in ticks may overflow */
+extern volatile int event_fix_state;    /* For cracker */
 #ifdef HAVE_MPI
 extern volatile int event_mpiprobe;	/* MPI probe for messages requested */
 #endif

--- a/src/tty.c
+++ b/src/tty.c
@@ -48,6 +48,9 @@ static struct termios saved_ti;
 static int in_stdin_mode;
 #endif
 
+/*
+ * This must be async signal-safe (for MPI builds, at least)
+ */
 int tty_has_keyboard(void)
 {
 #if !defined(__DJGPP__) && !defined(__MINGW32__) && !defined (_MSC_VER)

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -186,8 +186,6 @@ static int restore_state(FILE *file)
 	return 0;
 }
 
-static int fix_state_delay;
-
 static void fix_state(void)
 {
 	if (hybrid_rec_rule || hybrid_rec_line || hybrid_rec_pos) {
@@ -201,10 +199,6 @@ static void fix_state(void)
 
 	if (options.flags & FLG_REGEX_CHK)
 		return;
-
-	if (++fix_state_delay < options.max_fix_state_delay)
-		return;
-	fix_state_delay=0;
 
 	rec_rule = rule_number;
 	rec_line = line_number;
@@ -527,9 +521,6 @@ void do_wordlist_crack(struct db_main *db, const char *name, int rules)
 			        options.eff_maxlength + mask_add_len);
 		fprintf(stderr, "\n");
 	}
-
-	if (options.flags & FLG_STACKED)
-		options.max_fix_state_delay = 0;
 
 	if (name) {
 		char *cp, csearch;


### PR DESCRIPTION
Cracker: Don't call fix_state more often than once per second
    
This replaces the wordlist-specific --fix-state-delay=N option and is always active, for all modes.  We ignore the option until after next release, then drop the remains of it.

Also (in separate commit) minor tweaks to signals.c per-second stuff.

Closes #4519 