### PR TITLE
Fix misaligned pointer warnings

### DIFF
--- a/src/androidfde_fmt_plug.c
+++ b/src/androidfde_fmt_plug.c
@@ -62,8 +62,8 @@ john_register_one(&fmt_fde);
 #define BENCHMARK_LENGTH    0x107
 #define BINARY_SIZE         0
 #define BINARY_ALIGN        1
-#define SALT_ALIGN          8
 #define SALT_SIZE           sizeof(struct custom_salt)
+#define SALT_ALIGN          sizeof(void*)
 #ifdef SIMD_COEF_32
 #define MIN_KEYS_PER_CRYPT  SSE_GROUP_SZ_SHA1
 #define MAX_KEYS_PER_CRYPT  (SSE_GROUP_SZ_SHA1 * 4)
@@ -86,8 +86,8 @@ static int *cracked;
 static int max_cracked;
 
 static struct custom_salt {
-	int loaded;
 	unsigned char *cipherbuf;
+	int loaded;
 	int keysize;
 	int iterations; // NOTE, not used. Hard coded to 2000 for FDE from Android <= 4.3 (PBKDF2-SHA1)
 	int saltlen;
@@ -95,7 +95,6 @@ static struct custom_salt {
 	unsigned char salt[16];
 	unsigned char mkey[64];
 	unsigned char iv[16];
-
 } *cur_salt;
 
 static void init(struct fmt_main *self)

--- a/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
@@ -33,9 +33,9 @@ john_register_one(&fmt_opencl_pbkdf2_hmac_sha512);
 #define FORMAT_NAME              "GRUB2 / OS X 10.8+"
 #define ALGORITHM_NAME           "PBKDF2-SHA512 OpenCL"
 #define BINARY_ALIGN             8
-#define SALT_ALIGN               8
 #define PLAINTEXT_LENGTH         110
 #define SALT_SIZE                sizeof(salt_t)
+#define SALT_ALIGN               sizeof(uint64_t)
 #define KERNEL_NAME              "pbkdf2_sha512_kernel"
 #define SPLIT_KERNEL_NAME        "pbkdf2_sha512_loop"
 

--- a/src/opencl_sspr_fmt_plug.c
+++ b/src/opencl_sspr_fmt_plug.c
@@ -41,9 +41,6 @@ john_register_one(&fmt_opencl_sspr);
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        0x107
 #define PLAINTEXT_LENGTH        64
-#define BINARY_ALIGN            MEM_ALIGN_WORD
-#define SALT_SIZE               sizeof(struct custom_salt)
-#define SALT_ALIGN              4
 #define MIN_KEYS_PER_CRYPT      1
 #define MAX_KEYS_PER_CRYPT      1
 #define SALT_LENGTH             32

--- a/src/pbkdf2-hmac-sha512_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha512_fmt_plug.c
@@ -52,6 +52,8 @@ john_register_one(&fmt_pbkdf2_hmac_sha512);
 #endif
 
 #define SALT_SIZE               sizeof(struct custom_salt)
+#define SALT_ALIGN              sizeof(uint32_t)
+
 #ifdef SIMD_COEF_64
 #define MIN_KEYS_PER_CRYPT	SSE_GROUP_SZ_SHA512
 #define MAX_KEYS_PER_CRYPT	SSE_GROUP_SZ_SHA512
@@ -69,9 +71,9 @@ john_register_one(&fmt_pbkdf2_hmac_sha512);
 #define PLAINTEXT_LENGTH        125
 
 static struct custom_salt {
+	uint32_t rounds;
 	uint8_t length;
 	uint8_t salt[PBKDF2_64_MAX_SALT_SIZE];
-	uint32_t rounds;
 } *cur_salt;
 
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
@@ -204,9 +206,9 @@ struct fmt_main fmt_pbkdf2_hmac_sha512 = {
 		0,
 		PLAINTEXT_LENGTH,
 		PBKDF2_SHA512_BINARY_SIZE,
-		sizeof(uint32_t),
+		PBKDF2_SHA512_BINARY_ALIGN,
 		SALT_SIZE,
-		sizeof(ARCH_WORD),
+		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_SPLIT_UNIFIES_CASE,

--- a/src/pbkdf2_hmac_common.h
+++ b/src/pbkdf2_hmac_common.h
@@ -52,6 +52,7 @@
 #define PBKDF2_SHA256_MAX_CIPHERTEXT_LENGTH (PBKDF2_SHA256_TAG_LEN + 6 + 1 + (PBKDF2_32_MAX_SALT_SIZE*4+2)/3 + 1 + (PBKDF2_SHA256_MAX_BINARY_SIZE*4+2)/3)
 
 #define PBKDF2_SHA512_BINARY_SIZE           64
+#define PBKDF2_SHA512_BINARY_ALIGN          sizeof(uint64_t)
 #define PBKDF2_SHA512_FORMAT_TAG            "$pbkdf2-hmac-sha512$"
 #define PBKDF2_SHA512_TAG_LEN               (sizeof(PBKDF2_SHA512_FORMAT_TAG) - 1)
 /* other signatures handled within prepare */

--- a/src/pbkdf2_hmac_common_plug.c
+++ b/src/pbkdf2_hmac_common_plug.c
@@ -478,7 +478,7 @@ char *pbkdf2_hmac_sha1_prepare(char *fields[10], struct fmt_main *self)
 void *pbkdf2_hmac_sha1_binary(char *ciphertext) {
 	static union {
 		unsigned char c[PBKDF2_SHA1_MAX_BINARY_SIZE];
-		ARCH_WORD dummy;
+		uint32_t dummy;
 	} buf;
 	unsigned char *out = buf.c;
 	char *p;
@@ -655,7 +655,7 @@ char *pbkdf2_hmac_sha256_prepare(char *fields[10], struct fmt_main *self) {
 void *pbkdf2_hmac_sha256_binary(char *ciphertext) {
 	static union {
 		char c[PBKDF2_SHA256_BINARY_SIZE];
-		ARCH_WORD dummy;
+		uint32_t dummy;
 	} buf;
 	char *ret = buf.c;
 	char *c = ciphertext;

--- a/src/sspr_common.h
+++ b/src/sspr_common.h
@@ -10,8 +10,11 @@
 #define FORMAT_TAG              "$sspr$"
 #define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
 #define BINARY_SIZE             64
+#define BINARY_ALIGN            sizeof(uint32_t)
 #define BINARY_SIZE_MIN         16
 #define MAX_SALT_LEN            1500
+#define SALT_SIZE               sizeof(struct custom_salt)
+#define SALT_ALIGN              sizeof(uint32_t)
 
 struct custom_salt {
 	uint32_t iterations;

--- a/src/sspr_fmt_plug.c
+++ b/src/sspr_fmt_plug.c
@@ -40,9 +40,6 @@ john_register_one(&fmt_sspr);
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        0x107
 #define PLAINTEXT_LENGTH        125
-#define BINARY_ALIGN            sizeof(uint32_t)
-#define SALT_SIZE               sizeof(struct custom_salt)
-#define SALT_ALIGN              sizeof(uint32_t)
 #define MIN_KEYS_PER_CRYPT      1
 #define MAX_KEYS_PER_CRYPT      4
 


### PR DESCRIPTION
Both had SALT_ALIGN fixed to 8 where it should be sizeof(pointer). I found no issues for them so fixed them rather than create issues.