### PR TITLE
Fixed shebangs and Python 3 compatibility

### DIFF
--- a/run/DPAPImk2john.py
+++ b/run/DPAPImk2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 # Modified (for JtR) by Dhiru Kholia in December, 2014.

--- a/run/aix2john.py
+++ b/run/aix2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import binascii
 import sys
@@ -62,17 +62,16 @@ if __name__ == "__main__":
     						help='Use this option if "lpa_options '
     								'= std_hash=true" is activated'
     						)
-    
+
     parser.add_argument('-f', dest="filename",
     						default=False,
     						help='Specify the AIX shadow file filename to read (usually /etc/security/passwd)'
     						)
-    
+
     args = parser.parse_args()
-    
+
     if args.filename:
         process_file(args.filename, args.is_standard)
-    else:   
+    else:
         print "Please specify a filename (-f)"
         sys.exit(-1)
-

--- a/run/aix2john.py
+++ b/run/aix2john.py
@@ -1,18 +1,30 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
+# This script extracts hashes from AIX /etc/security/passwd
+# cat /etc/security/passwd
+# root:
+#         password = mrXXXXXXXXXX
+#         lastupdate = 1343960660
+#         flags =
+#
+# admin:
+#         password = oiXXXXXXXXXX
+#         lastupdate = 1339748349
+#         flags =
+# ...
+
+# Note: Some of this functionality is also covered by the unshadow program.
+
+
+import argparse
 import binascii
 import sys
 import re
 
-try:
-	 import argparse
-except ImportError:
-    sys.stderr.write("Stop living in the past. Upgrade your python!\n")
-
 
 def process_file(filename, is_standard):
     try:
-        fd = open(filename, "rb")
+        fd = open(filename, "r")
     except IOError:
         e = sys.exc_info()[1]
         sys.stderr.write("%s\n" % str(e))
@@ -51,16 +63,14 @@ def process_file(filename, is_standard):
 if __name__ == "__main__":
 
     if len(sys.argv) < 2:
-        sys.stderr.write("Usage: %s [-s] -f <AIX passwd file "
-            "(/etc/security/passwd)>\n" % sys.argv[0])
+        sys.stderr.write("Usage: %s [-s] -f <AIX passwd file (/etc/security/passwd)>\n" % sys.argv[0])
         sys.exit(-1)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-s', action="store_true",
     						default=False,
     						dest="is_standard",
