### PR TITLE
Single mode: Let --mkpc=N option reflect buffer allocations

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -105,7 +105,7 @@ static int process_key_stack_rules(char *key);
 /* Expose max_keys_per_crypt to the world (needed in recovery.c) */
 int crk_max_keys_per_crypt(void)
 {
-	return  crk_params->max_keys_per_crypt;
+	return options.force_maxkeys ? options.force_maxkeys : crk_params->max_keys_per_crypt;
 }
 
 static void crk_dummy_set_salt(void *salt)

--- a/src/single.c
+++ b/src/single.c
@@ -250,6 +250,11 @@ static void single_init(void)
 
 	length = options.eff_maxlength;
 	key_count = single_db->format->params.min_keys_per_crypt;
+
+	/* Do not allocate buffers we'll never use */
+	if (options.force_maxkeys && key_count > options.force_maxkeys)
+		key_count = options.force_maxkeys;
+
 	if (key_count < SINGLE_HASH_MIN)
 		key_count = SINGLE_HASH_MIN;
 /*


### PR DESCRIPTION
We always honored --mkpc for Single mode, but after some code evolution it would no longer reduce the buffer use.

Also a minor bug fix for salt resume, where we need to reflect --mkpc for optimal resume.