### PR TITLE
Eclipse Mosquitto - mosquitto_passwd hash converter - mosquitto2john.py

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -157,6 +157,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Drop support for --fix-state-delay option, and instead do something better
   in the cracker engine - by default, and for all modes.  [magnum; 2020]
 
+- Addition of mosquitto2john.py for cracking of Eclipse Mosquitto passwd files.
+  [blackfell; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 
@@ -560,3 +563,4 @@ Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
   mostly part of our development process and not the release, although some
   CI-related files do exist in our released tree.
   [Claudio, magnum; 2015-2019]
+

--- a/doc/README-mosquitto.md
+++ b/doc/README-mosquitto.md
@@ -1,0 +1,144 @@
+# Eclipse mosquitto_password cracking
+
+mosquitto2john.py is a helper script to allow you to convert Eclipse Mosquitto
+passwd files into a John friendly format. The script takes a 
+[mosquitto_passwd file](https://mosquitto.org/man/mosquitto_passwd-1.html) as 
+its only required input. 
+
+## Usage
+
+```
+❯ mosquitto2john.py --help
+usage: mosquitto2john.py [-h] [-hc] [passwd_file ...]
+
+positional arguments:
+  passwd_file     Path to the source mosquitto_passwd file(s).
+
+optional arguments:
+  -h, --help      show this help message and exit
+  -hc, --hashcat  Convert hashes to hashcat friendly formats.
+
+Find more Information:
+    See doc/README-mosquitto.md for info/troubleshooting.
+```
+
+This script is intended to work in the classic something2john.py way, provide
+mosquitto_passwd files and pipe the output into an outfile of your choosing:
+
+```
+❯ mosquitto2john.py mosquitto_passwd mosquitto_passwd_2 > mosquitto.hash
+❯ john ./mosquitto.hash
+[...SNIP...]
+Session completed. 
+```
+### Hashcat
+
+The hashcat option converts the hashes to Hashcat friendly formats - mode 1710 
+for SHA512 and 12100 for pbkdf2-hmac-sha512 hashes. In the following example, 
+some SHA512 and pbkdf2-hmac-sha512 hashes have already been exported into 
+separate files according to their type:
+
+```
+❯ ls
+sha512_hashes     HMAC_hashes
+# Identify the SHA512 hashes by their format: HEX_DIGEST:HEX_SALT
+❯ head -n 1 sha512_hashes
+SOMELONGHEXDIGEST:SOMEHEXSALT
+❯ hashcat -a 0 -m 1710 --hex-salt ./sha512_hashes [WORDLIST]
+[... SNIP ...]
+# Identify the HMAC hashes by a leading sha512: and following iteration count
+# These also have base64 salt and digests
+❯ head -n 1 HMAC_hashes
+sha512:101:BaSe64SaLt:BaSe64DiGeSt==
+❯ hashcat -a 0 -m 12100 ./HMAC_hashes [WORDLIST]
+[... SNIP ...]
+```
+
+**Note** the *use of --hex-salt in mode 1710* this is required for successful
+cracking.
+
+## Troubleshooting
+
+### No hashes loaded?
+
+In certain older versions of JtR and only for the SHA512 format hashes 
+(dynamic_82), you may have problems autodetecting the hash format. You
+can manually specify the format with *--format=dynamic_82 in this instance*:
+
+```
+# Peek at the format to spot the issue -  just after the username field
+❯ head -n 1 ./mosquitto.hash
+username:$dynamic_82$SOMELONGHASH$SOMESALT	
+# Now manually specify the dynamic_82 format
+❯ john ./mosquitto.hash --format=dynamic_82
+[...SNIP...]
+Session completed. 
+```
+
+### Mixed Hash Types?
+
+The Eclipse mosquitto_passwd program might allow different hash varieties, 
+depending on the Version you're working against. In the rare case that this
+could come up, the output can either be split into two (using, say grep), or
+you can simply specify the hash format on the command line. In the following
+example, hashes are stored in a single file and each format worked against
+sequentially:
+
+```
+❯ ls
+mosquitto_out
+# Now crack one at a time because different hash modes
+❯ john ./mosquitto_out --format=dynamic_82 
+[... SNIP ...]
+Session completed.
+❯ john ./mosquitto_out --format=pbkdf2-hmac-sha512
+[... SNIP ...]
+Session completed.
+```
+
+Similarly, if using Hashcat, we need to crack any mixed hash formats one 
+flavour at a time. The following is an equivalent example in Hashcat:
+
+```
+❯ ls
+hcat_out_file
+❯ hashcat -a 0 -m 1710 --hex-salt hcat_out_file [WORDLIST]
+[... SNIP ...]
+Hashfile 'hcat_out_file' on line 1 [...SNIP...]: Token length exception
+[... SNIP ...]
+❯ hashcat -a 0 -m 12100 hcat_out_file [WORDLIST]
+[... SNIP ...]
+Hashfile 'hcat_out_file' on line 2 [...SNIP...]: Token length exception
+[... SNIP ...]
+```
+This time, a Token length exception is raised for the hashes whose format
+doesn't match the current mode. Hashcat will continue to crack the valid 
+hashes just fine, but to avoid this,you may instead choose to split the two 
+formats into separate files. See the usage section for hashcat hash 
+identification.
+
+Again, note the need to **specify --hex-salt** for the 1710 format hashes.
+
+### Invalid input. Try removing ':' from username
+
+You may see this error on (hopefully) rare occasions if the mosquitto_passwd
+file itself  contains an error. Eclipse mention in one line of the 
+[mosquitto_passwd README](https://mosquitto.org/man/mosquitto_passwd-1.html) 
+that colons are a forbidden username character. Just because there's nothing 
+stopping this happening and it's not a huge warning, mosquitto2john looks out
+for it and will tell you what to do if you have a non-conforming passwd file. 
+
+The simplest solution in this instance is to make a note of the username, 
+remove the colon and try your conversion again. Happy hacking.
+
+## More info? Troubleshooting the Script itself?
+
+See https://github.com/eclipse/mosquitto/search?q=pw_sha512_pbkdf2 for info
+on HMAC formats. An equivalent search can be made for SHA512. This is the 
+information used to infer the valid hash formats.
+
+Hashes have been assumed to always be of the format: 
+username:$[HASHNO][$ITER(HMAC ONLY)]$SALT$HASH
+Where salt and hash are always B64 encoded and usernames SHOULD not include a 
+colon. Any usernames with a colon are out of spec, but possible, so we handle 
+by alerting the user and advising on manual management. 

--- a/run/mosquitto2john.py
+++ b/run/mosquitto2john.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+# This software is Copyright (c) 2021, Blackfell <github at blackfell.net>
+# and it is hereby released to the general public under the following terms:
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.
+
+import re, argparse
+
+from hashlib import pbkdf2_hmac, sha512
+from base64 import b64encode, b64decode
+from sys import exit, argv, stderr, stdout
+from binascii import hexlify
+from textwrap import dedent
+
+def format_hmac(user, hash_data, hashcat):
+    """Take hash data and return a valid hashcat hash for the
+    PBKDF2-HMAC-SHA512 hash mode (12100) if hashcat is set to True
+    else it will return a valid john format hash for the 
+    JtR pbkdf2-hmac-sha512 hash format"""
+
+    hcat_fmt_str = "sha512:{}:{}:{}"
+    john_fmt_str = "{}:$pbkdf2-hmac-sha512${}.{}.{}"
+    junk, morejunk, iterations, salt, digest = hash_data.split("$")
+    
+    if hashcat:
+        #Everything just goes in base64 in this mode - nice & easy
+        return hcat_fmt_str.format(iterations, salt, digest)
+
+    # John format needs Hex conversions
+    hex_digest = hexlify(b64decode(digest)).decode().upper()
+    hex_salt = hexlify(b64decode(salt)).decode().upper()
+    
+    return john_fmt_str.format(user, iterations, hex_salt, hex_digest)
+
+def format_sha512(user, hash_data, hashcat):
+    """Take hash data and return a valid hashcat hash for the
+    salted SHA512 hash mode (1710) if hashcat is set True
+    else it will take a hash and return a valid john hash for the
+    dynamic_82 John mode - sha512($password.$salt) """
+
+    hcat_fmt_str = "{}:{}"
+    john_fmt_str = "{}:$dynamic_82${}$HEX${}"
+    junk, morejunk, salt, digest = hash_data.split("$")
+
+    # Convert hash and salt to hex - needed for both formats now
+    hex_digest = hexlify(b64decode(digest)).decode().upper()
+    hex_salt = hexlify(b64decode(salt)).decode().upper()
+    
+    if hashcat:
+        return hcat_fmt_str.format(hex_digest, hex_salt)
+    
+    return john_fmt_str.format(user, hex_digest, hex_salt)
+
+def extract_hash(line, hmac_list, sha512_list, regex, hashcat):
+    """Do basic parsing on a given passwd file line, if valid hash found
+    format it accordingly for its type and once properly formatted,
+    append to the corresponding hash list. Hash identification is managed 
+    by a pretty basic regex passed from calling function."""
+
+    # If there are no hashes on this line - return
+    line = line.strip()
+    if not line: return
+    m = regex.match(line)
+    if not m: return
+
+    # We know mosquitto_passwd doesn't permit colons in the user field
+    # but this isn't enforced in code, so quick check for that
+    if m.group().count(":") > 1:
+        stderr.write(
+                "Invalid input. Try removing ':' from username:\n {}\n"
+                .format(m.group()))
+        return
+    
+    # Everything else in the hash is an int, $ or b64, so we can split on :
+    user, hash_data = m.group().split(":")
+
+    # Get any HMACs and put them in the HMAC list
+    if hash_data.count("$") == 4:
+        hmac_list.append(format_hmac(user, hash_data, hashcat))
+
+    # Get any plain SHA512s and put them in the sha512 list
+    elif hash_data.count("$") == 3:
+        sha512_list.append(format_sha512(user, hash_data, hashcat))
+
+    # Maybe there's a bad match some how?
+    else:
+        stderr.write("Error parsing hash - bad format:\n{}".format(
+                hash_string))
+
+
+def process_file(hashfile, hashcat):
+    """Take a mosquitto_passwd file and convert to John/Hashcat compatible 
+    format.Can handle both SHA512 and PBKDF2_HMAC_SHA512 output formats.
+    Uses raw hex or base64 for hash and salt because 'bad' bytes are possible.
+
+    Some versions of mosquitto_passwd can use mixed hash types, so we
+    manage the two possible variants in simple lists, up until writing
+    them out. 
+
+    See https://github.com/eclipse/mosquitto/search?q=pw_sha512_pbkdf2 for
+    info on HMAC format Hashes. An equivalent search can be made for SHA512.
+    
+    Hashes have been assumed to always be of the format:
+        username:$[HASHNO][$ITER(HMAC ONLY)]$SALT$HASH
+    Where salt and hash are always B64 encoded and usernames can be .+
+    Any usernames with a colon are out of spec, but possible, so we handle
+    them by alerting the user and advising manual management.
+    """
+
+    hmac_list = []
+    sha512_list = []
+
+    # This is probably close enough-ish to being a good regex for the job
+    # Suggestions welcome 
+    regex = re.compile(
+            r".+:\$[6-7](\$[0-9]+)*\$[a-zA-Z0-9+/=]+\$[a-zA-Z0-9+/=]{80,90}")
+
+    # Read matching hashes from the file, populate the hmac and sha512 lists
+    with open(hashfile, 'r') as h:
+        for line in h:
+            # Extract any hash and format them while we're at it
+            extract_hash(line, hmac_list, sha512_list, regex, hashcat)
+
+    # Write to stdout if we have any hashes
+    if len(sha512_list) > 0 or len(hmac_list) > 0:
+        for h in sha512_list:
+            stdout.write(h + "\n")
+        for h in hmac_list:
+            stdout.write(h + "\n")
+
+    # The other case is that we found nothing
+    else:
+        stderr.write(
+                "No hashes found. Is this a valid mosquitto_passwd file?\n")
+
+def get_args():
+    parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=dedent('''\
+                    Find more Information:
+                        See doc/README-mosquitto.md for info/troubleshooting.
+                        '''))
+    parser.add_argument("-hc", "--hashcat", action = "store_true", \
+            help = "Convert hashes to hashcat friendly formats.")
+    parser.add_argument("passwd_file", nargs='*', \
+            help = "Path to the source mosquitto_passwd file(s).")
+
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    
+    #Get user options
+    args = get_args()
+
+    for passwd_file in args.passwd_file:
+        # Quick check that our file is real before we crack on
+        try:
+            with open(passwd_file, 'r') as f:
+                pass
+        except:
+            stderr.write("'{}' is not a readable file.\n".format(
+                passwd_file))
+            exit(1)
+        # Do the conversion stuff
+        process_file(passwd_file, args.hashcat)


### PR DESCRIPTION
Helper script to format Eclipse mosquitto_passwd files for John as mentioned in [Issue 4550](https://github.com/openwall/john/issues/4550).

Changes Comprise addition of run/mosquitto2john.py and doc/README-mosquitto files, along with a small addition to doc/NEWS. The script itself is a cut-down version of the version listed in the original issue (now renamed to [https://github.com/Blackfell/python_widgets/blob/main/mosquito_passwd_crack.py](https://github.com/Blackfell/python_widgets/blob/main/mosquito_passwd_crack.py)). This version is wholly focused on converting to John compatible format and manages stdout and stderr in a way that mimics some of the other *2john.py tools (because it's better!). 

More than happy to take pointers and fixes, in particular, I've tried to imitate the entries in doc/NEWS, let me know if that looks about right or not and I'll happily amend. Similarly, the README is markdown still, happy to re-format as you prefer. 

Tested (mostly) against Mosquitto version 2.0.5 install of mosquitto_passwd, using Docker, ubuntu:latest to create test passwd files. Tested outputs against three John installs on Arch, Ubuntu and Kali. Mileage for auto-detection of dynamic_82 format seems to vary per-install of John (i.e. works on everything I've tested on except Kali), but can always crack hashes if the format is specified on the command line (some info in README to reflect this). If there's a way my script can help improve format auto-detection, I'll be glad to add, I just can't see what could be causing it, beyond a local build issue. 

Cheers,
 - Blackfell