### PR TITLE
zip2john: Only use 2-byte early-reject checks for version < 2.0

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -160,6 +160,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Addition of mosquitto2john.py for cracking of Eclipse Mosquitto passwd files.
   [blackfell; 2021]
 
+- Final fixes for zip2john selection of 1-byte or 2-byte early-reject checks,
+  after seeing several issues and digging into the specs.  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 
@@ -563,4 +566,3 @@ Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
   mostly part of our development process and not the release, although some
   CI-related files do exist in our released tree.
   [Claudio, magnum; 2015-2019]
-


### PR DESCRIPTION
Single-byte check for all other archives.  APPNOTE.TXT seems pretty clear about this, we shouldn't try to rely on any efh to indicate the matter.

Closes #4571, see also #4541 and #4300

Note that this fix not only disables 2-byte checks for some archives - it also *enables* them for others: Prior to this, any archive without any `efh` fields would get the single-byte check.