### PR TITLE
Add support for restic repositories

### DIFF
--- a/doc/README.restic
+++ b/doc/README.restic
@@ -1,0 +1,12 @@
+Cracking restic backup passwords
+================================
+
+1. Run restic2john.py on restic repository directory:
+
+E.g. $ ../run/restic2john.py /srv/restic > hash
+
+2. Run john on the output of restic2john.py.
+
+E.g. $ ../run/john hash
+
+3. Wait for the password to get cracked.

--- a/run/restic2john.py
+++ b/run/restic2john.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This software is Copyright (c) 2020, Jürgen Hötzel <juergen at hoetzel.info>
+# and it is hereby released to the general public under the following terms:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.
+
+
+import sys
+import os
+import os.path
+import json
+from base64 import b64decode
+from binascii import hexlify
+
+
+def process_dir(directory):
+    keys_dir = os.path.join(directory, "keys")
+    if not os.path.isdir(keys_dir):
+        sys.stderr.write("%s: not a valid restic repository\n" % directory)
+        return -1
+    for filename in os.listdir(keys_dir):
+        with open(os.path.join(keys_dir, filename)) as f:
+            config = json.load(f)
+            kdf = config.get("kdf")
+            if kdf != "scrypt":
+                sys.stderr.write("%s: Only scrypt is supported. Used: kdf %s\n" % (kdf, directory))
+                continue
+            n = config.get("N")
+            r = config.get("r")
+            p = config.get("p")
+            salt = b64decode(config.get("salt"))
+            if len(salt) != 64:
+                sys.stderr.write("%s: Invalid salt len %d\n" % (kdf, len(salt)))
+            data = b64decode(config.get("data"))
+            sys.stdout.write("$restic$%s*%s*%s*%s*%s*%s\n" % (kdf, n, r, p, hexlify(salt).decode(), hexlify(data).decode()))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: %s [restic repository dirs]\n" % sys.argv[0])
+        sys.exit(-1)
+
+    for j in range(1, len(sys.argv)):
+        process_dir(sys.argv[j])

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -39,7 +39,7 @@ PEFLAGS = peflags --dynamicbase=true --nxcompat=true
 SHELL = /bin/sh
 VPATH = @srcdir@
 
-subdirs = aes secp256k1 ed25519-donna @ZTEX_SUBDIRS@
+subdirs = aes secp256k1 ed25519-donna poly1305-donna @ZTEX_SUBDIRS@
 top_srcdir = @top_srcdir@
 srcdir = @srcdir@
 prefix = @prefix@
@@ -550,7 +550,7 @@ find_version:
 	echo "#define JTR_GIT_VERSION $(JTR_GIT_VERSION)" > version.h.new
 	diff >/dev/null 2>/dev/null version.h.new version.h && $(RM) version.h.new || $(MV) version.h.new version.h
 
-SUBDIRS = aes secp256k1 ed25519-donna @ZTEX_SUBDIRS@
+SUBDIRS = aes secp256k1 ed25519-donna poly1305-donna @ZTEX_SUBDIRS@
 
 .PHONY: subdirs $(SUBDIRS) find_version
 
@@ -575,6 +575,10 @@ secp256k1/secp256k1.a:
 ed25519-donna/ed25519-donna.a:
 	$(MAKE) -C ed25519-donna all
 
+poly1305-donna/poly1305-donna.a:
+	$(MAKE) -C poly1305-donna all
+
+
 ###############################################################################
 #  Process targets.  Note, these are *nix targets, but also work fine under
 #  cygwin.  The only problem with cygwin, is that the ln -s will NOT generate
@@ -586,8 +590,8 @@ ed25519-donna/ed25519-donna.a:
 
 # PTHREAD_CFLAGS and OPENMP_CFLAGS may actually contain linker options,
 # like -fopenmp
-../run/john@EXE_EXT@: $(JOHN_OBJS) aes/aes.a secp256k1/secp256k1.a ed25519-donna/ed25519-donna.a @ZTEX_SUBDIRS@
-	$(LD) $(JOHN_OBJS) $(LDFLAGS) @OPENSSL_LIBS@ @COMMONCRYPTO_LIBS@ @OPENMP_CFLAGS@ @GMP_LIBS@ @SKEY_LIBS@ @REXGEN_LIBS@ @CL_LIBS@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @M_LIBS@ @RT_LIBS@ @Z_LIBS@ @DL_LIBS@ @CRYPT_LIBS@ @BZ2_LIBS@ @ZTEX_LIBS@ aes/aes.a secp256k1/secp256k1.a ed25519-donna/ed25519-donna.a -o $@
+../run/john@EXE_EXT@: $(JOHN_OBJS) aes/aes.a secp256k1/secp256k1.a ed25519-donna/ed25519-donna.a poly1305-donna/poly1305-donna.a @ZTEX_SUBDIRS@
+	$(LD) $(JOHN_OBJS) $(LDFLAGS) @OPENSSL_LIBS@ @COMMONCRYPTO_LIBS@ @OPENMP_CFLAGS@ @GMP_LIBS@ @SKEY_LIBS@ @REXGEN_LIBS@ @CL_LIBS@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @M_LIBS@ @RT_LIBS@ @Z_LIBS@ @DL_LIBS@ @CRYPT_LIBS@ @BZ2_LIBS@ @ZTEX_LIBS@ aes/aes.a secp256k1/secp256k1.a ed25519-donna/ed25519-donna.a poly1305-donna/poly1305-donna.a -o $@
 
 ../run/unshadow: ../run/john
 	$(RM) ../run/unshadow

--- a/src/configure
+++ b/src/configure
@@ -16508,7 +16508,7 @@ echo "#define JOHN_BLD \"${host_os} ${CPU_BIT_STR}-bit${using_x32} ${host_cpu} $
 
 HOST_OS="$host_os"
 
-ac_config_files="$ac_config_files Makefile aes/Makefile aes/aesni/Makefile aes/openssl/Makefile secp256k1/Makefile ed25519-donna/Makefile"
+ac_config_files="$ac_config_files Makefile aes/Makefile aes/aesni/Makefile aes/openssl/Makefile secp256k1/Makefile ed25519-donna/Makefile poly1305-donna/Makefile"
 
 
 CFLAGS_EXTRA_BACKUP=$CFLAGS_EXTRA
@@ -17225,6 +17225,7 @@ do
     "aes/openssl/Makefile") CONFIG_FILES="$CONFIG_FILES aes/openssl/Makefile" ;;
     "secp256k1/Makefile") CONFIG_FILES="$CONFIG_FILES secp256k1/Makefile" ;;
     "ed25519-donna/Makefile") CONFIG_FILES="$CONFIG_FILES ed25519-donna/Makefile" ;;
+    "poly1305-donna/Makefile") CONFIG_FILES="$CONFIG_FILES poly1305-donna/Makefile" ;;
     "default") CONFIG_COMMANDS="$CONFIG_COMMANDS default" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1097,7 +1097,8 @@ AC_CONFIG_FILES([Makefile
                  aes/aesni/Makefile
                  aes/openssl/Makefile
                  secp256k1/Makefile
-                 ed25519-donna/Makefile])
+                 ed25519-donna/Makefile
+		 poly1305-donna/Makefile])
 
 dnl Escaping the '#' in things like "-Wno-error=#warnings" is required in
 dnl Makefile but forbidden when *not* in Makefile so we need to back-up

--- a/src/poly1305-donna/Makefile.in
+++ b/src/poly1305-donna/Makefile.in
@@ -1,0 +1,38 @@
+@SET_MAKE@
+CC = @CC@
+CXX = @CXX@
+AS = @CC@
+LD = @CC@
+CPP = @CC@
+CPPFLAGS = @CPPFLAGS@
+CFLAGS = @CFLAGS@ @CFLAGS_EXTRA@ -Wno-unused-function
+ASFLAGS = @ASFLAGS@ -c @EXTRA_AS_FLAGS@
+LDFLAGS = @LDFLAGS@
+AR = @AR@
+FIND = @FIND@
+RM = /bin/rm -f
+
+IN = poly1305-donna.o
+
+all: poly1305-donna.a
+default: poly1305-donna.a
+
+poly1305-donna.o: poly1305-donna.c
+	$(CC) -DHAVE_CONFIG_H $(CFLAGS) $(CPPFLAGS) -c poly1305-donna.c -o poly1305-donna.o
+
+.PHONY: subdirs $(SUBDIRS)
+
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@ all
+
+poly1305-donna.a: $(SUBDIRS) poly1305-donna.o
+	$(AR) -rs $@ $(IN)
+
+clean:
+	$(FIND) . -name \*.a -exec $(RM) {} \;
+	$(FIND) . -name \*.o -exec $(RM) {} \;
+
+distclean: clean
+	$(RM) Makefile

