### PR TITLE
ARM: Revert our trust in __ARM_FEATURE_UNALIGNED in general

### DIFF
--- a/src/arm32le.h
+++ b/src/arm32le.h
@@ -27,7 +27,7 @@
 #define ARCH_INT_GT_32			0
 #endif
 
-#define ARCH_ALLOWS_UNALIGNED		__ARM_FEATURE_UNALIGNED
+#define ARCH_ALLOWS_UNALIGNED		0
 #define ARCH_INDEX(x)			((unsigned int)(unsigned char)(x))
 
 #define CPU_DETECT			0

--- a/src/arm64le.h
+++ b/src/arm64le.h
@@ -28,7 +28,7 @@
 #define ARCH_INT_GT_32			0
 #endif
 
-#define ARCH_ALLOWS_UNALIGNED		__ARM_FEATURE_UNALIGNED
+#define ARCH_ALLOWS_UNALIGNED		0
 #define ARCH_INDEX(x)			((unsigned int)(unsigned char)(x))
 
 #define CPU_DETECT			0

--- a/src/opencl_rar_fmt_plug.c
+++ b/src/opencl_rar_fmt_plug.c
@@ -40,7 +40,14 @@
  *
  */
 
-#ifdef HAVE_OPENCL
+#if HAVE_OPENCL
+
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+#include "arch.h"
+
+#if ARCH_ALLOWS_UNALIGNED || __ARM_FEATURE_UNALIGNED
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_ocl_rar;
@@ -54,11 +61,6 @@ john_register_one(&fmt_ocl_rar);
 #include <omp.h>
 #endif
 
-#if AC_BUILT
-#include "autoconfig.h"
-#endif
-
-#include "arch.h"
 #include "sha.h"
 #include "crc32.h"
 #include "misc.h"
@@ -433,4 +435,14 @@ struct fmt_main fmt_ocl_rar = {
 
 #endif /* plugin stanza */
 
+#else
+#if !defined(FMT_EXTERNS_H) && !defined(FMT_REGISTERS_H)
+#ifdef __GNUC__
+#warning ": target system requires aligned memory access, RAR OpenCL format disabled:"
+#elif _MSC_VER
+#pragma message(": target system requires aligned memory access, RAR OpenCL format disabled:")
+#endif
+#endif
+
+#endif /* ARCH_ALLOWS_UNALIGNED || __ARM_FEATURE_UNALIGNED */
 #endif /* HAVE_OPENCL */

--- a/src/rar_fmt_plug.c
+++ b/src/rar_fmt_plug.c
@@ -45,7 +45,7 @@
 #endif
 #include "arch.h"
 
-#if ARCH_ALLOWS_UNALIGNED
+#if ARCH_ALLOWS_UNALIGNED || __ARM_FEATURE_UNALIGNED
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_rar;
@@ -453,4 +453,4 @@ struct fmt_main fmt_rar = {
 #endif
 #endif
 
-#endif	/* ARCH_ALLOWS_UNALIGNED */
+#endif	/* ARCH_ALLOWS_UNALIGNED || __ARM_FEATURE_UNALIGNED */


### PR DESCRIPTION
...but do trust it in terms of building the RAR format.  While at it, have RAR-opencl also rely on the same terms, since the culprit is actually in the unrar code we've nicked from ClamAV.  Closes #4600