### PR TITLE
--stdout: Speedup for -v=1 (as in "do not actually output candidates")

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -1161,10 +1161,12 @@ static int process_key(char *key)
 	sig_timer_emu_tick();
 #endif
 
+	if (options.verbosity > 1 || event_status)
+		strnzcpy(crk_stdout_key, key, crk_params->plaintext_length + 1);
+
 	if (event_pending && crk_process_event())
 		return 1;
 
-	strnzcpy(crk_stdout_key, key, crk_params->plaintext_length + 1);
 	if (options.verbosity > 1)
 		puts(crk_stdout_key);
 


### PR DESCRIPTION
Don't bother updating crk_stdout_key unless we're about to use it. This speeds up stdout mode considerably for testing purposes and should be completely harmless in all other cases.

The rationale for the old `-verb=1` muting stdout candidate output (since many years) was that `/dev/null` is surprisingly slow on macOS. For some testing (like mode benchmarking, or eg. watching subsets mode go through its different stages using `-log-stderr`), this additional speedup (easily another 2x) is quite useful.