--- a/src/poly1305-donna/README.md
+++ b/src/poly1305-donna/README.md
@@ -1,0 +1,112 @@
+"A state-of-the-art message-authentication code"
+
+# ABOUT
+
+See: [http://cr.yp.to/mac.html](http://cr.yp.to/mac.html) and [http://cr.yp.to/mac/poly1305-20050329.pdf](http://cr.yp.to/mac/poly1305-20050329.pdf)
+
+These are quite portable implementations of increasing efficiency depending on the size of the multiplier available.
+Optimized implementations have been moved to [poly1305-opt](https://github.com/floodyberry/poly1305-opt)
+
+# BUILDING
+
+## Default
+
+If compiled with no options, `poly1305-donna.c` will select between the 32 bit and 64 bit implementations based
+on what it can tell the compiler supports
+
+    gcc poly1305-donna.c -O3 -o poly1305.o
+
+## Selecting a specific version
+
+    gcc poly1305-donna.c -O3 -o poly1305.o -DPOLY1305_XXBIT
+
+Where `-DPOLY1305_XXBIT` is one of
+
+ * `-DPOLY1305_8BIT`, 8->16 bit multiplies, 32 bit additions
+ * `-DPOLY1305_16BIT`, 16->32 bit multiples, 32 bit additions
+ * `-DPOLY1305_32BIT`, 32->64 bit multiplies, 64 bit additions
+ * `-DPOLY1305_64BIT`, 64->128 bit multiplies, 128 bit additions
+
+8 bit and 16 bit versions were written to keep the code size small, 32 bit and 64 bit versions are mildly optimized due
+to needing fewer multiplications. All 4 can be made faster at the expense of increased code size and complexity, which
+is not the intention of this project.
+
+# USAGE
+
+See: [http://nacl.cace-project.eu/onetimeauth.html](http://nacl.cace-project.eu/onetimeauth.html), in specific, slightly plagiarized:
+
+The poly1305_auth function, viewed as a function of the message for a uniform random key, is
+designed to meet the standard notion of unforgeability after a single message. After the sender
+authenticates one message, an attacker cannot find authenticators for any other messages.
+
+The sender **MUST NOT** use poly1305_auth to authenticate more than one message under the same key.
+Authenticators for two messages under the same key should be expected to reveal enough information
+to allow forgeries of authenticators on other messages.
+
+## Functions
+
+`poly1305_context` is declared in [poly1305.h](poly1305.h) and is an opaque structure large enough to support
+every underlying platform specific implementation. It should be size_t aligned, which should be handled already
+with the size_t member `aligner`.
+
+`void poly1305_init(poly1305_context *ctx, const unsigned char key[32]);`
+
+where
+
+`key` is the 32 byte key that is **only used for this message and is discarded immediately after**
+
+`void poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes);`
+
+where `m` is a pointer to the message fragment to be processed, and
+
+`bytes` is the length of the message fragment
+
+`void poly1305_finish(poly1305_context *ctx, unsigned char mac[16]);`
+
+where `mac` is the buffer which receives the 16 byte authenticator. After calling finish, the underlying
+implementation will zero out `ctx`.
+
+`void poly1305_auth(unsigned char mac[16], const unsigned char *m, size_t bytes, const unsigned char key[32]);`
+
+where `mac` is the buffer which receives the 16 byte authenticator,
+
+`m` is a pointer to the message to be processed,
+
+`bytes` is the number of bytes in the message, and
+
+`key` is the 32 byte key that is **only used for this message and is discarded immediately after**.
+
+`int poly1305_verify(const unsigned char mac1[16], const unsigned char mac2[16]);`
+
+where `mac1` is compared to `mac2` in constant time and returns `1` if they are equal and `0` if they are not
+
+`int poly1305_power_on_self_test(void);`
+
+tests the underlying implementation to verify it is working correctly. It returns `1` if all tests pass, and `0` if
+any tests fail.
+
+## Example
+
+### Simple
+
+    #include "poly1305-donna.h"
+
+    unsigned char key[32] = {...}, mac[16];
+    unsigned char msg[] = {...};
+
+    poly1305_auth(mac, msg, msglen, key);
+
+### Full
+
+[example-poly1305.c](example-poly1305.c) is a simple example of how to verify the underlying implementation is producing
+the correct results, compute an authenticator, and test it against an expected value.
+
+# LICENSE
+
+[MIT](http://www.opensource.org/licenses/mit-license.php) or PUBLIC DOMAIN
+
+
+# NAMESAKE
+
+I borrowed the idea for these from Adam Langley's [curve25519-donna](http://github.com/agl/curve25519-donna), hence
+the name.

--- a/src/poly1305-donna/poly1305-donna-16.h
+++ b/src/poly1305-donna/poly1305-donna-16.h
@@ -1,0 +1,201 @@
+/*
+	poly1305 implementation using 16 bit * 16 bit = 32 bit multiplication and 32 bit addition
+*/
+
+#if defined(_MSC_VER)
+	#define POLY1305_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+	#define POLY1305_NOINLINE __attribute__((noinline))
+#else
+	#define POLY1305_NOINLINE
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 18*sizeof(unsigned short) */
+typedef struct poly1305_state_internal_t {
+	unsigned char buffer[poly1305_block_size];
+	size_t leftover;
+	unsigned short r[10];
+	unsigned short h[10];
+	unsigned short pad[8];
+	unsigned char final;
+} poly1305_state_internal_t;
+
+/* interpret two 8 bit unsigned integers as a 16 bit unsigned integer in little endian */
+static unsigned short
+U8TO16(const unsigned char *p) {
+	return
+		(((unsigned short)(p[0] & 0xff)      ) |
+	     ((unsigned short)(p[1] & 0xff) <<  8));
+}
+
+/* store a 16 bit unsigned integer as two 8 bit unsigned integers in little endian */
+static void
+U16TO8(unsigned char *p, unsigned short v) {
+	p[0] = (v      ) & 0xff;
+	p[1] = (v >>  8) & 0xff;
+}
+
+void
+poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	unsigned short t0,t1,t2,t3,t4,t5,t6,t7;
+	size_t i;
+
+	/* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+	t0 = U8TO16(&key[ 0]); st->r[0] = ( t0                    ) & 0x1fff;
+	t1 = U8TO16(&key[ 2]); st->r[1] = ((t0 >> 13) | (t1 <<  3)) & 0x1fff;
+	t2 = U8TO16(&key[ 4]); st->r[2] = ((t1 >> 10) | (t2 <<  6)) & 0x1f03;
+	t3 = U8TO16(&key[ 6]); st->r[3] = ((t2 >>  7) | (t3 <<  9)) & 0x1fff;
+	t4 = U8TO16(&key[ 8]); st->r[4] = ((t3 >>  4) | (t4 << 12)) & 0x00ff;
+	                       st->r[5] = ((t4 >>  1)             ) & 0x1ffe;
+	t5 = U8TO16(&key[10]); st->r[6] = ((t4 >> 14) | (t5 <<  2)) & 0x1fff;
+	t6 = U8TO16(&key[12]); st->r[7] = ((t5 >> 11) | (t6 <<  5)) & 0x1f81;
+	t7 = U8TO16(&key[14]); st->r[8] = ((t6 >>  8) | (t7 <<  8)) & 0x1fff;
+	                       st->r[9] = ((t7 >>  5)             ) & 0x007f;
+
+	/* h = 0 */
+	for (i = 0; i < 10; i++)
+		st->h[i] = 0;
+
+	/* save pad for later */
+	for (i = 0; i < 8; i++)
+		st->pad[i] = U8TO16(&key[16 + (2 * i)]);
+
+	st->leftover = 0;
+	st->final = 0;
+}
+
+static void
+poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t bytes) {
+	const unsigned short hibit = (st->final) ? 0 : (1 << 11); /* 1 << 128 */
+	unsigned short t0,t1,t2,t3,t4,t5,t6,t7;
+	unsigned long d[10];
+	unsigned long c;
+
+	while (bytes >= poly1305_block_size) {
+		size_t i, j;
+
+		/* h += m[i] */
+		t0 = U8TO16(&m[ 0]); st->h[0] += ( t0                    ) & 0x1fff;
+		t1 = U8TO16(&m[ 2]); st->h[1] += ((t0 >> 13) | (t1 <<  3)) & 0x1fff;
+		t2 = U8TO16(&m[ 4]); st->h[2] += ((t1 >> 10) | (t2 <<  6)) & 0x1fff;
+		t3 = U8TO16(&m[ 6]); st->h[3] += ((t2 >>  7) | (t3 <<  9)) & 0x1fff;
+		t4 = U8TO16(&m[ 8]); st->h[4] += ((t3 >>  4) | (t4 << 12)) & 0x1fff;
+		                     st->h[5] += ((t4 >>  1)             ) & 0x1fff;
+		t5 = U8TO16(&m[10]); st->h[6] += ((t4 >> 14) | (t5 <<  2)) & 0x1fff;
+		t6 = U8TO16(&m[12]); st->h[7] += ((t5 >> 11) | (t6 <<  5)) & 0x1fff;
+		t7 = U8TO16(&m[14]); st->h[8] += ((t6 >>  8) | (t7 <<  8)) & 0x1fff;
+		                     st->h[9] += ((t7 >>  5)             ) | hibit;
+
+		/* h *= r, (partial) h %= p */
+		for (i = 0, c = 0; i < 10; i++) {
+			d[i] = c;
+			for (j = 0; j < 10; j++) {
+				d[i] += (unsigned long)st->h[j] * ((j <= i) ? st->r[i - j] : (5 * st->r[i + 10 - j]));
+				/* Sum(h[i] * r[i] * 5) will overflow slightly above 6 products with an unclamped r, so carry at 5 */
+				if (j == 4) {
+					c = (d[i] >> 13);
+					d[i] &= 0x1fff;
+				}
+			}
+			c += (d[i] >> 13);
+			d[i] &= 0x1fff;
+		}
+		c = ((c << 2) + c); /* c *= 5 */
+		c += d[0];
+		d[0] = ((unsigned short)c & 0x1fff);
+		c = (c >> 13);
+		d[1] += c;
+
+		for (i = 0; i < 10; i++)
+			st->h[i] = (unsigned short)d[i];
+
+		m += poly1305_block_size;
+		bytes -= poly1305_block_size;
+	}
+}
+
+POLY1305_NOINLINE void
+poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	unsigned short c;
+	unsigned short g[10];
+	unsigned short mask;
+	unsigned long f;
+	size_t i;
+
+	/* process the remaining block */
+	if (st->leftover) {
+		size_t i = st->leftover;
+		st->buffer[i++] = 1;
+		for (; i < poly1305_block_size; i++)
+			st->buffer[i] = 0;
+		st->final = 1;
+		poly1305_blocks(st, st->buffer, poly1305_block_size);
+	}
+
+	/* fully carry h */
+	c = st->h[1] >> 13;
+	st->h[1] &= 0x1fff;
+	for (i = 2; i < 10; i++) {
+		st->h[i] += c;
+		c = st->h[i] >> 13;
+		st->h[i] &= 0x1fff;
+	}
+	st->h[0] += (c * 5);
+	c = st->h[0] >> 13;
+	st->h[0] &= 0x1fff;
+	st->h[1] += c;
+	c = st->h[1] >> 13;
+	st->h[1] &= 0x1fff;
+	st->h[2] += c;
+
+	/* compute h + -p */
+	g[0] = st->h[0] + 5;
+	c = g[0] >> 13;
+	g[0] &= 0x1fff;
+	for (i = 1; i < 10; i++) {
+		g[i] = st->h[i] + c;
+		c = g[i] >> 13;
+		g[i] &= 0x1fff;
+	}
+
+	/* select h if h < p, or h + -p if h >= p */
+	mask = (c ^ 1) - 1;
+	for (i = 0; i < 10; i++)
+		g[i] &= mask;
+	mask = ~mask;
+	for (i = 0; i < 10; i++)
+		st->h[i] = (st->h[i] & mask) | g[i];
+
+	/* h = h % (2^128) */
+	st->h[0] = ((st->h[0]      ) | (st->h[1] << 13)                   ) & 0xffff;
+	st->h[1] = ((st->h[1] >>  3) | (st->h[2] << 10)                   ) & 0xffff;
+	st->h[2] = ((st->h[2] >>  6) | (st->h[3] <<  7)                   ) & 0xffff;
+	st->h[3] = ((st->h[3] >>  9) | (st->h[4] <<  4)                   ) & 0xffff;
+	st->h[4] = ((st->h[4] >> 12) | (st->h[5] <<  1) | (st->h[6] << 14)) & 0xffff;
+	st->h[5] = ((st->h[6] >>  2) | (st->h[7] << 11)                   ) & 0xffff;
+	st->h[6] = ((st->h[7] >>  5) | (st->h[8] <<  8)                   ) & 0xffff;
+	st->h[7] = ((st->h[8] >>  8) | (st->h[9] <<  5)                   ) & 0xffff;
+
+	/* mac = (h + pad) % (2^128) */
+	f = (unsigned long)st->h[0] + st->pad[0];
+	st->h[0] = (unsigned short)f;
+	for (i = 1; i < 8; i++) {
+		f = (unsigned long)st->h[i] + st->pad[i] + (f >> 16);
+		st->h[i] = (unsigned short)f;
+	}
+
+	for (i = 0; i < 8; i++)
+		U16TO8(mac + (i * 2), st->h[i]);
+
+	/* zero out the state */
+	for (i = 0; i < 10; i++)
+		st->h[i] = 0;
+	for (i = 0; i < 10; i++)
+		st->r[i] = 0;
+	for (i = 0; i < 8; i++)
+		st->pad[i] = 0;
+}

--- a/src/poly1305-donna/poly1305-donna-32.h
+++ b/src/poly1305-donna/poly1305-donna-32.h
@@ -1,0 +1,219 @@
+/*
+	poly1305 implementation using 32 bit * 32 bit = 64 bit multiplication and 64 bit addition
+*/
+
+#if defined(_MSC_VER)
+	#define POLY1305_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+	#define POLY1305_NOINLINE __attribute__((noinline))
+#else
+	#define POLY1305_NOINLINE
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 14*sizeof(unsigned long) */
+typedef struct poly1305_state_internal_t {
+	unsigned long r[5];
+	unsigned long h[5];
+	unsigned long pad[4];
+	size_t leftover;
+	unsigned char buffer[poly1305_block_size];
+	unsigned char final;
+} poly1305_state_internal_t;
+
+/* interpret four 8 bit unsigned integers as a 32 bit unsigned integer in little endian */
+static unsigned long
+U8TO32(const unsigned char *p) {
+	return
+		(((unsigned long)(p[0] & 0xff)      ) |
+	     ((unsigned long)(p[1] & 0xff) <<  8) |
+         ((unsigned long)(p[2] & 0xff) << 16) |
+         ((unsigned long)(p[3] & 0xff) << 24));
+}
+
+/* store a 32 bit unsigned integer as four 8 bit unsigned integers in little endian */
+static void
+U32TO8(unsigned char *p, unsigned long v) {
+	p[0] = (v      ) & 0xff;
+	p[1] = (v >>  8) & 0xff;
+	p[2] = (v >> 16) & 0xff;
+	p[3] = (v >> 24) & 0xff;
+}
+
+void
+poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+
+	/* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+	st->r[0] = (U8TO32(&key[ 0])     ) & 0x3ffffff;
+	st->r[1] = (U8TO32(&key[ 3]) >> 2) & 0x3ffff03;
+	st->r[2] = (U8TO32(&key[ 6]) >> 4) & 0x3ffc0ff;
+	st->r[3] = (U8TO32(&key[ 9]) >> 6) & 0x3f03fff;
+	st->r[4] = (U8TO32(&key[12]) >> 8) & 0x00fffff;
+
+	/* h = 0 */
+	st->h[0] = 0;
+	st->h[1] = 0;
+	st->h[2] = 0;
+	st->h[3] = 0;
+	st->h[4] = 0;
+
+	/* save pad for later */
+	st->pad[0] = U8TO32(&key[16]);
+	st->pad[1] = U8TO32(&key[20]);
+	st->pad[2] = U8TO32(&key[24]);
+	st->pad[3] = U8TO32(&key[28]);
+
+	st->leftover = 0;
+	st->final = 0;
+}
+
+static void
+poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t bytes) {
+	const unsigned long hibit = (st->final) ? 0 : (1UL << 24); /* 1 << 128 */
+	unsigned long r0,r1,r2,r3,r4;
+	unsigned long s1,s2,s3,s4;
+	unsigned long h0,h1,h2,h3,h4;
+	unsigned long long d0,d1,d2,d3,d4;
+	unsigned long c;
+
+	r0 = st->r[0];
+	r1 = st->r[1];
+	r2 = st->r[2];
+	r3 = st->r[3];
+	r4 = st->r[4];
+
+	s1 = r1 * 5;
+	s2 = r2 * 5;
+	s3 = r3 * 5;
+	s4 = r4 * 5;
+
+	h0 = st->h[0];
+	h1 = st->h[1];
+	h2 = st->h[2];
+	h3 = st->h[3];
+	h4 = st->h[4];
+
+	while (bytes >= poly1305_block_size) {
+		/* h += m[i] */
+		h0 += (U8TO32(m+ 0)     ) & 0x3ffffff;
+		h1 += (U8TO32(m+ 3) >> 2) & 0x3ffffff;
+		h2 += (U8TO32(m+ 6) >> 4) & 0x3ffffff;
+		h3 += (U8TO32(m+ 9) >> 6) & 0x3ffffff;
+		h4 += (U8TO32(m+12) >> 8) | hibit;
+
+		/* h *= r */
+		d0 = ((unsigned long long)h0 * r0) + ((unsigned long long)h1 * s4) + ((unsigned long long)h2 * s3) + ((unsigned long long)h3 * s2) + ((unsigned long long)h4 * s1);
+		d1 = ((unsigned long long)h0 * r1) + ((unsigned long long)h1 * r0) + ((unsigned long long)h2 * s4) + ((unsigned long long)h3 * s3) + ((unsigned long long)h4 * s2);
+		d2 = ((unsigned long long)h0 * r2) + ((unsigned long long)h1 * r1) + ((unsigned long long)h2 * r0) + ((unsigned long long)h3 * s4) + ((unsigned long long)h4 * s3);
+		d3 = ((unsigned long long)h0 * r3) + ((unsigned long long)h1 * r2) + ((unsigned long long)h2 * r1) + ((unsigned long long)h3 * r0) + ((unsigned long long)h4 * s4);
+		d4 = ((unsigned long long)h0 * r4) + ((unsigned long long)h1 * r3) + ((unsigned long long)h2 * r2) + ((unsigned long long)h3 * r1) + ((unsigned long long)h4 * r0);
+
+		/* (partial) h %= p */
+		              c = (unsigned long)(d0 >> 26); h0 = (unsigned long)d0 & 0x3ffffff;
+		d1 += c;      c = (unsigned long)(d1 >> 26); h1 = (unsigned long)d1 & 0x3ffffff;
+		d2 += c;      c = (unsigned long)(d2 >> 26); h2 = (unsigned long)d2 & 0x3ffffff;
+		d3 += c;      c = (unsigned long)(d3 >> 26); h3 = (unsigned long)d3 & 0x3ffffff;
+		d4 += c;      c = (unsigned long)(d4 >> 26); h4 = (unsigned long)d4 & 0x3ffffff;
+		h0 += c * 5;  c =                (h0 >> 26); h0 =                h0 & 0x3ffffff;
+		h1 += c;
+
+		m += poly1305_block_size;
+		bytes -= poly1305_block_size;
+	}
+
+	st->h[0] = h0;
+	st->h[1] = h1;
+	st->h[2] = h2;
+	st->h[3] = h3;
+	st->h[4] = h4;
+}
+
+POLY1305_NOINLINE void
+poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	unsigned long h0,h1,h2,h3,h4,c;
+	unsigned long g0,g1,g2,g3,g4;
+	unsigned long long f;
+	unsigned long mask;
+
+	/* process the remaining block */
+	if (st->leftover) {
+		size_t i = st->leftover;
+		st->buffer[i++] = 1;
+		for (; i < poly1305_block_size; i++)
+			st->buffer[i] = 0;
+		st->final = 1;
+		poly1305_blocks(st, st->buffer, poly1305_block_size);
+	}
+
+	/* fully carry h */
+	h0 = st->h[0];
+	h1 = st->h[1];
+	h2 = st->h[2];
+	h3 = st->h[3];
+	h4 = st->h[4];
+
+	             c = h1 >> 26; h1 = h1 & 0x3ffffff;
+	h2 +=     c; c = h2 >> 26; h2 = h2 & 0x3ffffff;
+	h3 +=     c; c = h3 >> 26; h3 = h3 & 0x3ffffff;
+	h4 +=     c; c = h4 >> 26; h4 = h4 & 0x3ffffff;
+	h0 += c * 5; c = h0 >> 26; h0 = h0 & 0x3ffffff;
+	h1 +=     c;
+
+	/* compute h + -p */
+	g0 = h0 + 5; c = g0 >> 26; g0 &= 0x3ffffff;
+	g1 = h1 + c; c = g1 >> 26; g1 &= 0x3ffffff;
+	g2 = h2 + c; c = g2 >> 26; g2 &= 0x3ffffff;
+	g3 = h3 + c; c = g3 >> 26; g3 &= 0x3ffffff;
+	g4 = h4 + c - (1UL << 26);
+
+	/* select h if h < p, or h + -p if h >= p */
+	mask = (g4 >> ((sizeof(unsigned long) * 8) - 1)) - 1;
+	g0 &= mask;
+	g1 &= mask;
+	g2 &= mask;
+	g3 &= mask;
+	g4 &= mask;
+	mask = ~mask;
+	h0 = (h0 & mask) | g0;
+	h1 = (h1 & mask) | g1;
+	h2 = (h2 & mask) | g2;
+	h3 = (h3 & mask) | g3;
+	h4 = (h4 & mask) | g4;
+
+	/* h = h % (2^128) */
+	h0 = ((h0      ) | (h1 << 26)) & 0xffffffff;
+	h1 = ((h1 >>  6) | (h2 << 20)) & 0xffffffff;
+	h2 = ((h2 >> 12) | (h3 << 14)) & 0xffffffff;
+	h3 = ((h3 >> 18) | (h4 <<  8)) & 0xffffffff;
+
+	/* mac = (h + pad) % (2^128) */
+	f = (unsigned long long)h0 + st->pad[0]            ; h0 = (unsigned long)f;
+	f = (unsigned long long)h1 + st->pad[1] + (f >> 32); h1 = (unsigned long)f;
+	f = (unsigned long long)h2 + st->pad[2] + (f >> 32); h2 = (unsigned long)f;
+	f = (unsigned long long)h3 + st->pad[3] + (f >> 32); h3 = (unsigned long)f;
+
+	U32TO8(mac +  0, h0);
+	U32TO8(mac +  4, h1);
+	U32TO8(mac +  8, h2);
+	U32TO8(mac + 12, h3);
+
+	/* zero out the state */
+	st->h[0] = 0;
+	st->h[1] = 0;
+	st->h[2] = 0;
+	st->h[3] = 0;
+	st->h[4] = 0;
+	st->r[0] = 0;
+	st->r[1] = 0;
+	st->r[2] = 0;
+	st->r[3] = 0;
+	st->r[4] = 0;
+	st->pad[0] = 0;
+	st->pad[1] = 0;
+	st->pad[2] = 0;
+	st->pad[3] = 0;
+}
+

