### PR TITLE
LM & NT formats: Add a sanity check for pwdump format

### DIFF
--- a/src/LM_fmt.c
+++ b/src/LM_fmt.c
@@ -71,7 +71,7 @@ static void init(struct fmt_main *self)
 
 static char *prepare(char *fields[10], struct fmt_main *self)
 {
-	if (fields[2] && strlen(fields[2]) == 32)
+	if (fields[1][0] != '$' && fields[2] && strlen(fields[2]) == 32)
 		return fields[2];
 	return fields[1];
 }

--- a/src/nt2_fmt_plug.c
+++ b/src/nt2_fmt_plug.c
@@ -265,7 +265,7 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 {
 	static char out[33 + TAG_LENGTH + 1];
 
-	if (!valid(split_fields[1], self)) {
+	if (!valid(split_fields[1], self) && split_fields[1][0] != '$') {
 		if (split_fields[3] && strlen(split_fields[3]) == 32) {
 			sprintf(out, "%s%s", FORMAT_TAG, split_fields[3]);
 			if (valid(out, self))

--- a/src/opencl_lm_fmt_plug.c
+++ b/src/opencl_lm_fmt_plug.c
@@ -65,7 +65,7 @@ static void init(struct fmt_main *pFmt)
 
 static char *prepare(char *fields[10], struct fmt_main *self)
 {
-	if (fields[2] && strlen(fields[2]) == 32)
+	if (fields[1][0] != '$' && fields[2] && strlen(fields[2]) == 32)
 		return fields[2];
 	return fields[1];
 }

--- a/src/opencl_nt_fmt_plug.c
+++ b/src/opencl_nt_fmt_plug.c
@@ -392,7 +392,7 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 {
 	static char out[33+FORMAT_TAG_LEN+1];
 
-	if (!valid(split_fields[1], self)) {
+	if (!valid(split_fields[1], self) && split_fields[1][0] != '$') {
 		if (split_fields[3] && strlen(split_fields[3]) == 32) {
 			sprintf(out, "%s%s", FORMAT_TAG, split_fields[3]);
 			if (valid(out,self))


### PR DESCRIPTION
If field[1][0] is '$', don't bother trying to parse as pwdump format because false positives from other hash types was seen.

Fixes #4647.