### PR TITLE
Fix --status for --fork with --node sessions; support any node ranges divisible by fork count

### DIFF
--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -1,5 +1,6 @@
 The following changes have been made between John 1.9.0 and 1.9.1-dev:
 
+* Let "--node" numbers range be any multiple of "--fork" process count.
 * Fixed "--status" to work right on sessions that use "--fork" with "--node".
 * Added two external modes: Filter_NoRepeats skips candidate passwords that
 contain the same character more than once, and Filter_Repeats is its inverse.

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -1,3 +1,8 @@
+The following changes have been made between John 1.9.0 and 1.9.1-dev:
+
+* Added two external modes: Filter_NoRepeats skips candidate passwords that
+contain the same character more than once, and Filter_Repeats is its inverse.
+
 The following changes have been made between John 1.8.0 and 1.9.0:
 
 * Increased the interleaving for bcrypt on x86-64 from 2x to 3x for a major

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -1,5 +1,6 @@
 The following changes have been made between John 1.9.0 and 1.9.1-dev:
 
+* Fixed "--status" to work right on sessions that use "--fork" with "--node".
 * Added two external modes: Filter_NoRepeats skips candidate passwords that
 contain the same character more than once, and Filter_Repeats is its inverse.
 

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -376,5 +376,3 @@ OpenBSD/PowerPC, OpenBSD/PA-RISC, OpenBSD/VAX, NetBSD/VAX, Solaris/SPARC64,
 Mac OS X (PowerPC and x86), SCO, BeOS.
 * Bug and portability fixes, and new bugs.
 * Bonus: "Strip" cracker included in the default john.conf (john.ini).
-
-$Owl$

--- a/doc/CONFIG
+++ b/doc/CONFIG
@@ -239,5 +239,3 @@ write to.  Names of files that do not exist will be silently ignored.
 	Defining an external mode.
 
 See EXTERNAL.
-
-$Owl$

--- a/doc/CONTACT
+++ b/doc/CONTACT
@@ -26,5 +26,3 @@ Please don't ask questions until you read the FAQ.
 Commercial support for John the Ripper is available from Openwall:
 
 	https://www.openwall.com/services/
-
-$Owl$

--- a/doc/CREDITS
+++ b/doc/CREDITS
@@ -72,5 +72,3 @@ Developer's Kit) that I used for the Win32 port:
 	http://www.delorie.com/djgpp/
 
 * Charles W Sandmann - for CWSDPMI, the DPMI server used with DJGPP.
-
-$Owl$

--- a/doc/EXAMPLES
+++ b/doc/EXAMPLES
@@ -403,5 +403,3 @@ You can find the actual implementation of such a cracking mode with lots
 of comments in the default configuration file supplied with John.
 Please refer to EXTERNAL for information on the programming language
 used.
-
-$Owl$

--- a/doc/EXTERNAL
+++ b/doc/EXTERNAL
@@ -221,5 +221,3 @@ new()/next()/next().... and know that the script restored itself properly.
 
 Following the above rules and functions, a external-hybrid script can do
 pretty much anything required to transform/morph/mangle words.
-
-$Owl$

--- a/doc/FAQ
+++ b/doc/FAQ
@@ -306,5 +306,3 @@ Although the meaning of some of the numbers that get into .rec files is
 trivial to explain, it is not possible to reasonably describe some
 others without going into great detail on John internals.  If you really
 need to know, read the source code.
-
-$Owl$

--- a/doc/LICENSE
+++ b/doc/LICENSE
@@ -57,5 +57,3 @@ Alexander Peslyak aka Solar Designer <solar at openwall.com>
 
 (There are additional copyright holders for "community enhanced" -jumbo
 versions of John the Ripper.)
-
-$Owl$

--- a/doc/MODES
+++ b/doc/MODES
@@ -199,5 +199,3 @@ in case of using a GPU-enabled format that supports it, mask mode will even be
 accelerated on GPU with a huge performance boost.  Having said that, there are
 things you can only do with rules, and other things that only regex can
 achieve, so mask mode is not always the best fit.