--- a/src/poly1305-donna/poly1305-donna-64.h
+++ b/src/poly1305-donna/poly1305-donna-64.h
@@ -1,0 +1,224 @@
+/*
+	poly1305 implementation using 64 bit * 64 bit = 128 bit multiplication and 128 bit addition
+*/
+
+#if defined(_MSC_VER)
+	#include <intrin.h>
+
+	typedef struct uint128_t {
+		unsigned long long lo;
+		unsigned long long hi;
+	} uint128_t;
+
+	#define MUL(out, x, y) out.lo = _umul128((x), (y), &out.hi)
+	#define ADD(out, in) { unsigned long long t = out.lo; out.lo += in.lo; out.hi += (out.lo < t) + in.hi; }
+	#define ADDLO(out, in) { unsigned long long t = out.lo; out.lo += in; out.hi += (out.lo < t); }
+	#define SHR(in, shift) (__shiftright128(in.lo, in.hi, (shift)))
+	#define LO(in) (in.lo)
+
+	#define POLY1305_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+	#if defined(__SIZEOF_INT128__)
+		typedef unsigned __int128 uint128_t;
+	#else
+		typedef unsigned uint128_t __attribute__((mode(TI)));
+	#endif
+
+	#define MUL(out, x, y) out = ((uint128_t)x * y)
+	#define ADD(out, in) out += in
+	#define ADDLO(out, in) out += in
+	#define SHR(in, shift) (unsigned long long)(in >> (shift))
+	#define LO(in) (unsigned long long)(in)
+
+	#define POLY1305_NOINLINE __attribute__((noinline))
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 8*sizeof(unsigned long long) */
+typedef struct poly1305_state_internal_t {
+	unsigned long long r[3];
+	unsigned long long h[3];
+	unsigned long long pad[2];
+	size_t leftover;
+	unsigned char buffer[poly1305_block_size];
+	unsigned char final;
+} poly1305_state_internal_t;
+
+/* interpret eight 8 bit unsigned integers as a 64 bit unsigned integer in little endian */
+static unsigned long long
+U8TO64(const unsigned char *p) {
+	return
+		(((unsigned long long)(p[0] & 0xff)      ) |
+		 ((unsigned long long)(p[1] & 0xff) <<  8) |
+		 ((unsigned long long)(p[2] & 0xff) << 16) |
+		 ((unsigned long long)(p[3] & 0xff) << 24) |
+		 ((unsigned long long)(p[4] & 0xff) << 32) |
+		 ((unsigned long long)(p[5] & 0xff) << 40) |
+		 ((unsigned long long)(p[6] & 0xff) << 48) |
+		 ((unsigned long long)(p[7] & 0xff) << 56));
+}
+
+/* store a 64 bit unsigned integer as eight 8 bit unsigned integers in little endian */
+static void
+U64TO8(unsigned char *p, unsigned long long v) {
+	p[0] = (v      ) & 0xff;
+	p[1] = (v >>  8) & 0xff;
+	p[2] = (v >> 16) & 0xff;
+	p[3] = (v >> 24) & 0xff;
+	p[4] = (v >> 32) & 0xff;
+	p[5] = (v >> 40) & 0xff;
+	p[6] = (v >> 48) & 0xff;
+	p[7] = (v >> 56) & 0xff;
+}
+
+void
+poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	unsigned long long t0,t1;
+
+	/* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+	t0 = U8TO64(&key[0]);
+	t1 = U8TO64(&key[8]);
+
+	st->r[0] = ( t0                    ) & 0xffc0fffffff;
+	st->r[1] = ((t0 >> 44) | (t1 << 20)) & 0xfffffc0ffff;
+	st->r[2] = ((t1 >> 24)             ) & 0x00ffffffc0f;
+
+	/* h = 0 */
+	st->h[0] = 0;
+	st->h[1] = 0;
+	st->h[2] = 0;
+
+	/* save pad for later */
+	st->pad[0] = U8TO64(&key[16]);
+	st->pad[1] = U8TO64(&key[24]);
+
+	st->leftover = 0;
+	st->final = 0;
+}
+
+static void
+poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t bytes) {
+	const unsigned long long hibit = (st->final) ? 0 : ((unsigned long long)1 << 40); /* 1 << 128 */
+	unsigned long long r0,r1,r2;
+	unsigned long long s1,s2;
+	unsigned long long h0,h1,h2;
+	unsigned long long c;
+	uint128_t d0,d1,d2,d;
+
+	r0 = st->r[0];
+	r1 = st->r[1];
+	r2 = st->r[2];
+
+	h0 = st->h[0];
+	h1 = st->h[1];
+	h2 = st->h[2];
+
+	s1 = r1 * (5 << 2);
+	s2 = r2 * (5 << 2);
+
+	while (bytes >= poly1305_block_size) {
+		unsigned long long t0,t1;
+
+		/* h += m[i] */
+		t0 = U8TO64(&m[0]);
+		t1 = U8TO64(&m[8]);
+
+		h0 += (( t0                    ) & 0xfffffffffff);
+		h1 += (((t0 >> 44) | (t1 << 20)) & 0xfffffffffff);
+		h2 += (((t1 >> 24)             ) & 0x3ffffffffff) | hibit;
+
+		/* h *= r */
+		MUL(d0, h0, r0); MUL(d, h1, s2); ADD(d0, d); MUL(d, h2, s1); ADD(d0, d);
+		MUL(d1, h0, r1); MUL(d, h1, r0); ADD(d1, d); MUL(d, h2, s2); ADD(d1, d);
+		MUL(d2, h0, r2); MUL(d, h1, r1); ADD(d2, d); MUL(d, h2, r0); ADD(d2, d);
+
+		/* (partial) h %= p */
+		              c = SHR(d0, 44); h0 = LO(d0) & 0xfffffffffff;
+		ADDLO(d1, c); c = SHR(d1, 44); h1 = LO(d1) & 0xfffffffffff;
+		ADDLO(d2, c); c = SHR(d2, 42); h2 = LO(d2) & 0x3ffffffffff;
+		h0  += c * 5; c = (h0 >> 44);  h0 =    h0  & 0xfffffffffff;
+		h1  += c;
+
+		m += poly1305_block_size;
+		bytes -= poly1305_block_size;
+	}
+
+	st->h[0] = h0;
+	st->h[1] = h1;
+	st->h[2] = h2;
+}
+
+
+POLY1305_NOINLINE void
+poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	unsigned long long h0,h1,h2,c;
+	unsigned long long g0,g1,g2;
+	unsigned long long t0,t1;
+
+	/* process the remaining block */
+	if (st->leftover) {
+		size_t i = st->leftover;
+		st->buffer[i] = 1;
+		for (i = i + 1; i < poly1305_block_size; i++)
+			st->buffer[i] = 0;
+		st->final = 1;
+		poly1305_blocks(st, st->buffer, poly1305_block_size);
+	}
+
+	/* fully carry h */
+	h0 = st->h[0];
+	h1 = st->h[1];
+	h2 = st->h[2];
+
+	             c = (h1 >> 44); h1 &= 0xfffffffffff;
+	h2 += c;     c = (h2 >> 42); h2 &= 0x3ffffffffff;
+	h0 += c * 5; c = (h0 >> 44); h0 &= 0xfffffffffff;
+	h1 += c;     c = (h1 >> 44); h1 &= 0xfffffffffff;
+	h2 += c;     c = (h2 >> 42); h2 &= 0x3ffffffffff;
+	h0 += c * 5; c = (h0 >> 44); h0 &= 0xfffffffffff;
+	h1 += c;
+
+	/* compute h + -p */
+	g0 = h0 + 5; c = (g0 >> 44); g0 &= 0xfffffffffff;
+	g1 = h1 + c; c = (g1 >> 44); g1 &= 0xfffffffffff;
+	g2 = h2 + c - ((unsigned long long)1 << 42);
+
+	/* select h if h < p, or h + -p if h >= p */
+	c = (g2 >> ((sizeof(unsigned long long) * 8) - 1)) - 1;
+	g0 &= c;
+	g1 &= c;
+	g2 &= c;
+	c = ~c;
+	h0 = (h0 & c) | g0;
+	h1 = (h1 & c) | g1;
+	h2 = (h2 & c) | g2;
+
+	/* h = (h + pad) */
+	t0 = st->pad[0];
+	t1 = st->pad[1];
+
+	h0 += (( t0                    ) & 0xfffffffffff)    ; c = (h0 >> 44); h0 &= 0xfffffffffff;
+	h1 += (((t0 >> 44) | (t1 << 20)) & 0xfffffffffff) + c; c = (h1 >> 44); h1 &= 0xfffffffffff;
+	h2 += (((t1 >> 24)             ) & 0x3ffffffffff) + c;                 h2 &= 0x3ffffffffff;
+
+	/* mac = h % (2^128) */
+	h0 = ((h0      ) | (h1 << 44));
+	h1 = ((h1 >> 20) | (h2 << 24));
+
+	U64TO8(&mac[0], h0);
+	U64TO8(&mac[8], h1);
+
+	/* zero out the state */
+	st->h[0] = 0;
+	st->h[1] = 0;
+	st->h[2] = 0;
+	st->r[0] = 0;
+	st->r[1] = 0;
+	st->r[2] = 0;
+	st->pad[0] = 0;
+	st->pad[1] = 0;
+}
+