-    						help='Use this option if "lpa_options '
-    								'= std_hash=true" is activated'
+    						help='Use this option if "lpa_options = std_hash=true" is activated'
     						)
 
     parser.add_argument('-f', dest="filename",
@@ -73,5 +83,5 @@ if __name__ == "__main__":
     if args.filename:
         process_file(args.filename, args.is_standard)
     else:
-        print "Please specify a filename (-f)"
+        print("Please specify a filename (-f)")
         sys.exit(-1)

--- a/run/androidfde2john.py
+++ b/run/androidfde2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 androidfde2john.py, program to "convert" Android FDE images / disks into JtR

--- a/run/axcrypt2john.py
+++ b/run/axcrypt2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # AxCrypt 1.x and 2.x encrypted file parser for JtR.
 #

--- a/run/ibmiscanner2john.py
+++ b/run/ibmiscanner2john.py
@@ -7,6 +7,12 @@
 # Output is sent to stdout. Redirect stdout to create a file for JtR.
 # See hackthelegacy.org for ibmiscanner tooling
 
+# Example input hash with username=heidi and password=diamonds
+# heidi:2B22E1F044E51AB1A645FC21A42019FEDD8B6950
+# Output:
+# heidi:$as400ssha1$2B22E1F044E51AB1A645FC21A42019FEDD8B6950$heidi
+
+
 import sys
 import os
 
@@ -20,10 +26,9 @@ def process_file(filename):
             try:
                 data = line.split(':')
                 out = data[0] + ":$as400ssha1$" + data[1] + "$" + data[0]
-                print out.encode('utf-8')
+                print(out)
             except:
                 sys.stderr.write("Error: parsing of line '%s' failed - skipping\n" % line)
-                pass
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:

--- a/run/keyring2john.py
+++ b/run/keyring2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 keyring2john.py -> convert Gnome Keyring files to john format.
@@ -27,52 +27,60 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+
+import argparse
+import binascii
+
+
 class GnomeKeyring_Parser():
     offset = 0
     keyring = ''
     KEYRING_FILE = ''
-    def __init__(self,KEYRING_FILE):
-        KEYRING_FILE_HEADER="GnomeKeyring\n\r\0\n"
+
+    def __init__(self, KEYRING_FILE):
+        KEYRING_FILE_HEADER = b"GnomeKeyring\n\r\0\n"
         self.KEYRING_FILE = KEYRING_FILE
-        self.keyring = open(KEYRING_FILE,'r').read()
+        self.keyring = open(KEYRING_FILE, 'rb').read()
         if self.keyring.find(KEYRING_FILE_HEADER) != 0:
             raise Exception ('Un-supported GNOME Keyring file!')
-    def read_keyring(self,length):
+
+    def hexstr(self, bytestr):
+        return binascii.hexlify(bytestr).decode('ascii')
+
+    def read_keyring(self, length):
         value = self.keyring[:length]
         self.keyring = self.keyring[length:]
         self.offset += length
         return value
+
     def parse_keyring(self):
         self.read_keyring(16) # Keyring header
         version = self.read_keyring(2) # version
         crypto = self.read_keyring(1) # crypto
         hash_t = self.read_keyring(1) # hash_t
         name_length = self.read_keyring(4) # name_length
-        name_length = int(name_length.encode('hex'),16)
+        name_length = int(self.hexstr(name_length), 16)
         name = self.read_keyring(name_length)
         ctime = self.read_keyring(8)
         mtime = self.read_keyring(8)
         flags = self.read_keyring(4)
         lock_timeout = self.read_keyring(4)
         iterations = self.read_keyring(4)
-        iterations = int(iterations.encode('hex'),16)
+        iterations = int(self.hexstr(iterations), 16)
         salt = self.read_keyring(8)
-        salt = salt.encode('hex')
+        salt = self.hexstr(salt)
         reserved = self.read_keyring(16)
         num_items = self.read_keyring(8)
-        num_items = int(num_items.encode('hex'),16)
+        num_items = int(self.hexstr(num_items), 16)
         hash_value = self.read_keyring(16)
-        hash_value = hash_value.encode('hex')
-        crypto_size = len(hash_value)/2
-        return self.KEYRING_FILE + ':$keyring$' + salt +'*'+str(iterations)+'*'+str(crypto_size)+'*0*'+hash_value
-
+        hash_value = self.hexstr(hash_value)
+        crypto_size = len(hash_value)//2
+        return self.KEYRING_FILE + ':$keyring$' + salt + '*' + str(iterations) + '*' + str(crypto_size) + '*0*'+ hash_value
 
 
 if __name__ == "__main__":
-    import argparse
     parser = argparse.ArgumentParser(description='keyring2john.py -> convert Gnome Keyring files to john format.')
     parser.add_argument('KEYRING_FILE', help='Input Gnome Keyring file')
     args=parser.parse_args()
     Parser = GnomeKeyring_Parser(args.KEYRING_FILE)
-    print Parser.parse_keyring()
-
+    print(Parser.parse_keyring())

--- a/run/netscreen.py
+++ b/run/netscreen.py
@@ -103,10 +103,10 @@ if __name__ == '__main__':
              if re.search(':',line):
                data=data.split(':',1) # line contains :
              else:
-                 print ("\n\n\n")
-                 print ("Error in input file.")
-                 print ("The input file must have either a \",\" or \":\" separator on each line.")
-                 print ("Also it should not contain any blank lines. Please correct the input file.")
+                 print("\n\n\n")
+                 print("Error in input file.")
+                 print("The input file must have either a \",\" or \":\" separator on each line.")
+                 print("Also it should not contain any blank lines. Please correct the input file.")
                  break
           username = data[0]
           password = data[1]

--- a/run/ps_token2john.py
+++ b/run/ps_token2john.py
@@ -1,20 +1,25 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
-import base64
-import hashlib
 import argparse
-import zlib
+import base64
+import binascii
+import hashlib
 import sys
+import zlib
 
-# Use "generate.py from https://erpscan.com/wp-content/uploads/tools/ERPScan-tockenchpoken.zip
+# Use "generate.py from https://erpscan.io/wp-content/uploads/tools/ERPScan-tockenchpoken.zip
 # to generate sample PS_TOKEN cookies.
 
-print "Based on tokenchpoken v0.5 beta's parse.py file"
-print 'Oracle PS_TOKEN cracker. Token parser'
-print
-print 'Alexey Tyurin - a.tyurin at erpscan.com'
-print 'ERPScan Research Group - http://www.erpscan.com'
-print
+print("""Based on tokenchpoken v0.5 beta's parse.py file
+Oracle PS_TOKEN cracker. Token parser
+
+Alexey Tyurin - a.tyurin at erpscan.io
+ERPScan Research Group - https://www.erpscan.io
+""")
+
+def hexstr(bytestr):
+    return binascii.hexlify(bytestr).decode('ascii')
+
 parser = argparse.ArgumentParser()
 parser.add_argument('-c', action='store', dest='cookie', required=True,
                     help='Set a victim\'s PS_TOKEN cookie for parsing')
@@ -24,7 +29,7 @@ args = parser.parse_args()
 input = args.cookie
 
 full_str = base64.b64decode(input)
-sha_mac = full_str[44:64].encode('hex')
+sha_mac = hexstr(full_str[44:64])
 inflate_data = full_str[76:]
 data = zlib.decompress(inflate_data)
 
@@ -32,13 +37,14 @@ data = zlib.decompress(inflate_data)
 data_hash = hashlib.sha1(data).hexdigest()
 
 user_length = data[20]
+if isinstance(user_length, int):
+    user_length = user_length.to_bytes(1, sys.byteorder)
 loc = 21
-user = data[loc:loc + int(user_length.encode('hex'), 16)].replace("\x00", "")
+user = data[loc:loc + int(hexstr(user_length), 16)].replace(b"\x00", b"").decode('utf-8')
 
 # python generate.py -e 0 -u PS -l ENG -p "" -n PSFT_HR -d 2015-07-01-08.06.46
 if data_hash == sha_mac:
-    print "%s: there is no password for the attacking node!" % user
+    print("%s: there is no password for the attacking node!" % user)
 else:
     # print hash
-    sys.stdout.write("%s:$dynamic_1600$%s$HEX$%s\n" % (user, sha_mac,
-                                                       data.encode("hex")))
+    sys.stdout.write("%s:$dynamic_1600$%s$HEX$%s\n" % (user, sha_mac, hexstr(data)))

--- a/run/zed2john.py
+++ b/run/zed2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # v0.3 now uses the login names
 # v0.2 comments added, find PBA vectors for every users
 


### PR DESCRIPTION
As requested in #4638 I searched for python2-only scripts and changed their shebangs accordingly.

For `ibmiscanner2john.py`, `keyring2john.py` and `ps_token2john.py` it was possible to generate sample data and subsequently made them compatible with both, Python 2 and Python 3. :smiley: 

(I'm not stopping to complain that having compatibility with both versions is much more complicated than Python 3 only. And it doesn't make the code prettier... :wink:  Eventually, Python 2 support should stop to lower the maintenance overhead.)