### PR TITLE
MPI: Let --node numbers range be any multiple of MPI process count

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -165,6 +165,8 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   issues and digging into the specs.  Note that a re-run of zip2john is needed
   for correct cracking. [magnum; 2021]
 
+- Allow any node range divisible by fork (or MPI) count.  [Solar, magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/john.c
+++ b/src/john.c
@@ -561,7 +561,7 @@ static void john_fork(void)
 				usleep(i * 100000);
 			}
 #endif
- 			if (rec_restoring_now) {
+			if (rec_restoring_now) {
 				unsigned int save_min = options.node_min;
 				unsigned int save_max = options.node_max;
 				unsigned int save_count = options.node_count;
@@ -618,23 +618,32 @@ static void john_fork(void)
 #if HAVE_MPI
 static void john_set_mpi(void)
 {
-	options.node_min += mpi_id;
-	options.node_max = options.node_min;
+	unsigned int range = options.node_max - options.node_min + 1;
+	unsigned int npf = range / mpi_p;
 
 	if (mpi_p > 1) {
 		if (!john_main_process) {
 			if (rec_restoring_now) {
-				unsigned int node_id = options.node_min;
+				unsigned int save_min = options.node_min;
+				unsigned int save_max = options.node_max;
+				unsigned int save_count = options.node_count;
+				unsigned int save_fork = options.fork;
+				options.node_min += mpi_id * npf;
+				options.node_max = options.node_min + npf - 1;
 				rec_done(-2);
 				rec_restore_args(1);
 				john_set_tristates();
-				if (node_id != options.node_min + mpi_id)
+				if (options.node_min != save_min ||
+				    options.node_max != save_max ||
+				    options.node_count != save_count ||
+				    options.fork != save_fork)
 					fprintf(stderr,
 					    "Inconsistent crash recovery file:"
 					    " %s\n", rec_name);
-				options.node_min = options.node_max = node_id;
 			}
 		}
+		options.node_min += mpi_id * npf;
+		options.node_max = options.node_min + npf - 1;
 	}
 	fflush(stdout);
 	fflush(stderr);

--- a/src/options.c
+++ b/src/options.c
@@ -863,9 +863,8 @@ void opt_init(char *name, int argc, char **argv)
 			msg = "node range must be divisible by fork count";
 #endif
 #ifdef HAVE_MPI
-		if (mpi_p > 1 &&
-		    options.node_max - options.node_min + 1 != mpi_p)
-			msg = "range must be consistent with MPI node count";
+		else if (mpi_p > 1 && range % mpi_p)
+			msg = "node range must be divisible by MPI node count";
 #endif
 		else if (!options.fork &&
 #ifdef HAVE_MPI


### PR DESCRIPTION
Implement the exact same changes recently made to --fork, but to the MPI code paths.

See 82d0825a8, #4592, closes #4594.