--- a/src/poly1305-donna/poly1305-donna-8.h
+++ b/src/poly1305-donna/poly1305-donna-8.h
@@ -1,0 +1,186 @@
+/*
+	poly1305 implementation using 8 bit * 8 bit = 16 bit multiplication and 32 bit addition
+
+	based on the public domain reference version in supercop by djb
+*/
+
+#if defined(_MSC_VER)
+	#define POLY1305_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+	#define POLY1305_NOINLINE __attribute__((noinline))
+#else
+	#define POLY1305_NOINLINE
+#endif
+
+#define poly1305_block_size 16
+
+/* 17 + sizeof(size_t) + 51*sizeof(unsigned char) */
+typedef struct poly1305_state_internal_t {
+	unsigned char buffer[poly1305_block_size];
+	size_t leftover;
+	unsigned char h[17];
+	unsigned char r[17];
+	unsigned char pad[17];
+	unsigned char final;
+} poly1305_state_internal_t;
+
+void
+poly1305_init(poly1305_context *ctx, const unsigned char key[32]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	size_t i;
+
+	st->leftover = 0;
+
+	/* h = 0 */
+	for (i = 0; i < 17; i++)
+		st->h[i] = 0;
+
+	/* r &= 0xffffffc0ffffffc0ffffffc0fffffff */
+	st->r[ 0] = key[ 0] & 0xff;
+	st->r[ 1] = key[ 1] & 0xff;
+	st->r[ 2] = key[ 2] & 0xff;
+	st->r[ 3] = key[ 3] & 0x0f;
+	st->r[ 4] = key[ 4] & 0xfc;
+	st->r[ 5] = key[ 5] & 0xff;
+	st->r[ 6] = key[ 6] & 0xff;
+	st->r[ 7] = key[ 7] & 0x0f;
+	st->r[ 8] = key[ 8] & 0xfc;
+	st->r[ 9] = key[ 9] & 0xff;
+	st->r[10] = key[10] & 0xff;
+	st->r[11] = key[11] & 0x0f;
+	st->r[12] = key[12] & 0xfc;
+	st->r[13] = key[13] & 0xff;
+	st->r[14] = key[14] & 0xff;
+	st->r[15] = key[15] & 0x0f;
+	st->r[16] = 0;
+
+	/* save pad for later */
+	for (i = 0; i < 16; i++)
+		st->pad[i] = key[i + 16];
+	st->pad[16] = 0;
+
+	st->final = 0;
+}
+
+static void
+poly1305_add(unsigned char h[17], const unsigned char c[17]) {
+	unsigned short u;
+	unsigned int i;
+	for (u = 0, i = 0; i < 17; i++) {
+		u += (unsigned short)h[i] + (unsigned short)c[i];
+		h[i] = (unsigned char)u & 0xff;
+		u >>= 8;
+	}
+}
+
+static void
+poly1305_squeeze(unsigned char h[17], unsigned long hr[17]) {
+	unsigned long u;
+	unsigned int i;
+	u = 0;
+	for (i = 0; i < 16; i++) {
+		u += hr[i];
+		h[i] = (unsigned char)u & 0xff;
+		u >>= 8;
+	}
+	u += hr[16];
+	h[16] = (unsigned char)u & 0x03;
+	u >>= 2;
+	u += (u << 2); /* u *= 5; */
+	for (i = 0; i < 16; i++) {
+		u += h[i];
+		h[i] = (unsigned char)u & 0xff;
+		u >>= 8;
+	}
+	h[16] += (unsigned char)u;
+}
+
+static void
+poly1305_freeze(unsigned char h[17]) {
+	static const unsigned char minusp[17] = {
+		0x05,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+		0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+		0xfc
+	};
+	unsigned char horig[17], negative;
+	unsigned int i;
+
+	/* compute h + -p */
+	for (i = 0; i < 17; i++)
+		horig[i] = h[i];
+	poly1305_add(h, minusp);
+
+	/* select h if h < p, or h + -p if h >= p */
+	negative = -(h[16] >> 7);
+	for (i = 0; i < 17; i++)
+		h[i] ^= negative & (horig[i] ^ h[i]);
+}
+
+static void
+poly1305_blocks(poly1305_state_internal_t *st, const unsigned char *m, size_t bytes) {
+	const unsigned char hibit = st->final ^ 1; /* 1 << 128 */
+
+	while (bytes >= poly1305_block_size) {
+		unsigned long hr[17], u;
+		unsigned char c[17];
+		unsigned int i, j;
+
+		/* h += m */
+		for (i = 0; i < 16; i++)
+			c[i] = m[i];
+		c[16] = hibit;
+		poly1305_add(st->h, c);
+
+		/* h *= r */
+		for (i = 0; i < 17; i++) {
+			u = 0;
+			for (j = 0; j <= i ; j++) {
+				u += (unsigned short)st->h[j] * st->r[i - j];
+			}
+			for (j = i + 1; j < 17; j++) {
+				unsigned long v = (unsigned short)st->h[j] * st->r[i + 17 - j];
+				v = ((v << 8) + (v << 6)); /* v *= (5 << 6); */
+				u += v;
+			}
+			hr[i] = u;
+		}
+
+		/* (partial) h %= p */
+		poly1305_squeeze(st->h, hr);
+
+		m += poly1305_block_size;
+		bytes -= poly1305_block_size;
+	}
+}
+
+POLY1305_NOINLINE void
+poly1305_finish(poly1305_context *ctx, unsigned char mac[16]) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	size_t i;
+
+	/* process the remaining block */
+	if (st->leftover) {
+		size_t i = st->leftover;
+		st->buffer[i++] = 1;
+		for (; i < poly1305_block_size; i++)
+			st->buffer[i] = 0;
+		st->final = 1;
+		poly1305_blocks(st, st->buffer, poly1305_block_size);
+	}
+
+	/* fully reduce h */
+	poly1305_freeze(st->h);
+
+	/* h = (h + pad) % (1 << 128) */
+	poly1305_add(st->h, st->pad);
+	for (i = 0; i < 16; i++)
+		mac[i] = st->h[i];
+
+	/* zero out the state */
+	for (i = 0; i < 17; i++)
+		st->h[i] = 0;
+	for (i = 0; i < 17; i++)
+		st->r[i] = 0;
+	for (i = 0; i < 17; i++)
+		st->pad[i] = 0;
+}

