### PR TITLE
Bench report weirdness

### DIFF
--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -182,7 +182,7 @@ BENCH_OBJS = \
 	$(BENCH_MD5_OBJS_DEPEND) \
 	$(BENCH_BF_OBJS_DEPEND) \
 	bench-t.o best.o common_g.o config_g.o formats_g.o jumbo.o dyna_salt.o \
-	memory.o miscnl.o params.o path.o signals_g.o tty.o
+	memory.o miscnl.o params.o path.o signals_g.o tty-t.o
 
 GENMKVPWD_OBJS = \
 	genmkvpwd.o mkvlib.o memory.o miscnl.o path.o jumbo.o
@@ -1946,6 +1946,9 @@ miscnl.o: misc.c
 
 bench-t.o: bench.c
 	$(CC) $(CFLAGS) $(OPT_NORMAL) -DBENCH_BUILD bench.c -o bench-t.o
+
+tty-t.o: tty.c
+	$(CC) $(CFLAGS) $(OPT_NORMAL) -DBENCH_BUILD tty.c -o tty-t.o
 
 *_fmt_plug.c: Makefile.legacy john.c
 	@

--- a/src/bench.c
+++ b/src/bench.c
@@ -1079,28 +1079,26 @@ next:
 #endif
 	} while ((format = format->next) && !event_abort);
 
-	if (failed && total > 1 && !event_abort)
-		printf("%u out of %u tests have FAILED\n", failed, total);
-	else if (total > 1 && !event_abort)
-		if (john_main_process) {
-#ifndef BENCH_BUILD
-			if (options.flags & FLG_MASK_CHK)
-				printf("%u formats benchmarked.\n", total);
-			else
-#endif
-
 #ifdef HAVE_OPENCL
 /*
  * Allow OpenCL build's "--test" to run on no-OpenCL systems.
  * Print a message about no OpenCL at the end of the run.
  */
-				if (opencl_unavailable)
-					opencl_was_skipped = " (OpenCL formats skipped)";
+	if (opencl_unavailable)
+		opencl_was_skipped = " (OpenCL formats skipped)";
 #endif
 
-				printf("All %u formats passed self-tests!%s\n",
-				       total, opencl_was_skipped);
-		}
+	if (failed && total > 1 && !event_abort)
+		printf("%u out of %u tests have FAILED%s\n", failed, total, opencl_was_skipped);
+	else if (total > 1 && !event_abort && john_main_process) {
+#ifndef BENCH_BUILD
+		if (benchmark_time)
+			printf("%u formats benchmarked%s.\n", total, opencl_was_skipped);
+		else
+#endif
+			printf("All %u formats passed self-tests%s!\n", total, opencl_was_skipped);
+	}
+
 #ifndef BENCH_BUILD
 	if (options.flags & FLG_LOOPTEST_CHK) {
 		loop_total++;

--- a/src/tty.c
+++ b/src/tty.c
@@ -84,7 +84,10 @@ void tty_init(opt_flags stdin_mode)
  * Give up the keyboard if we're not the foreground process.  This can be
  * overridden with --force-tty option.
  */
-	if (!(options.flags & FLG_FORCE_TTY) && tcgetpgrp(fd) != getpid()) {
+#ifndef BENCH_BUILD
+	if (!(options.flags & FLG_FORCE_TTY))
+#endif
+	if (tcgetpgrp(fd) != getpid()) {
 		close(fd);
 		return;
 	}
@@ -151,8 +154,10 @@ void tty_done(void)
 	fd = tty_fd; tty_fd = -1;
 
 /* Do the usually-best-thing in the race condition sometimes caused by --force-tty */
+#ifndef BENCH_BUILD
 	if (options.flags & FLG_FORCE_TTY)
 		saved_ti.c_lflag |= (ICANON | ECHO);
+#endif
 
 	tcsetattr(fd, TCSANOW, &saved_ti);
 


### PR DESCRIPTION
Fix "passed self-tests" vs. "benchmarked" reporting
    
Basically there were artefacts from when OpenCL benchmarks with mask would imply that self-tests was skipped. Some other logic bugs fixed as well.

Closes #4536