### PR TITLE
Corrections for human_prefix()

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -574,7 +574,7 @@ char *human_prefix(uint64_t num)
 	}
 
 	if (*p)
-		snprintf(out, 16, "%u %c", (uint32_t)num, *p);
+		snprintf(out, 16, "%u %ci", (uint32_t)num, *p);
 	else
 		snprintf(out, 16, "%u ", (uint32_t)num);
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -190,14 +190,16 @@ const char *jtr_lltoa(int64_t num, char *result, int result_len, int base);
 const char *jtr_ulltoa(uint64_t num, char *result, int result_len, int base);
 
 /*
- * Change some large number to a string possibly using SI prefix
- * eg. 437281954 -> "417 M"
+ * Change some large number to a string possibly using binary prefix,
+ * eg. 437281954 -> "417 Mi"
+ * Note: "leaks" 16 bytes each time (mem_alloc_tiny)
  */
 extern char *human_prefix(uint64_t num);
 
 /*
  * Change some tiny number to a string possibly using SI prefix
  * eg. 0.123 -> "123 m"
+ * Note: "leaks" 16 bytes each time (mem_alloc_tiny)
  */
 extern char *human_prefix_small(double num);
 


### PR DESCRIPTION
The comments stated SI prefix while the example correctly showed that it (unlike human_prefix_small) will produce a binary prefix.

Fix comments and add an "i" to its output (as in Ki, Mi) rendering proper IEC prefixes.