--- a/src/poly1305-donna/poly1305-donna.c
+++ b/src/poly1305-donna/poly1305-donna.c
@@ -1,0 +1,201 @@
+#include "poly1305-donna.h"
+
+#if defined(POLY1305_8BIT)
+#include "poly1305-donna-8.h"
+#elif defined(POLY1305_16BIT)
+#include "poly1305-donna-16.h"
+#elif defined(POLY1305_32BIT)
+#include "poly1305-donna-32.h"
+#elif defined(POLY1305_64BIT)
+#include "poly1305-donna-64.h"
+#else
+
+/* auto detect between 32bit / 64bit */
+#define HAS_SIZEOF_INT128_64BIT (defined(__SIZEOF_INT128__) && defined(__LP64__))
+#define HAS_MSVC_64BIT (defined(_MSC_VER) && defined(_M_X64))
+#define HAS_GCC_4_4_64BIT (defined(__GNUC__) && defined(__LP64__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))))
+
+#if (HAS_SIZEOF_INT128_64BIT || HAS_MSVC_64BIT || HAS_GCC_4_4_64BIT)
+#include "poly1305-donna-64.h"
+#else
+#include "poly1305-donna-32.h"
+#endif
+
+#endif
+
+void
+poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes) {
+	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
+	size_t i;
+
+	/* handle leftover */
+	if (st->leftover) {
+		size_t want = (poly1305_block_size - st->leftover);
+		if (want > bytes)
+			want = bytes;
+		for (i = 0; i < want; i++)
+			st->buffer[st->leftover + i] = m[i];
+		bytes -= want;
+		m += want;
+		st->leftover += want;
+		if (st->leftover < poly1305_block_size)
+			return;
+		poly1305_blocks(st, st->buffer, poly1305_block_size);
+		st->leftover = 0;
+	}
+
+	/* process full blocks */
+	if (bytes >= poly1305_block_size) {
+		size_t want = (bytes & ~(poly1305_block_size - 1));
+		poly1305_blocks(st, m, want);
+		m += want;
+		bytes -= want;
+	}
+
+	/* store leftover */
+	if (bytes) {
+		for (i = 0; i < bytes; i++)
+			st->buffer[st->leftover + i] = m[i];
+		st->leftover += bytes;
+	}
+}
+
+void
+poly1305_auth(unsigned char mac[16], const unsigned char *m, size_t bytes, const unsigned char key[32]) {
+	poly1305_context ctx;
+	poly1305_init(&ctx, key);
+	poly1305_update(&ctx, m, bytes);
+	poly1305_finish(&ctx, mac);
+}
+
+int
+poly1305_verify(const unsigned char mac1[16], const unsigned char mac2[16]) {
+	size_t i;
+	unsigned int dif = 0;
+	for (i = 0; i < 16; i++)
+		dif |= (mac1[i] ^ mac2[i]);
+	dif = (dif - 1) >> ((sizeof(unsigned int) * 8) - 1);
+	return (dif & 1);
+}
+
+
+/* test a few basic operations */
+int
+poly1305_power_on_self_test(void) {
+	/* example from nacl */
+	static const unsigned char nacl_key[32] = {
+		0xee,0xa6,0xa7,0x25,0x1c,0x1e,0x72,0x91,
+		0x6d,0x11,0xc2,0xcb,0x21,0x4d,0x3c,0x25,
+		0x25,0x39,0x12,0x1d,0x8e,0x23,0x4e,0x65,
+		0x2d,0x65,0x1f,0xa4,0xc8,0xcf,0xf8,0x80,
+	};
+
+	static const unsigned char nacl_msg[131] = {
+		0x8e,0x99,0x3b,0x9f,0x48,0x68,0x12,0x73,
+		0xc2,0x96,0x50,0xba,0x32,0xfc,0x76,0xce,
+		0x48,0x33,0x2e,0xa7,0x16,0x4d,0x96,0xa4,
+		0x47,0x6f,0xb8,0xc5,0x31,0xa1,0x18,0x6a,
+		0xc0,0xdf,0xc1,0x7c,0x98,0xdc,0xe8,0x7b,
+		0x4d,0xa7,0xf0,0x11,0xec,0x48,0xc9,0x72,
+		0x71,0xd2,0xc2,0x0f,0x9b,0x92,0x8f,0xe2,
+		0x27,0x0d,0x6f,0xb8,0x63,0xd5,0x17,0x38,
+		0xb4,0x8e,0xee,0xe3,0x14,0xa7,0xcc,0x8a,
+		0xb9,0x32,0x16,0x45,0x48,0xe5,0x26,0xae,
+		0x90,0x22,0x43,0x68,0x51,0x7a,0xcf,0xea,
+		0xbd,0x6b,0xb3,0x73,0x2b,0xc0,0xe9,0xda,
+		0x99,0x83,0x2b,0x61,0xca,0x01,0xb6,0xde,
+		0x56,0x24,0x4a,0x9e,0x88,0xd5,0xf9,0xb3,
+		0x79,0x73,0xf6,0x22,0xa4,0x3d,0x14,0xa6,
+		0x59,0x9b,0x1f,0x65,0x4c,0xb4,0x5a,0x74,
+		0xe3,0x55,0xa5
+	};
+
+	static const unsigned char nacl_mac[16] = {
+		0xf3,0xff,0xc7,0x70,0x3f,0x94,0x00,0xe5,
+		0x2a,0x7d,0xfb,0x4b,0x3d,0x33,0x05,0xd9
+	};
+
+	/* generates a final value of (2^130 - 2) == 3 */
+	static const unsigned char wrap_key[32] = {
+		0x02,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+		0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+		0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+		0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+	};
+
+	static const unsigned char wrap_msg[16] = {
+		0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+		0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff
+	};
+
+	static const unsigned char wrap_mac[16] = {
+		0x03,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+		0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+	};
+
+	/*
+		mac of the macs of messages of length 0 to 256, where the key and messages
+		have all their values set to the length
+	*/
+	static const unsigned char total_key[32] = {
+		0x01,0x02,0x03,0x04,0x05,0x06,0x07,
+		0xff,0xfe,0xfd,0xfc,0xfb,0xfa,0xf9,
+		0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+		0xff,0xff,0xff,0xff,0xff,0xff,0xff
+	};
+
+	static const unsigned char total_mac[16] = {
+		0x64,0xaf,0xe2,0xe8,0xd6,0xad,0x7b,0xbd,
+		0xd2,0x87,0xf9,0x7c,0x44,0x62,0x3d,0x39
+	};
+
+	poly1305_context ctx;
+	poly1305_context total_ctx;
+	unsigned char all_key[32];
+	unsigned char all_msg[256];
+	unsigned char mac[16];
+	size_t i, j;
+	int result = 1;
+
+	for (i = 0; i < sizeof(mac); i++)
+		mac[i] = 0;
+	poly1305_auth(mac, nacl_msg, sizeof(nacl_msg), nacl_key);
+	result &= poly1305_verify(nacl_mac, mac);
+
+	for (i = 0; i < sizeof(mac); i++)
+		mac[i] = 0;
+	poly1305_init(&ctx, nacl_key);
+	poly1305_update(&ctx, nacl_msg +   0, 32);
+	poly1305_update(&ctx, nacl_msg +  32, 64);
+	poly1305_update(&ctx, nacl_msg +  96, 16);
+	poly1305_update(&ctx, nacl_msg + 112,  8);
+	poly1305_update(&ctx, nacl_msg + 120,  4);
+	poly1305_update(&ctx, nacl_msg + 124,  2);
+	poly1305_update(&ctx, nacl_msg + 126,  1);
+	poly1305_update(&ctx, nacl_msg + 127,  1);
+	poly1305_update(&ctx, nacl_msg + 128,  1);
+	poly1305_update(&ctx, nacl_msg + 129,  1);
+	poly1305_update(&ctx, nacl_msg + 130,  1);
+	poly1305_finish(&ctx, mac);
+	result &= poly1305_verify(nacl_mac, mac);
+
+	for (i = 0; i < sizeof(mac); i++)
+		mac[i] = 0;
+	poly1305_auth(mac, wrap_msg, sizeof(wrap_msg), wrap_key);
+	result &= poly1305_verify(wrap_mac, mac);
+
+	poly1305_init(&total_ctx, total_key);
+	for (i = 0; i < 256; i++) {
+		/* set key and message to 'i,i,i..' */
+		for (j = 0; j < sizeof(all_key); j++)
+			all_key[j] = i;
+		for (j = 0; j < i; j++)
+			all_msg[j] = i;
+		poly1305_auth(mac, all_msg, i, all_key);
+		poly1305_update(&total_ctx, mac, 16);
+	}
+	poly1305_finish(&total_ctx, mac);
+	result &= poly1305_verify(total_mac, mac);
+
+	return result;
+}

