### PR TITLE
Deprecation: Use ElementTree.iter() instead of ElementTree.getiterator() when available

### DIFF
--- a/run/office2john.py
+++ b/run/office2john.py
@@ -2919,7 +2919,8 @@ def xml_metadata_parser(data, filename):
     tree = ElementTree()
     tree.parse(data)
 
-    for node in tree.getiterator('{http://schemas.microsoft.com/office/2006/keyEncryptor/password}encryptedKey'):
+    tree_iter = tree.iter if hasattr(ElementTree, 'iter') else tree.getiterator
+    for node in tree_iter('{http://schemas.microsoft.com/office/2006/keyEncryptor/password}encryptedKey'):
         spinCount = node.attrib.get("spinCount")
         assert(spinCount)
         saltSize = node.attrib.get("saltSize")


### PR DESCRIPTION
Hi!

`ElementTree.getiterator()` was deprecated in favor of `ElementTree.iter()` in Python 2.7 and Python 3.2, and it was removed in Python 3.9:
- https://docs.python.org/2.7/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator
- https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator

In order to ensure compatibility with old versions of Python, this patch tries to use `ElementTree.iter()` if it is available, but falls back to `ElementTree.getiterator()` if this is not the case.

Cheers,\
SnipFoo.