### PR TITLE
Add two external modes: Filter_NoRepeats and Filter_Repeats

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -1553,6 +1553,65 @@ void filter()
 	word = 0;
 }
 
+# Skip candidate passwords that contain the same character more than once
+[List.External:Filter_NoRepeats]
+int seen[0x100], now;
+
+void init()
+{
+	now = 1;
+}
+
+void filter()
+{
+	int i, c;
+
+	if (!--now) {
+		i = 0;
+		while (i < 0x100)
+			seen[i++] = 0;
+		now = 1000000000;
+	}
+
+	i = 0;
+	while (c = word[i++]) {
+		if (seen[c] == now) {
+			word = 0; return;
+		}
+		seen[c] = now;
+	}
+}
+
+# Keep only candidate passwords that contain the same character more than once
+[List.External:Filter_Repeats]
+int seen[0x100], now;
+
+void init()
+{
+	now = 1;
+}
+
+void filter()
+{
+	int i, c;
+
+	if (!--now) {
+		i = 0;
+		while (i < 0x100)
+			seen[i++] = 0;
+		now = 1000000000;
+	}
+
+	i = 0;
+	while (c = word[i++]) {
+		if (seen[c] == now)
+			return;
+		seen[c] = now;
+	}
+
+	word = 0;
+}
+
 # A simple cracker for LM hashes
 [List.External:LanMan]
 int length;				// Current length


### PR DESCRIPTION
Filter_NoRepeats skips candidate passwords that contain the same character more than once, and Filter_Repeats is its inverse.

(These were first introduced in core in November 2019.)