--- a/src/poly1305-donna/poly1305-donna.h
+++ b/src/poly1305-donna/poly1305-donna.h
@@ -1,0 +1,20 @@
+#ifndef POLY1305_DONNA_H
+#define POLY1305_DONNA_H
+
+#include <stddef.h>
+
+typedef struct poly1305_context {
+	size_t aligner;
+	unsigned char opaque[136];
+} poly1305_context;
+
+void poly1305_init(poly1305_context *ctx, const unsigned char key[32]);
+void poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes);
+void poly1305_finish(poly1305_context *ctx, unsigned char mac[16]);
+void poly1305_auth(unsigned char mac[16], const unsigned char *m, size_t bytes, const unsigned char key[32]);
+
+int poly1305_verify(const unsigned char mac1[16], const unsigned char mac2[16]);
+int poly1305_power_on_self_test(void);
+
+#endif /* POLY1305_DONNA_H */
+

--- a/src/restic_fmt_plug.c
+++ b/src/restic_fmt_plug.c
@@ -1,0 +1,341 @@
+/*
+ * This software is Copyright (c) 2020, Jürgen Hötzel <juergen at hoetzel.info>
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_restic;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_restic);
+#endif
+
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "aes.h"
+#include "arch.h"
+#include "base64_convert.h"
+#include "common.h"
+#include "formats.h"
+#include "misc.h"
+#include "poly1305-donna/poly1305-donna.h"
+#include "yescrypt/sysendian.h"
+#include "yescrypt/yescrypt.h"
+
+#define FORMAT_NAME "Restic Repository"
+#define FORMAT_LABEL "restic"
+#define FORMAT_TAG "$restic$"
+#define TAG_LENGTH (sizeof(FORMAT_TAG)-1)
+#define ALGORITHM_NAME "PBKDF2/scrypt Poly1305"
+#define PLAINTEXT_LENGTH 125
+#define BINARY_SIZE 16 /* MAC */
+#define BINARY_ALIGN sizeof(uint32_t)
+#define DATA_SIZE 160
+#define SALT_ALIGN sizeof(uint32_t)
+#define MAC_SIZE 16
+#define NONCE_SIZE 16
+#define BENCHMARK_COMMENT ""
+#define BENCHMARK_LENGTH 7
+#define MIN_KEYS_PER_CRYPT 1
+#define MAX_KEYS_PER_CRYPT 1
+
+static int max_threads;
+static yescrypt_local_t *local;
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+static uint64_t poly1305_key_mask[2];
+
+typedef struct restic_salt {
+	uint32_t N;
+	uint32_t r;
+	uint32_t p;
+	char salt[64];
+	unsigned char data[DATA_SIZE];
+} restic_salt;
+
+static restic_salt *cur_salt;
+
+static struct fmt_tests restic_tests[] = {
+	{
+		"$restic$scrypt*8192*8*1*ed29ad65948797a275f15b1da36fdd2b0247a7772d69ecfdf21141d837fb0780b6fb48cf7ccc3e4146a105dee0df4851256e204671d97c718c7e6b4a7a8cfb75*879acc157daa013218fcccf6b60be20f1e52baa893698a589f026165f51bbb1da03b0a5db42885d8bcffb34030b0bb26716e9f7c950cccb674494d63d104ee8808e713a7d483a6a0ef36b14aaac652eaa3a92b12f9d7a4cfead72ed0a216ccaeb0ddf9c6e94aa84c82590ae9a6ffc1b48b4fba163635ffb4e0633de668827e567e8c834539ae18d750be6f8f86f12101b04ab926fa570038eb6f78ef6021c1b1",
+		"penance"
+	},
+	{
+		"$restic$scrypt*32768*8*5*e6dac36997999525fdeeb075434416047dab7d28b0c26f82fa44a469747659ecb86614e66b75151e0bd8acc2f8c7b29d258bf8e6a39d47455bd8d34e87622510*f82d75db1dc5087fb2bdb014bb51cf07b72b62d10cb164fb244b0358b9c1bbac3663f0ca3f00f12731dc3cc3b6c9de949dc74b31d22e515e55096d219d75babc798a9a7a47fc86034e6fe358a93a6b1eff71d2b791ecee3b775b2b910ecf55abef7d53e4a0fac08e5526f1c25eab06dcd26a1250cb37b7dc115391c680becce8a5e63bdbe2326626c88d16bece0d6dca51de89e43207ea6febc6e119486024a0",
+		"password"
+	},
+	{NULL}
+};
+
+static void init(struct fmt_main *self)
+{
+	max_threads = 1;
+	local = mem_alloc(sizeof(*local) * max_threads);
+	int i;
+	for (i = 0; i < max_threads; i++)
+		yescrypt_init_local(&local[i]);
+
+	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));
+	crypt_out = mem_calloc(self->params.max_keys_per_crypt, sizeof(*crypt_out));
+
+	be64enc(&poly1305_key_mask[0], 0xFFFFFF0FFCFFFF0FULL);
+	be64enc(&poly1305_key_mask[1], 0XFCFFFF0FFCFFFF0FULL);
+}
+
+static void done(void)
+{
+	int i;
+	for (i = 0; i < max_threads; i++)
+		yescrypt_free_local(&local[i]);
+	MEM_FREE(local);
+	MEM_FREE(saved_key);
+	MEM_FREE(crypt_out);
+}
+
+static int valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *keeptr, *p;
+
+	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH) != 0)
+		return 0;
+
+	ctcopy = strdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += TAG_LENGTH;
+
+	if (((p = strtokm(ctcopy, "*")) == NULL) || (strcmp("scrypt", p) != 0))
+		goto err;
+	if (((p = strtokm(NULL, "*")) == NULL) || !isdec(p)) /* scrypt: N */
+		goto err;
+	if (((p = strtokm(NULL, "*")) == NULL) || !isdec(p)) /* scrypt: r */
+		goto err;
+	if (((p = strtokm(NULL, "*")) == NULL) || !isdec(p)) /* scrypt: p */
+		goto err;
+	if (((p = strtokm(NULL, "*")) == NULL) || !ishexn(p, 64)) /* scrypt: salt */
+		goto err;
+	if (((p = strtokm(NULL, "*")) == NULL) || !ishexn(p, 160)) /* restic: data */
+		goto err;
+
+	MEM_FREE(keeptr);
+	return 1;
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *restic_get_binary(char *ciphertext)
+{
+	static unsigned char c[BINARY_SIZE];
+	char *p;
+	int i;
+	p = strrchr(ciphertext, '*') + 1;
+	// Restic design doc: If the password is incorrect or the key file has been tampered with,
+	// the computed MAC will not match the last 16 bytes of the data
+	p += (160 - 16) * 2;
+	for (i = 0; i < BINARY_SIZE; i++) {
+		c[i] = (atoi16[ARCH_INDEX(*p)] << 4) | atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+	return c;
+}
+
+void *restic_get_salt(char *ciphertext)
+{
+	char *ctcopy = strdup(ciphertext);
+	char *keeptr = ctcopy;
+	int i;
+	char *p;
+	restic_salt *cur_salt;
+
+	cur_salt = mem_calloc_tiny(sizeof(restic_salt), SALT_ALIGN);
+
+	ctcopy += TAG_LENGTH;
+
+	strtokm(ctcopy, "*"); /* SCRYPT */
+
+	p = strtokm(NULL, "*");
+	cur_salt->N = atoi(p);
+
+	p = strtokm(NULL, "*");
+	cur_salt->r = atoi(p);
+
+	p = strtokm(NULL, "*");
+	cur_salt->p = atoi(p);
+
+	p = strtokm(NULL, "*");
+	for (i = 0; i < sizeof(cur_salt->salt); i++)
+		cur_salt->salt[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16 +
+		                    atoi16[ARCH_INDEX(p[i * 2 + 1])];
+
+	p = strtokm(NULL, "*");
+	for (i = 0; i < sizeof(cur_salt->data); i++)
+		cur_salt->data[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16 +
+		                    atoi16[ARCH_INDEX(p[i * 2 + 1])];
+
+	MEM_FREE(keeptr);
+	return cur_salt;
+}
+
+unsigned int restic_tunable_cost_N(void *salt)
+{
+	restic_salt *rs = salt;
+	return (unsigned int)rs->N;
+}
+
+unsigned int restic_tunable_cost_r(void *salt)
+{
+	restic_salt *rs = salt;
+	return (unsigned int)rs->r;
+}
+
+unsigned int restic_tunable_cost_p(void *salt)
+{
+	restic_salt *rs = salt;
+	return (unsigned int)rs->p;
+}
+
+void restic_set_salt(void *salt)
+{
+	cur_salt = (restic_salt *)salt;
+}
+
+void restic_set_key(char *key, int index)
+{
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
+}
+
+char *restic_get_key(int index)
+{
+	return saved_key[index];
+}
+
+int restic_cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (((uint32_t *)binary)[0] == crypt_out[index][0])
+			return 1;
+	return 0;
+}
+
+int restic_cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+}
+
+int restic_cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+static int restic_crypt_all(int *pcount, struct db_salt *salt)
+{
+	int count = *pcount;
+	int index;
+	int failed = 0;
+	yescrypt_params_t params = {.N = cur_salt->N, .r = cur_salt->r, .p = cur_salt->p};
+#ifdef _OPENMP
+	#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index++) {
+		uint8_t kdf_out[64];
+#ifdef _OPENMP
+		int t = omp_get_thread_num();
+		if (t >= max_threads) {
+			#pragma omp atomic
+			failed |= 2;
+			continue;
+		}
+#else
+		const int t = 0;
+#endif
+		if (yescrypt_kdf(NULL, &local[t], (const uint8_t *)saved_key[index],
+		                 strlen(saved_key[index]),
+		                 (const uint8_t *)cur_salt->salt, sizeof(cur_salt->salt), &params, kdf_out,
+		                 sizeof(kdf_out))) {
+			failed |= 1;
+		}
+
+		uint8_t *poly1305_key = kdf_out + 32;
+		const unsigned char *nonce = cur_salt->data;
+		const unsigned char *ciphertext = cur_salt->data + NONCE_SIZE;
+		unsigned char prepared_key[32];
+		uint64_t masked_key[32 / sizeof(uint64_t)];
+
+		memcpy(masked_key, poly1305_key, 32);
+		masked_key[2] &= poly1305_key_mask[0];
+		masked_key[3] &= poly1305_key_mask[1];
+
+		AES_KEY aeskey;
+		AES_set_encrypt_key((unsigned char *)masked_key, 128, &aeskey);
+		AES_ecb_encrypt(nonce, prepared_key + 16, &aeskey, AES_ENCRYPT);
+		memcpy(prepared_key, masked_key + 2, 16);
+		poly1305_auth((unsigned char *)crypt_out[index], ciphertext, 128,
+		              prepared_key);
+	}
+	if (failed) {
+#ifdef _OPENMP
+		if (failed & 2) {
+			fprintf(stderr, "OpenMP thread number out of range\n");
+			error();
+		}
+#endif
+		fprintf(stderr, "scrypt failed: %s\n", strerror(errno));
+		error();
+	}
+	return count;
+}
+
+struct fmt_main fmt_restic = {/* fmt_params */
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		sizeof(restic_salt),
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		{"N", "r", "p"},
+		{FORMAT_TAG},
+		restic_tests
+	},
+	/* fmt_methods */
+	{
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		valid,
+		fmt_default_split,
+		restic_get_binary,
+		restic_get_salt,
+		{restic_tunable_cost_N, restic_tunable_cost_r, restic_tunable_cost_p},
+		fmt_default_source,
+		{fmt_default_binary_hash},
+		fmt_default_salt_hash,
+		NULL,
+		restic_set_salt,
+		restic_set_key,
+		restic_get_key,
+		fmt_default_clear_keys,
+		restic_crypt_all,
+		{fmt_default_get_hash},
+		restic_cmp_all,
+		restic_cmp_one,
+		restic_cmp_exact
+	}
+};


### PR DESCRIPTION
`restic` is a backup program available under many Unix-like operating systems (such as Linux, BSD, and Mac OS X) and ships with many popular Linux distributions including Ubuntu, Arch, and Fedora.

For Poly1305-AES MAC I imported third party code from [poly1305-donna](https://github.com/floodyberry/poly1305-donna) which is under the same license and from the same author (public domain) as `ed25519-donna`  (used by `tezos_fmt_plug.c`).