-
-$Owl$

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -402,8 +402,14 @@ with similar per-core performance, you could run an OpenMP-enabled build
 on both of them and use "--node=1/9" (without "--fork") on the first
 machine (8 threads in 1 process) and "--fork=8 --node=2-9/9" on the
 64-core machine (8 threads in 8 processes, for 64 threads total on this
-machine).  With the current implementation, the node numbers range
-assigned to each John invocation must match the "--fork" process count.
+machine).  The node numbers range assigned to each John invocation must
+be a multiple of the "--fork" process count.  You'd usually have the
+number of nodes in the range exactly match the "--fork" process count,
+but you can use other multiples to compensate for major differences in
+per-process performance between different machines.  For example, on a
+machine where each process is twice faster than on another, you'd
+reasonably allocate two virtual node numbers per each "--fork" process,
+e.g. with "--fork=8 --node=9-24/24".
 
 When running with "--fork", multiple ".rec" files are created, which are
 then read back by "--status" and "--restore" if you use those options.

--- a/doc/RULES
+++ b/doc/RULES
@@ -368,5 +368,3 @@ The preprocess rule [\x01-\xff] will be replaced with 255 characters
 
 Please refer to the default configuration file for John the Ripper for
 many example uses of the features described in here.
-
-$Owl$

--- a/src/options.c
+++ b/src/options.c
@@ -607,8 +607,11 @@ void opt_init(char *name, int argc, char **argv)
 		status_print();
 #if OS_FORK
 		if (options.fork) {
-			unsigned int i, node_max = options.node_max;
-			for (i = options.node_min + 1; i <= node_max; i++) {
+			unsigned int node_max = options.node_max;
+			unsigned int range = node_max - options.node_min + 1;
+			unsigned int npf = range / options.fork;
+			unsigned int i = options.node_min;
+			while ((i += npf) <= node_max) {
 				rec_name = rec_name_orig;
 				rec_name_completed = 0;
 				rec_restoring_now = 0;
@@ -844,6 +847,7 @@ void opt_init(char *name, int argc, char **argv)
 				options.node_max += mpi_p - 1;
 #endif
 		}
+		unsigned int range = options.node_max - options.node_min + 1;
 		if (n < 2)
 			msg = "valid syntax is MIN-MAX/TOTAL or N/TOTAL";
 		else if (!options.node_min)
@@ -855,9 +859,8 @@ void opt_init(char *name, int argc, char **argv)
 		else if (options.node_max > options.node_count)
 			msg = "node numbers can't exceed node count";
 #if OS_FORK
-		else if (options.fork &&
-		    options.node_max - options.node_min + 1 != options.fork)
-			msg = "range must be consistent with --fork number";
+		else if (options.fork && range % options.fork)
+			msg = "node range must be divisible by fork count";
 #endif
 #ifdef HAVE_MPI
 		if (mpi_p > 1 &&
@@ -866,10 +869,9 @@ void opt_init(char *name, int argc, char **argv)
 #endif
 		else if (!options.fork &&
 #ifdef HAVE_MPI
-		         mpi_p == 1 &&
+		    mpi_p == 1 &&
 #endif
-		    options.node_max - options.node_min + 1 ==
-		    options.node_count)
+		    range == options.node_count)
 			msg = "node numbers can't span the whole range";
 		if (msg) {
 			if (john_main_process)

--- a/src/options.c
+++ b/src/options.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of John the Ripper password cracker,
- * Copyright (c) 1996-2019 by Solar Designer
+ * Copyright (c) 1996-2021 by Solar Designer
  *
  * ...with changes in the jumbo patch, by JimF and magnum (and various others?)
  *
@@ -252,7 +252,7 @@ static struct opt_entry opt_list[] = {
 
 #define JOHN_BANNER	  \
 "John the Ripper " JTR_GIT_VERSION _MP_VERSION DEBUG_STRING ASAN_STRING UBSAN_STRING " [" JOHN_BLD "]\n" \
-"Copyright (c) 1996-2020 by " JOHN_COPYRIGHT "\n" \
+"Copyright (c) 1996-2021 by " JOHN_COPYRIGHT "\n" \
 "Homepage: https://www.openwall.com/john/\n" \
 "\n" \
 "Usage: %s [OPTIONS] [PASSWORD-FILES]\n\n"
@@ -607,8 +607,8 @@ void opt_init(char *name, int argc, char **argv)
 		status_print();
 #if OS_FORK
 		if (options.fork) {
-			unsigned int i;
-			for (i = 2; i <= options.fork; i++) {
+			unsigned int i, node_max = options.node_max;
+			for (i = options.node_min + 1; i <= node_max; i++) {
 				rec_name = rec_name_orig;
 				rec_name_completed = 0;
 				rec_restoring_now = 0;


### PR DESCRIPTION
This is a merge of these changes I had made and tested in core earlier today. In jumbo, I've only tested that these build (but didn't try building with MPI support). I haven't yet tested whether they actually work. I hope @sectroyer and others will help with testing.

Fixes #4589, closes #4584.