### PR TITLE
Support building without OpenSSL

### DIFF
--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -14,23 +14,32 @@ Jumbo/autoconf-specific README-DISTROS.)
 You may have obtained the source code or a "binary" (pre-compiled)
 distribution of John the Ripper.  On Unix-like systems, it is typical
 to get the source code and compile it into "binary" executables right
-on the system you intend to run John on.  On DOS and Windows, however,
-it is typical to get a binary distribution which is ready for use.
+on the system you intend to run John on.  On Windows, however, it is
+typical to get a binary distribution which is ready for use.
 
 The following instructions apply to the source code distribution of
 John only.  If you have a binary distribution, then there's nothing
 for you to compile and you can start using John right away.
 
+Also, the instructions here are mostly generic (not very OS specific).
+Please refer to INSTALL-FEDORA, INSTALL-UBUNTU, or INSTALL-WINDOWS for
+instructions specific to those systems.
 
-	Requirements
 
-The Jumbo versions requires OpenSSL 0.9.7 or later. To get all functionality
-you need 1.0.1. For building, not only the run-time libs are needed but also
-"devel" stuff like header files. This is often a separate package, so, e.g.,
-for Ubuntu you need "libssl-dev" as well as "libssl".
+	Requirements.
 
-Some helper tools are written in Python. A couple helper tools (vncpcap2john
-and SIPdump) need libpcap. A couple of formats need extra libraries in order
+Much functionality of JtR jumbo requires OpenSSL.  To get all of the related
+functionality, you need OpenSSL 1.0.1 or later.  With slightly older OpenSSL,
+you'll receive partial functionality.  You can also build without OpenSSL at
+all by passing the "--without-openssl" option to "./configure" (see below),
+but the functionality of such build will be greatly reduced.
+
+For building with OpenSSL, not only the runtime libraries are needed but also
+"development" stuff like header files.  This is often a separate package, so,
+e.g., for Ubuntu you need "libssl-dev" as well as "libssl".
+
+Some helper tools are written in Python.  A couple helper tools (vncpcap2john
+and SIPdump) need libpcap.  A couple of formats need extra libraries in order
 to get included:
 
 	mozilla		libnss
@@ -39,6 +48,9 @@ to get included:
 
 Again, you also need e.g. libnss-dev, libkrb5-dev and libgmp-dev in order to
 build.
+
+Some formats also need libz and libbz2 (and their "development" components) for
+full functionality.
 
 
 	Compiling the sources on a Unix-like system.
@@ -116,7 +128,7 @@ targets other than "generic" and since they typically use gcc, they are
 usually not affected by this potential problem.
 
 
-	OMP fallback build
+	OMP fallback build.
 
 Even a non-distro "native" build can gain from having OMP fallback. This
 means you will have a "john" binary that has OpenMP support, but that it
@@ -132,7 +144,7 @@ too. Here's how to do it for your "home build":
 Then you just run "./john" (from run directory) as usual.
 
 
-	Optimal interleaving factors (intrinsics builds)
+	Optimal interleaving factors (intrinsics builds).
 
 There is a script "testparas.pl" in the src directory, that can be used
 to test for optimal performance. Run it on an idle system. It will finish
@@ -140,7 +152,7 @@ with printing a full "./configure" command line to use. For most people,
 it's actually overkill. Spend the time learning tricks instead!
 
 
-	Optimal build on OS X
+	Optimal build on OS X.
 
 Using OS X, you can install Xcode (free in App Store) and then its "command
 line tools" and after that a normal build should work fine.  However, using

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -174,6 +174,15 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Add options --subsets-prefer-short and --subsets-prefer-small to Subsets
   mode, affecting candidate order.  [magnum; 2021]
 
+- Support "./configure --without-openssl" on all platforms, which excludes much
+  functionality, but allows the build to complete.  (Previously, this was only
+  supported on macOS and required use of Apple's CommonCrypto.)  [Solar; 2021]
+
+- Repair "make -f Makefile.legacy linux-mic" (easy cross-compilation for first
+  generation Xeon Phi) and make it not depend on zlib by default.  The OpenSSL
+  and GMP dependencies are now also easy to exclude by commenting out lines in
+  Makefile.legacy, for all targets.  [Solar; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/README-MIC
+++ b/doc/README-MIC
@@ -10,7 +10,7 @@ environments for MIC can be found on Intel's website.
 Library Denpendencies:
 -----------------------
 
-JtR requires some libraries that are not available on MIC, which means you'll 
+JtR can use some libraries that are not available on MIC, which means you'll 
 need to build them for MIC by yourself.
 These libraries are:
     Zlib (libz)
@@ -19,7 +19,7 @@ These libraries are:
 
 They can be downloaded from their websites. But building them requires some 
 effort, and only the mentioned versions are guaranteed to work.  
-Assuming those libraries are to be install under path $MIC and the path to
+Assuming those libraries are to be installed under path $MIC and the path to
 JtR is $JOHN, then follow the steps below.
 
 Build Zlib (version 1.2.8):
@@ -45,6 +45,12 @@ $ cd libressl-2.1.6
 $ ./configure CC="icc -mmic" --host=k1om-linux --prefix=$MIC
 $ make && make install
 
+These library dependencies are optional, but much functionality will be
+excluded if they are not satisfied.  To build without Zlib and GMP, you don't
+need to do anything special - the "./configure" script for JtR will detect
+their absence and skip their usage.  To build without OpenSSL/LibreSSL, use
+"./configure --without-openssl".
+
 
 --------------
 Building JtR:
@@ -68,6 +74,13 @@ following:
     libsvml
 They can be found under /opt/intel/lib/mic or some other directory you
 specified when installing Intel compiler.
+
+Alternatively to the above, you can build with:
+
+$ make -f Makefile.legacy linux-mic
+
+By default, this "linux-mic" target uses GMP and OpenSSL (but not Zlib).
+To exclude those, comment out the corresponding lines in Makefile.legacy.
 
 
 ---------

--- a/src/7z_common_plug.c
+++ b/src/7z_common_plug.c
@@ -9,7 +9,7 @@
 #include <string.h>
 
 #include "arch.h"
-#if !AC_BUILT
+#if !AC_BUILT && !__MIC__
 #define HAVE_LIBZ 1 /* legacy build has -lz in LDFLAGS */
 #endif
 #if HAVE_LIBZ

--- a/src/7z_fmt_plug.c
+++ b/src/7z_fmt_plug.c
@@ -19,7 +19,7 @@ john_register_one(&fmt_sevenzip);
 #include <string.h>
 
 #include "arch.h"
-#if !AC_BUILT
+#if !AC_BUILT && !__MIC__
 #define HAVE_LIBZ 1 /* legacy build has -lz in LDFLAGS */
 #endif
 #if HAVE_LIBZ

--- a/src/FG2_fmt_plug.c
+++ b/src/FG2_fmt_plug.c
@@ -43,7 +43,7 @@ john_register_one(&fmt_FG2);
 #include "common.h"
 #include "formats.h"
 #include "misc.h"
-#include "sha.h"
+#include "sha2.h"
 #include "base64_convert.h"
 
 #define FORMAT_LABEL            "Fortigate256"

--- a/src/KRB4_fmt_plug.c
+++ b/src/KRB4_fmt_plug.c
@@ -32,6 +32,12 @@
   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_KRB4;
 #elif FMT_REGISTERS_H
@@ -309,3 +315,4 @@ struct fmt_main fmt_KRB4 = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/KRB4_std_plug.c
+++ b/src/KRB4_std_plug.c
@@ -17,6 +17,8 @@
 #include "autoconfig.h"
 #endif
 
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #ifdef KRB4_USE_SYSTEM_CRYPT
 #define _XOPEN_SOURCE 4 /* for crypt(3) */
 #define _XOPEN_SOURCE_EXTENDED
@@ -135,3 +137,5 @@ afs_string_to_key(char *str, char *cell, DES_cblock *key)
     else
         afs_cmu_StringToKey (str, realm, key);
 }
+
+#endif /* OpenSSL */

--- a/src/KRB5_fmt_plug.c
+++ b/src/KRB5_fmt_plug.c
@@ -15,6 +15,12 @@
  *  Copyright (C) 1990 by the Massachusetts Institute of Technology.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_KRB5;
 #elif FMT_REGISTERS_H
@@ -356,3 +362,4 @@ struct fmt_main fmt_KRB5 = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/KRB5_std_plug.c
+++ b/src/KRB5_std_plug.c
@@ -20,6 +20,11 @@
  *
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 
 #include <stdlib.h>
 #include <string.h>
@@ -276,3 +281,5 @@ void str2key(char *user, char *realm, char *passwd, krb5_key *krb5key) {
     MEM_FREE(text);
 }
 // }}}
+
+#endif /* OpenSSL */

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -89,7 +89,7 @@ JOHN_OBJS = \
 	rc4.o \
 	hmacmd5.o \
 	base64_convert.o \
-	md4.o sha2.o \
+	md4.o sha1.o sha2.o \
 	dynamic_fmt.o dynamic_parser.o dynamic_preloads.o dynamic_utils.o dynamic_big_crypt.o \
 	dynamic_compiler.o dynamic_compiler_lib.o \
 	ripemd.o tiger.o \
@@ -364,7 +364,7 @@ KeccakHash.o:	KeccakHash.c KeccakHash.h KeccakSponge.h KeccakF-1600-interface.h 
 
 KeccakSponge.o:	KeccakSponge.c KeccakSponge.h KeccakF-1600-interface.h os.h os-autoconf.h autoconfig.h jumbo.h arch.h memory.h
 
-keepass2john.o:	keepass2john.c autoconfig.h arch.h missing_getopt.h jumbo.h params.h memory.h os.h os-autoconf.h base64.h
+keepass2john.o:	keepass2john.c autoconfig.h arch.h missing_getopt.h jumbo.h params.h memory.h os.h os-autoconf.h base64.h sha2.h
 
 bitlocker2john.o:	bitlocker2john.c autoconfig.h arch.h missing_getopt.h jumbo.h params.h memory.h os.h os-autoconf.h
 
@@ -460,6 +460,8 @@ sboxes-s.o:	sboxes-s.c
 scrypt_fmt.o:	scrypt_fmt.c yescrypt/yescrypt.h arch.h misc.h jumbo.h autoconfig.h common.h memory.h formats.h params.h base64_convert.h os.h os-autoconf.h
 
 showformats.o:	showformats.c showformats.h loader.h options.h config.h dynamic.h
+
+sha1.o: sha1.c sph_sha1.h
 
 sha2.o:	sha2.c arch.h sha2.h aligned.h openssl_local_overrides.h md4.h md5.h jtr_sha2.h johnswap.h common.h memory.h stdbool.h params.h os.h os-autoconf.h autoconfig.h jumbo.h
 
@@ -693,8 +695,8 @@ poly1305-donna/poly1305-donna.a:
 ../run/uaf2john@EXE_EXT@: uaf2john.o uaf_encode.o
 	$(LD) $(LDFLAGS) @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ uaf2john.o uaf_encode.o @OPENMP_CFLAGS@ -o $@
 
-../run/keepass2john@EXE_EXT@: keepass2john.c jumbo.c base64_convert.c misc.c common.c memory.c
-	$(CC) -DAC_BUILT -Wall -O2 @CPPFLAGS@ @CFLAGS@ @OPENSSL_CFLAGS@ @CFLAGS_EXTRA@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ keepass2john.c jumbo.c base64_convert.c -D_JOHN_MISC_NO_LOG misc.c common.c memory.c  $(LDFLAGS) @OPENMP_CFLAGS@ @OPENSSL_LIBS@ -o $@
+../run/keepass2john@EXE_EXT@: keepass2john.c jumbo.c base64_convert.c misc.c common.c memory.c sha2.o
+	$(CC) -DAC_BUILT -Wall -O2 @CPPFLAGS@ @CFLAGS@ @OPENSSL_CFLAGS@ @CFLAGS_EXTRA@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ keepass2john.c jumbo.c base64_convert.c -D_JOHN_MISC_NO_LOG misc.c common.c memory.c sha2.o $(LDFLAGS) @OPENMP_CFLAGS@ @OPENSSL_LIBS@ -o $@
 
 ../run/dmg2john@EXE_EXT@: dmg2john.o jumbo.o
 	$(LD) $(LDFLAGS) @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ dmg2john.o jumbo.o @OPENMP_CFLAGS@ -o $@
@@ -716,8 +718,8 @@ poly1305-donna/poly1305-donna.a:
 	$(LD) $(LDFLAGS) wpapcap2john.o jumbo.o @OPENMP_CFLAGS@ -o $@
 
 # Note, this one is NOT build by default. To get it, do a make ../run/dynacomptest (or ../run/dynacomptest.exe for cygwin/mingw builds)
-../run/dynacomptest@EXE_EXT@: dynamic_compiler.c dynamic_compiler_lib.c dynamic_utils.c misc.c unicode.c base64_convert.o base64.o common.o crc32.o KeccakDuplex.o KeccakF-1600-opt64.o KeccakHash.o KeccakSponge.o gost.o jumbo.o memory.o ripemd.o tiger.o haval.o skein.o md2.o panama.o whirlpool.o sha2.o
-	$(CC) -DAC_BUILT -Wall -O2 @CPPFLAGS@ @CFLAGS@  @CFLAGS_EXTRA@ @OPENSSL_CFLAGS@ @OPENMP_CFLAGS@ -DWITH_MAIN -D_JOHN_MISC_NO_LOG -DUNICODE_NO_OPTIONS dynamic_compiler.c dynamic_compiler_lib.c dynamic_utils.c misc.c unicode.c base64_convert.o base64.o common.o crc32.o KeccakDuplex.o KeccakF-1600-opt64.o KeccakHash.o KeccakSponge.o gost.o jumbo.o memory.o ripemd.o tiger.o haval.o skein.o md2.o panama.o whirlpool.o sha2.o $(LDFLAGS)  @OPENSSL_LIBS@ @COMMONCRYPTO_LIBS@  -o $@
+../run/dynacomptest@EXE_EXT@: dynamic_compiler.c dynamic_compiler_lib.c dynamic_utils.c misc.c unicode.c base64_convert.o base64.o common.o crc32.o KeccakDuplex.o KeccakF-1600-opt64.o KeccakHash.o KeccakSponge.o gost.o jumbo.o memory.o ripemd.o tiger.o haval.o skein.o md2.o panama.o whirlpool.o sha1.o sha2.o
+	$(CC) -DAC_BUILT -Wall -O2 @CPPFLAGS@ @CFLAGS@  @CFLAGS_EXTRA@ @OPENSSL_CFLAGS@ @OPENMP_CFLAGS@ -DWITH_MAIN -D_JOHN_MISC_NO_LOG -DUNICODE_NO_OPTIONS dynamic_compiler.c dynamic_compiler_lib.c dynamic_utils.c misc.c unicode.c base64_convert.o base64.o common.o crc32.o KeccakDuplex.o KeccakF-1600-opt64.o KeccakHash.o KeccakSponge.o gost.o jumbo.o memory.o ripemd.o tiger.o haval.o skein.o md2.o panama.o whirlpool.o sha1.o sha2.o $(LDFLAGS)  @OPENSSL_LIBS@ @COMMONCRYPTO_LIBS@  -o $@
 
 ../run/cprepair@EXE_EXT@: cprepair.c autoconfig.h unicode.c unicode.h options.h misc.h misc.c
 	$(CC) -DAC_BUILT -Wall -O3 @CFLAGS_EXTRA@ @OPENSSL_CFLAGS@ -DNOT_JOHN -D_JOHN_MISC_NO_LOG $(CPPFLAGS) cprepair.c unicode.c misc.c memory.c -o $@

--- a/src/Makefile.legacy
+++ b/src/Makefile.legacy
@@ -63,6 +63,7 @@ OMPFLAGS =
 # paths does not exist, because find will return false even though finding a
 # file. If these hacks do not work, comment them out and see next sections.
 ifndef RELEASE_BLD
+# Comment this out when cross-compiling, such as with the linux-mic target
 HAVE_LIBGMP = `find 2>&1 /usr/include /usr/local/include -name "gmp.h" | grep -q "gmp.h" && echo -DHAVE_LIBGMP`
 GMP_LDFLAGS = `find 2>&1 /usr/include /usr/local/include -name "gmp.h" | grep -q "gmp.h" && echo -lgmp`
 REXGEN_FLAGS = `find 2>&1 /usr/include/librexgen/c /usr/local/include/librexgen/c -name "librexgen.h" | grep -q "librexgen.h" && echo -DHAVE_LIBREXGEN=1`
@@ -74,6 +75,10 @@ endif
 # in case the auto-detection does not work.
 #HAVE_LIBGMP = -DHAVE_LIBGMP
 #GMP_LDFLAGS = -lgmp
+
+# Comment these out to build without OpenSSL
+CFLAGS_OPENSSL = -DHAVE_LIBSSL -DHAVE_LIBCRYPTO
+LDFLAGS_OPENSSL = -L/usr/local/ssl/lib -lssl -lcrypto
 
 ifdef NVIDIA_CUDA
 OCLROOT = $(NVIDIA_CUDA)
@@ -89,15 +94,16 @@ AMDAPP = -DAMDAPPSDK
 OCLROOT = $(ATISTREAMSDKROOT)
 endif
 
-CFLAGS = -c -Wall -O2 -fomit-frame-pointer -I/usr/local/include -DHAVE_LIBSSL $(REXGEN_FLAGS) $(HAVE_LIBGMP) $(OMPFLAGS) $(AMDAPP) $(JOHN_CFLAGS) $(RELEASE_BLD)
+CFLAGS = -c -Wall -O2 -fomit-frame-pointer -I/usr/local/include $(CFLAGS_OPENSSL) $(REXGEN_FLAGS) $(HAVE_LIBGMP) $(OMPFLAGS) $(AMDAPP) $(JOHN_CFLAGS) $(RELEASE_BLD)
 # -DHAVE_SKEY
 # CFLAGS for use on the main john.c file only
 CFLAGS_MAIN = $(CFLAGS)
 ASFLAGS = -c $(OMPFLAGS) $(JOHN_ASFLAGS)
-LDFLAGS = -s -L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lrt \
+LDFLAGS = -s -L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz -lrt \
 	$(OMPFLAGS) $(GMP_LDFLAGS) $(JOHN_LDFLAGS) $(REXGEN_LDFLAGS)
 # -lskey
-LDFLAGS_SOLARIS = -lrt -lnsl -lsocket -lm -lz -lcrypto -lssl
+LDFLAGS_MIC = -s -L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lrt $(OMPFLAGS) $(JOHN_LDFLAGS)
+LDFLAGS_SOLARIS = -lrt -lnsl -lsocket -lm -lz $(LDFLAGS_OPENSSL)
 LDFLAGS_MKV = -s -lm $(OMPFLAGS)
 OPT_NORMAL = -funroll-loops
 # Remove the "-Os" if you're using an ancient version of gcc
@@ -127,7 +133,7 @@ JOHN_OBJS = \
 	rc4.o \
 	hmacmd5.o \
 	base64_convert.o \
-	md4.o sha2.o \
+	md4.o sha1.o sha2.o \
 	dynamic_fmt.o dynamic_parser.o dynamic_preloads.o dynamic_utils.o dynamic_big_crypt.o \
 	dynamic_compiler.o dynamic_compiler_lib.o \
 	ripemd.o tiger.o \
@@ -337,7 +343,8 @@ unit-tests:
 
 linux-x86-64-avx512:
 	$(LN) x86-64.h arch.h
-	$(MAKE) $(PROJ) \
+	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
+	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o" \
 		CFLAGS_MAIN="$(CFLAGS) -DJOHN_AVX512F -DHAVE_CRYPT" \
 		CFLAGS="$(CFLAGS) -mavx512f -DHAVE_CRYPT" \
@@ -346,7 +353,8 @@ linux-x86-64-avx512:
 
 linux-x86-64-avx2:
 	$(LN) x86-64.h arch.h
-	$(MAKE) $(PROJ) \
+	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
+	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o" \
 		CFLAGS_MAIN="$(CFLAGS) -DJOHN_AVX2 -DHAVE_CRYPT" \
 		CFLAGS="$(CFLAGS) -mavx2 -DHAVE_CRYPT" \
@@ -465,13 +473,13 @@ linux-x86-64-clang-debug:
 	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o simd-intrinsics.o" \
 		CFLAGS="-Wall -c -g -O1 -faddress-sanitizer -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_LIBGMP) $(JOHN_CFLAGS)" \
-		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -faddress-sanitizer $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
+		LDFLAGS="-L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz -lcrypt -ldl -faddress-sanitizer $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++" \
 		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) \
 		CFLAGS="-Wall -c -g -O1 -faddress-sanitizer -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_LIBGMP) $(JOHN_CFLAGS)" \
-		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -faddress-sanitizer $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
+		LDFLAGS="-L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz -lcrypt -ldl -faddress-sanitizer $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++"
 	@echo "All done"
 
@@ -481,12 +489,12 @@ linux-x86-64-newgcc-debug:
 	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o simd-intrinsics.o" \
 		CFLAGS="-Wall -c -g -O1 -fsanitize=address -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_LIBGMP) $(JOHN_CFLAGS)" \
-		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -fsanitize=address $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
+		LDFLAGS="-L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz -lcrypt -ldl -fsanitize=address $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
 		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) \
 		CFLAGS="-Wall -c -g -O1 -fsanitize=address -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_LIBGMP) $(JOHN_CFLAGS)" \
-		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -fsanitize=address $(GMP_LDFLAGS) $(JOHN_LDFLAGS)"
+		LDFLAGS="-L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz -lcrypt -ldl -fsanitize=address $(GMP_LDFLAGS) $(JOHN_LDFLAGS)"
 	@echo "All done"
 
 linux-x86-64-icc:
@@ -496,7 +504,7 @@ linux-x86-64-icc:
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o simd-intrinsics.o" \
 		CFLAGS="-c -fast -O2 -I/usr/include -static-intel -DHAVE_CRYPT -DHAVE_LIBDL $(ICCOMPFLAGS) $(HAVE_LIBGMP) $(JOHN_CFLAGS)" \
 		ASFLAGS="-c -xHost $(JOHN_ASFLAGS)" \
-		LDFLAGS="-lm -lssl -lcrypto -ipo -static-intel -lcrypt -ldl -lz $(ICCOMPFLAGS) -s $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
+		LDFLAGS="-lm $(LDFLAGS_OPENSSL) -ipo -static-intel -lcrypt -ldl -lz $(ICCOMPFLAGS) -s $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="icc" CC="icc" AS="icc" LD="icc" \
 		AESNI_ARCH=64 YASM_FORMAT="elf64"
 	@echo "Failing after this point just means some helper tools did not build:"
@@ -570,7 +578,8 @@ linux-x86-64-32-any:
 
 linux-x86-avx512:
 	$(LN) x86-sse.h arch.h
-	$(MAKE) $(PROJ) \
+	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
+	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86.o" \
 		CFLAGS_MAIN="$(CFLAGS) -m32 -DJOHN_AVX512F -DHAVE_CRYPT" \
 		CFLAGS="$(CFLAGS) -m32 -mavx512f -DHAVE_CRYPT" \
@@ -579,7 +588,8 @@ linux-x86-avx512:
 
 linux-x86-avx2:
 	$(LN) x86-sse.h arch.h
-	$(MAKE) $(PROJ) \
+	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
+	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86.o" \
 		CFLAGS_MAIN="$(CFLAGS) -m32 -DJOHN_AVX2 -DHAVE_CRYPT" \
 		CFLAGS="$(CFLAGS) -m32 -mavx2 -DHAVE_CRYPT" \
@@ -697,29 +707,31 @@ linux-x86-clang-debug:
 	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86.o x86-sse.o simd-intrinsics.o" \
 		CFLAGS="-Wall -c -g -O1 -faddress-sanitizer -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL -D_LARGEFILE64_SOURCE $(HAVE_LIBGMP) $(OMPFLAGS) $(JOHN_CFLAGS)" \
-		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -faddress-sanitizer $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
+		LDFLAGS="-L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz -lcrypt -ldl -faddress-sanitizer $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++" \
 		AESNI_ARCH=86 YASM_FORMAT="elf32"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) \
 		CFLAGS="-Wall -c -g -O1 -faddress-sanitizer -I/usr/include -msse2 -DDEBUG -DHAVE_CRYPT -DHAVE_LIBDL $(HAVE_LIBGMP) $(OMPFLAGS) $(JOHN_CFLAGS)" \
-		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz -lcrypt -ldl -faddress-sanitizer $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
+		LDFLAGS="-L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz -lcrypt -ldl -faddress-sanitizer $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++"
 	@echo "All done"
 
 linux-mic:
 	$(LN) mic.h arch.h
-	$(MAKE) $(PROJ) \
-		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o" \
+	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
+	$(MAKE_ORIG) $(PROJ) \
+		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o simd-intrinsics.o" \
 		CC=icc \
 		CFLAGS="$(CFLAGS) -no-opt-prefetch -mmic -openmp -DHAVE_CRYPT" \
-		LDFLAGS="$(LDFLAGS) -mmic -openmp -lcrypt" \
+		LDFLAGS="$(LDFLAGS_MIC) -mmic -openmp -lcrypt" \
 		OPT_INLINE="$(OPT_NORMAL) -finline-functions"
 	@echo "You'll likely need to scp Intel's OpenMP runtime library such as /opt/intel/*/compiler/lib/mic/libiomp?.so over to the target MIC cards and set LD_LIBRARY_PATH in order to run the produced john binary"
 
 linux-arm64le:
 	$(LN) arm64le.h arch.h
-	$(MAKE) $(PROJ) \
+	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
+	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o" \
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT" \
 		LDFLAGS="$(LDFLAGS) -lcrypt" \
@@ -736,7 +748,7 @@ linux-arm32le-neon:
 
 linux-arm32le:
 	$(LN) arm32le.h arch.h
-	echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
+	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
 	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o" \
 		CFLAGS="$(CFLAGS) -DHAVE_CRYPT" \
@@ -854,7 +866,7 @@ freebsd-x86-64:
 	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
 	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) x86-64.o simd-intrinsics.o" \
-		CFLAGS="$(CFLAGS) -D__BSD_VISIBLE
+		CFLAGS="$(CFLAGS) -D__BSD_VISIBLE"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
 	@echo "All done"
@@ -876,7 +888,7 @@ freebsd-x86-mmx:
 	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
 	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) x86.o x86-mmx.o" \
-		CFLAGS="$(CFLAGS) -D__BSD_VISIBLE \
+		CFLAGS="$(CFLAGS) -D__BSD_VISIBLE" \
 		ASFLAGS="$(ASFLAGS) -DBSD"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
@@ -887,7 +899,7 @@ freebsd-x86-any:
 	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
 	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) x86.o" \
-		CFLAGS="$(CFLAGS) -D__BSD_VISIBLE \
+		CFLAGS="$(CFLAGS) -D__BSD_VISIBLE" \
 		ASFLAGS="$(ASFLAGS) -DBSD"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
@@ -898,7 +910,7 @@ freebsd-x86-any-a.out:
 	@echo "#define JOHN_BLD" '"'$@'"' > john_build_rule.h
 	$(MAKE_ORIG) $(PROJ) \
 		JOHN_OBJS="$(JOHN_OBJS) x86.o" \
-		CFLAGS="$(CFLAGS) -D__BSD_VISIBLE \
+		CFLAGS="$(CFLAGS) -D__BSD_VISIBLE" \
 		ASFLAGS="$(ASFLAGS) -DUNDERSCORES -DALIGN_LOG -DBSD"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP)
@@ -1288,13 +1300,13 @@ macosx-x86-64-clang-debug:
 		JOHN_OBJS="$(JOHN_OBJS) c3_fmt.o x86-64.o simd-intrinsics.o" \
 		ASFLAGS="$(ASFLAGS) -m64 -DUNDERSCORES -DBSD -DALIGN_LOG" \
 		CFLAGS="-Wall -c -g -O1 -I/usr/include -I/usr/local/include -Wno-deprecated-declarations -DDEBUG -DHAVE_CRYPT -DBSD $(HAVE_LIBGMP) $(JOHN_CFLAGS)" \
-		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
+		LDFLAGS="-L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++"
 	@echo "Failing after this point just means some helper tools did not build:"
 	$(MAKE_ORIG) $(PROJ_PCAP) \
 		ASFLAGS="$(ASFLAGS) -m64 -DUNDERSCORES -DBSD -DALIGN_LOG" \
 		CFLAGS="-Wall -c -g -O1 -I/usr/include -I/usr/local/include -Wno-deprecated-declarations -DDEBUG -DHAVE_CRYPT -DBSD $(HAVE_LIBGMP) $(JOHN_CFLAGS)" \
-		LDFLAGS="-L/usr/local/lib -L/usr/local/ssl/lib -lssl -lcrypto -lm -lz $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
+		LDFLAGS="-L/usr/local/lib $(LDFLAGS_OPENSSL) -lm -lz $(GMP_LDFLAGS) $(JOHN_LDFLAGS)" \
 		CPP="clang" CC="clang" AS="clang" LD="clang" CXX="clang++"
 	@echo "All done"
 
@@ -1548,7 +1560,7 @@ win64-mingw-x86-64:
 	$(MAKE_ORIG) $(PROJ_WIN32_MINGW) \
 		JOHN_OBJS="$(JOHN_OBJS) x86-64.o simd-intrinsics.o" \
 		CFLAGS="-c -static -Wall -O2 -fomit-frame-pointer -I/usr/local/include $(OMPFLAGS) $(AMDAPP) $(JOHN_CFLAGS) -mpreferred-stack-boundary=4" \
-		LDFLAGS="-static -lssl -lcrypto -lwsock32 -lws2_32 -lgdi32 -lm -lpthread -lz $(OMPFLAGS)" \
+		LDFLAGS="-static $(LDFLAGS_OPENSSL) -lwsock32 -lws2_32 -lgdi32 -lm -lpthread -lz $(OMPFLAGS)" \
 		ASFLAGS="$(ASFLAGS)" \
 		CPP=$(GCC) CC=$(GCC) LD=$(GCC) CXX=$(CXX)
 	@echo "Failing after this point just means some helper tools did not build:"
@@ -1646,7 +1658,7 @@ win32-mingw-x86-sse2:
 	$(MAKE_ORIG) $(PROJ_WIN32_MINGW) \
 		JOHN_OBJS="$(JOHN_OBJS) x86.o x86-sse.o simd-intrinsics.o" \
 		CFLAGS="-c -static -Wall -O2 -fomit-frame-pointer -I/usr/local/include $(OMPFLAGS) $(AMDAPP) $(JOHN_CFLAGS) -Wall -mpreferred-stack-boundary=4 -msse2 -m32" \
-		LDFLAGS="-static -lssl -lcrypto -lwsock32 -lwst -lws2_32 -lgdi32 -lm -lpthread.dll -lz.dll $(OMPFLAGS)" \
+		LDFLAGS="-static $(LDFLAGS_OPENSSL) -lwsock32 -lwst -lws2_32 -lgdi32 -lm -lpthread.dll -lz.dll $(OMPFLAGS)" \
 		ASFLAGS="$(ASFLAGS) -msse2 -m32 -DUNDERSCORES" \
 		CPP=$(GCC) CC=$(GCC) LD=$(GCC) CXX=$(CXX)
 	@echo "Failing after this point just means some helper tools did not build:"

--- a/src/NETLM_fmt_plug.c
+++ b/src/NETLM_fmt_plug.c
@@ -32,6 +32,12 @@
  *
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_NETLM;
 #elif FMT_REGISTERS_H
@@ -379,3 +385,4 @@ struct fmt_main fmt_NETLM = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/NETSPLITLM_fmt_plug.c
+++ b/src/NETSPLITLM_fmt_plug.c
@@ -14,6 +14,12 @@
  * Code is in public domain.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_NETHALFLM;
 #elif FMT_REGISTERS_H
@@ -337,3 +343,4 @@ struct fmt_main fmt_NETHALFLM = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/aes/openssl/ossl_aes.c
+++ b/src/aes/openssl/ossl_aes.c
@@ -77,11 +77,11 @@ void JTR_AES_decrypt(const unsigned char *in, unsigned char *out, const AES_KEY 
 }
 
 #undef AES_set_encrypt_key
-void JTR_AES_set_encrypt_key(const unsigned char *userKey, const int bits, AES_KEY *key) {
-	AES_set_encrypt_key(userKey, bits, key);
+int JTR_AES_set_encrypt_key(const unsigned char *userKey, const int bits, AES_KEY *key) {
+	return AES_set_encrypt_key(userKey, bits, key);
 }
 
 #undef AES_set_decrypt_key
-void JTR_AES_set_decrypt_key(const unsigned char *userKey, const int bits, AES_KEY *key) {
-	AES_set_decrypt_key(userKey, bits, key);
+int JTR_AES_set_decrypt_key(const unsigned char *userKey, const int bits, AES_KEY *key) {
+	return AES_set_decrypt_key(userKey, bits, key);
 }

--- a/src/aes_gcm.h
+++ b/src/aes_gcm.h
@@ -9,7 +9,14 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 #include <openssl/aes.h>
+#endif
 
 // #include "aes.h"
 

--- a/src/aes_ige_plug.c
+++ b/src/aes_ige_plug.c
@@ -49,6 +49,12 @@
  *
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include <string.h>
 
 #include <openssl/aes.h>
@@ -192,3 +198,5 @@ void JtR_AES_ige_encrypt(const unsigned char *in, unsigned char *out,
         }
     }
 }
+
+#endif /* OpenSSL */

--- a/src/as400_des_fmt_plug.c
+++ b/src/as400_des_fmt_plug.c
@@ -17,6 +17,12 @@
  * Hash format => userid:$as400des$*userid*hash
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_as400des;
 #elif FMT_REGISTERS_H
@@ -392,3 +398,4 @@ struct fmt_main fmt_as400des = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/bestcrypt_fmt_plug.c
+++ b/src/bestcrypt_fmt_plug.c
@@ -29,7 +29,7 @@ john_register_one(&fmt_bestcrypt);
 
 #define OMP_SCALE               1 // this is a slow format
 
-#include "sha.h"
+#include "sha2.h"
 #include "loader.h"
 #include "pkcs12.h"
 #include "aes.h"

--- a/src/bitlocker_fmt_plug.c
+++ b/src/bitlocker_fmt_plug.c
@@ -37,7 +37,7 @@ john_register_one(&fmt_bitlocker);
 #include "johnswap.h"
 #include "aes.h"
 #include "aes_ccm.h"
-#include "sha.h"
+#include "sha2.h"
 #include "jumbo.h"
 #include "bitlocker_common.h"
 #define CPU_FORMAT              1

--- a/src/clipperz_srp_fmt_plug.c
+++ b/src/clipperz_srp_fmt_plug.c
@@ -49,16 +49,21 @@
  * n = 125617018995153554710546479714086468244499594888726646874671447258204721048803
  * g = 2 */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if !AC_BUILT && !__MIC__
+#define HAVE_LIBGMP 1 /* legacy build uses libgmp by default, except for MIC */
+#endif
+
+#if HAVE_LIBGMP || HAVE_LIBCRYPTO /* we need one of these for bignum */
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_clipperz;
 #elif FMT_REGISTERS_H
 john_register_one(&fmt_clipperz);
 #else
-
-#if AC_BUILT
-/* need to know if HAVE_LIBGMP is set, for autoconfig build */
-#include "autoconfig.h"
-#endif
 
 #include <string.h>
 #ifdef HAVE_LIBGMP
@@ -509,3 +514,4 @@ struct fmt_main fmt_clipperz = {
 };
 
 #endif /* plugin stanza */
+#endif /* HAVE_LIBGMP || HAVE_LIBCRYPTO */

--- a/src/configure
+++ b/src/configure
@@ -1416,7 +1416,8 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --without-openssl       Do not use Openssl (CommonCrypto must be enabled)
+  --without-openssl       Do not use OpenSSL (can use CommonCrypto instead or
+                          exclude much functionality)
   --with-commoncrypto     Use CommonCrypto
   --with-endian=little|big
                           Set endianness for target if it doesn't detect
@@ -12124,13 +12125,6 @@ See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 
-if test "x$with_commoncrypto" != xyes && test "x$with_openssl" = xno; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 1 "At least one of OpenSSL and CommonCrypto must be used
-See \`config.log' for more details" "$LINENO" 5; }
-
-fi
 
 if test "x$with_commoncrypto" = xyes; then :
   ac_fn_c_check_header_mongrel "$LINENO" "CommonCrypto/CommonDigest.h" "ac_cv_header_CommonCrypto_CommonDigest_h" "$ac_includes_default"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -54,7 +54,7 @@ AC_ARG_VAR([LD], [full pathname of linker to use])
 
 dnl Define Packages.
 dnl Use OpenSSL (default: yes).
-AC_ARG_WITH(openssl, [AS_HELP_STRING([--without-openssl],[Do not use Openssl (CommonCrypto must be enabled)])],,[with_openssl=yes])
+AC_ARG_WITH(openssl, [AS_HELP_STRING([--without-openssl],[Do not use OpenSSL (can use CommonCrypto instead or exclude much functionality)])],,[with_openssl=yes])
 dnl Use CommonCrypto (default: no)
 AC_ARG_WITH(commoncrypto, [AS_HELP_STRING([--with-commoncrypto],[Use CommonCrypto])],,[with_commoncrypto=no])
 dnl Cludge for endian (if not auto detected)
@@ -581,9 +581,9 @@ dnl is specified, the -llibname will NOT get appended to LIBS. So it has to be
 dnl done by 'hand'.
 dnl ======================================================================
 
-AS_IF([test "x$with_commoncrypto" != xyes && test "x$with_openssl" = xno],
-   [AC_MSG_FAILURE([At least one of OpenSSL and CommonCrypto must be used],1)]
-)
+dnl AS_IF([test "x$with_commoncrypto" != xyes && test "x$with_openssl" = xno],
+dnl    [AC_MSG_FAILURE([At least one of OpenSSL and CommonCrypto must be used],1)]
+dnl )
 
 AS_IF([test "x$with_commoncrypto" = xyes],
   [AC_CHECK_HEADER([CommonCrypto/CommonDigest.h],

--- a/src/dashlane_common_plug.c
+++ b/src/dashlane_common_plug.c
@@ -1,5 +1,5 @@
 #include "arch.h"
-#if !AC_BUILT
+#if !AC_BUILT && !__MIC__
 #define HAVE_LIBZ 1 /* legacy build has -lz in LDFLAGS */
 #endif
 #if HAVE_LIBZ

--- a/src/dashlane_fmt_plug.c
+++ b/src/dashlane_fmt_plug.c
@@ -11,7 +11,7 @@
  */
 
 #include "arch.h"
-#if !AC_BUILT
+#if !AC_BUILT && !__MIC__
 #define HAVE_LIBZ 1 /* legacy build has -lz in LDFLAGS */
 #endif
 #if HAVE_LIBZ

--- a/src/dmg_fmt_plug.c
+++ b/src/dmg_fmt_plug.c
@@ -41,6 +41,12 @@
  */
 //#define DMG_DEBUG		2
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_dmg;
 #elif FMT_REGISTERS_H
@@ -742,3 +748,4 @@ struct fmt_main fmt_dmg = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/dpapimk_fmt_plug.c
+++ b/src/dpapimk_fmt_plug.c
@@ -14,6 +14,12 @@
  * work on the DPAPI masterkey file version 1 implementation.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_DPAPImk;
 #elif FMT_REGISTERS_H
@@ -531,3 +537,4 @@ struct fmt_main fmt_DPAPImk = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/dynamic.h
+++ b/src/dynamic.h
@@ -28,7 +28,14 @@
 #ifndef DYNAMIC_DISABLED
 
 #include "simd-intrinsics.h"
+
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 #include <openssl/opensslv.h>
+#endif
 
 #ifdef _OPENMP
 #define DYNA_OMP_PARAMS unsigned int first, unsigned int last, unsigned int tid

--- a/src/dynamic_big_crypt_header.cin
+++ b/src/dynamic_big_crypt_header.cin
@@ -117,7 +117,9 @@
 #define sph_skein384_close(a,b) sph_skein384_close(b,a)
 #define sph_skein512_close(a,b) sph_skein512_close(b,a)
 
+#if defined(HAVE_LIBCRYPTO) || defined(HAVE_COMMONCRYPTO)
 #include <openssl/opensslv.h>
+#endif
 #if (AC_BUILT && HAVE_WHIRLPOOL) ||	  \
    (!AC_BUILT && OPENSSL_VERSION_NUMBER >= 0x10000000 && !HAVE_NO_SSL_WHIRLPOOL)
 #include <openssl/whrlpool.h>

--- a/src/ed25519-donna/ed25519-donna-portable-identify.h
+++ b/src/ed25519-donna/ed25519-donna-portable-identify.h
@@ -45,7 +45,7 @@
 
 
 /* cpu */
-#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__ ) || defined(_M_X64)
+#if (defined(__amd64__) || defined(__amd64) || defined(__x86_64__ ) || defined(_M_X64)) && !defined(__k1om__)
 	#define CPU_X86_64
 #elif defined(__i586__) || defined(__i686__) || (defined(_M_IX86) && (_M_IX86 >= 500))
 	#define CPU_X86 500

--- a/src/electrum_fmt_plug.c
+++ b/src/electrum_fmt_plug.c
@@ -10,6 +10,12 @@
  * Special thanks goes to Christopher Gurnee for making this work possible.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include "arch.h"
 #if !AC_BUILT
 #define HAVE_LIBZ 1
@@ -513,3 +519,4 @@ struct fmt_main fmt_electrum = {
 #endif
 
 #endif /* HAVE_LIBZ */
+#endif /* OpenSSL */

--- a/src/gpg2john.c
+++ b/src/gpg2john.c
@@ -43,7 +43,9 @@
 #include <errno.h>
 
 #if !AC_BUILT
-#define HAVE_LIBZ 1
+ #if !__MIC__
+ #define HAVE_LIBZ 1
+ #endif
  #include <string.h>
  #ifndef _MSC_VER
   #include <strings.h>

--- a/src/gpg_common.h
+++ b/src/gpg_common.h
@@ -81,18 +81,6 @@ enum {
 #define MD5_DIGEST_LENGTH 16
 #endif
 
-#ifndef SHA_DIGEST_LENGTH
-#define SHA_DIGEST_LENGTH 20
-#endif
-
-#ifndef SHA256_DIGEST_LENGTH
-#define SHA256_DIGEST_LENGTH 32
-#endif
-
-#ifndef SHA512_DIGEST_LENGTH
-#define SHA512_DIGEST_LENGTH 64
-#endif
-
 struct gpg_common_custom_salt {
 	dyna_salt dsalt;
 	int datalen;

--- a/src/gpg_common_plug.c
+++ b/src/gpg_common_plug.c
@@ -11,6 +11,12 @@
  *  (CPU, OpenCL)
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
@@ -25,6 +31,7 @@
 
 #include "twofish.h"
 #include "idea-JtR.h"
+#include "sha.h"
 #include "sha2.h"
 #include "md5.h"
 #include "formats.h"
@@ -1693,3 +1700,5 @@ unsigned int gpg_common_gpg_cipher_algorithm(void *salt)
 	my_salt = *(struct gpg_common_custom_salt **)salt;
 	return (unsigned int) my_salt->cipher_algorithm;
 }
+
+#endif /* OpenSSL */

--- a/src/gpg_fmt_plug.c
+++ b/src/gpg_fmt_plug.c
@@ -24,6 +24,12 @@
  * Converted to use 'common' code, Feb29-Mar1 2016, JimF.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_gpg;
 #elif FMT_REGISTERS_H
@@ -212,3 +218,4 @@ struct fmt_main fmt_gpg = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/ike-crack.h
+++ b/src/ike-crack.h
@@ -50,10 +50,10 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdint.h>
-#include <openssl/sha.h>
 
 #include "misc.h"	// error()
 #include "md5.h"
+#include "sha.h"
 #include "memory.h"
 /* Defines */
 
@@ -515,8 +515,11 @@ inline static void compute_hash(const psk_entry * psk_params,
 		unsigned char nortel_psk[SHA1_HASH_LEN];
 		unsigned char nortel_pwd_hash[SHA1_HASH_LEN];
 
-		SHA1((unsigned char *) password, password_len,
-		    nortel_pwd_hash);
+		SHA_CTX ctx;
+		SHA1_Init(&ctx);
+		SHA1_Update(&ctx, password, password_len);
+		SHA1_Final(nortel_pwd_hash, &ctx);
+
 		hmac_sha1((unsigned char *) psk_params->nortel_user,
 		    strlen(psk_params->nortel_user), nortel_pwd_hash,
 		    SHA1_HASH_LEN, nortel_psk);

--- a/src/ike-crack.h
+++ b/src/ike-crack.h
@@ -174,8 +174,8 @@ static unsigned char *hex2data(const char *string, size_t * data_len)
  *	This function is based on the code from the RFC 2104 appendix.
  *
  *	We use #ifdef to select either the OpenSSL MD5 functions or the
- *	built-in MD5 functions depending on whether HAVE_LIBSSL is defined.
- *	This is faster that calling OpenSSL "HMAC" directly.
+ *	built-in MD5 functions depending on whether HAVE_LIBCRYPTO is defined.
+ *	This is faster than calling OpenSSL "HMAC" directly.
  */
 inline static unsigned char *hmac_md5(unsigned char *text,
     size_t text_len, unsigned char *key, size_t key_len, unsigned char *md)
@@ -256,8 +256,8 @@ inline static unsigned char *hmac_md5(unsigned char *text,
  *	This function is based on the code from the RFC 2104 appendix.
  *
  *	We use #ifdef to select either the OpenSSL SHA1 functions or the
- *	built-in SHA1 functions depending on whether HAVE_LIBSSL is defined.
- *	This is faster that calling OpenSSL "HMAC" directly.
+ *	built-in SHA1 functions depending on whether HAVE_LIBCRYPTO is defined.
+ *	This is faster than calling OpenSSL "HMAC" directly.
  */
 inline static unsigned char *hmac_sha1(const unsigned char *text,
     size_t text_len, const unsigned char *key, size_t key_len,

--- a/src/itunes_fmt_plug.c
+++ b/src/itunes_fmt_plug.c
@@ -18,7 +18,6 @@ john_register_one(&fmt_itunes);
 #else
 
 #include <string.h>
-#include <openssl/des.h>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/src/iwork_fmt_plug.c
+++ b/src/iwork_fmt_plug.c
@@ -20,7 +20,6 @@ john_register_one(&fmt_iwork);
 #else
 
 #include <string.h>
-#include <openssl/des.h>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/src/keychain_common_plug.c
+++ b/src/keychain_common_plug.c
@@ -2,6 +2,12 @@
  * Common code for the Apple Keychain format.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_OPENCL || HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include "arch.h"
 #include "misc.h"
 #include "common.h"
@@ -75,3 +81,5 @@ void *keychain_get_salt(char *ciphertext)
 	MEM_FREE(keeptr);
 	return (void *)&cs;
 }
+
+#endif /* HAVE_OPENCL || HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO */

--- a/src/keychain_fmt_plug.c
+++ b/src/keychain_fmt_plug.c
@@ -14,6 +14,12 @@
  * See https://matt.ucc.asn.au/apple/ for more information.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_keychain;
 #elif FMT_REGISTERS_H
@@ -230,3 +236,4 @@ struct fmt_main fmt_keychain = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/krb5_asrep_fmt_plug.c
+++ b/src/krb5_asrep_fmt_plug.c
@@ -54,6 +54,12 @@
  * available.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_krb5asrep;
 #elif FMT_REGISTERS_H
@@ -400,3 +406,4 @@ struct fmt_main fmt_krb5asrep = {
 };
 
 #endif
+#endif /* OpenSSL */

--- a/src/krb5_common_plug.c
+++ b/src/krb5_common_plug.c
@@ -1,3 +1,9 @@
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include <openssl/des.h>
 
 #include "krb5_common.h"
@@ -330,3 +336,5 @@ int des_string_to_key_shishi(char *string, size_t stringlen,
 
 	return 0;
 }
+
+#endif /* OpenSSL */

--- a/src/krb5_db_fmt_plug.c
+++ b/src/krb5_db_fmt_plug.c
@@ -28,6 +28,8 @@
 #include "autoconfig.h"
 #endif
 
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_krb5_18;
 extern struct fmt_main fmt_krb5_17;
@@ -506,3 +508,4 @@ struct fmt_main fmt_krb5_3 = {
 
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/krb5pa-sha1_fmt_plug.c
+++ b/src/krb5pa-sha1_fmt_plug.c
@@ -32,6 +32,12 @@
  * released under same terms as above.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_krb5pa;
 #elif FMT_REGISTERS_H
@@ -481,3 +487,4 @@ struct fmt_main fmt_krb5pa = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/kwallet_fmt_plug.c
+++ b/src/kwallet_fmt_plug.c
@@ -11,6 +11,12 @@
  * modification, are permitted.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_kwallet;
 #elif FMT_REGISTERS_H
@@ -435,3 +441,4 @@ struct fmt_main fmt_kwallet = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/leet_cc_fmt_plug.c
+++ b/src/leet_cc_fmt_plug.c
@@ -18,11 +18,18 @@ extern struct fmt_main fmt_leet;
 john_register_one(&fmt_leet);
 #else
 
+#include <string.h>
+
 #include "arch.h"
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
 #include "openssl_local_overrides.h"
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 #include <openssl/opensslv.h>
-#include <string.h>
+#endif
 #if (AC_BUILT && HAVE_WHIRLPOOL) ||	  \
    (!AC_BUILT && OPENSSL_VERSION_NUMBER >= 0x10000000 && !HAVE_NO_SSL_WHIRLPOOL)
 #include <openssl/whrlpool.h>

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -229,7 +229,7 @@ static void listconf_list_build_info(void)
 #if HAVE_OPENCL
 	printf("OpenCL headers version: %s\n",get_opencl_header_version());
 #endif
-#if HAVE_LIBSSL
+#if HAVE_LIBCRYPTO
 	printf("Crypto library: OpenSSL\n");
 #endif
 #if HAVE_COMMONCRYPTO

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -42,8 +42,10 @@
  #endif
 #endif
 
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
+#endif
 
 #if HAVE_LIBDL
 #include <dlfcn.h>
@@ -53,7 +55,7 @@
 #define HAVE_LIBDL 1
 #endif
 
-#if HAVE_LIBGMP
+#if HAVE_LIBGMP && !__MIC__
 #if HAVE_GMP_GMP_H
 #include <gmp/gmp.h>
 #else

--- a/src/lotus85_fmt_plug.c
+++ b/src/lotus85_fmt_plug.c
@@ -8,6 +8,12 @@
  * Kholia).
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_lotus_85;
 #elif FMT_REGISTERS_H
@@ -481,3 +487,4 @@ struct fmt_main fmt_lotus_85 =
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/md4.c
+++ b/src/md4.c
@@ -22,7 +22,7 @@
  */
 
 #include "md4.h"
-#ifndef HAVE_LIBSSL
+#if !HAVE_LIBCRYPTO
 #include <string.h>
 
 /*

--- a/src/md4.h
+++ b/src/md4.h
@@ -8,9 +8,9 @@
  * See md4.c for more information.
  */
 
-#include "arch.h"
+#include "arch.h" /* also includes autoconfig.h for HAVE_LIBCRYPTO */
 
-#ifdef HAVE_LIBSSL
+#if HAVE_LIBCRYPTO
 #include <openssl/md4.h>
 #elif !defined(_MD4_H)
 #define _MD4_H
@@ -35,4 +35,4 @@ extern void MD4_Init(MD4_CTX *ctx);
 extern void MD4_Update(MD4_CTX *ctx, const void *data, unsigned long size);
 extern void MD4_Final(unsigned char *result, MD4_CTX *ctx);
 
-#endif
+#endif /* _MD4_H */

--- a/src/md5.c
+++ b/src/md5.c
@@ -23,7 +23,7 @@
  */
 
 #include "md5.h"
-#ifndef HAVE_LIBSSL
+#if !HAVE_LIBCRYPTO
 #include <string.h>
 
 /*

--- a/src/md5.h
+++ b/src/md5.h
@@ -16,12 +16,12 @@
 #define _MD5_H
 
 /* Any 32-bit or wider unsigned integer data type will do */
-/* this needs to be defined no matter if building with HAVE_LIBSSL or not */
+/* this needs to be defined no matter if building with HAVE_LIBCRYPTO or not */
 typedef unsigned int MD5_u32plus;
 
-#include "arch.h"
+#include "arch.h" /* also includes autoconfig.h for HAVE_LIBCRYPTO */
 
-#ifdef HAVE_LIBSSL
+#if HAVE_LIBCRYPTO
 #include <openssl/md5.h>
 
 #else
@@ -43,6 +43,6 @@ extern void MD5_Init(MD5_CTX *ctx);
 extern void MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size);
 extern void MD5_PreFinal(MD5_CTX *ctx);
 extern void MD5_Final(unsigned char *result, MD5_CTX *ctx);
-#endif /* HAVE_LIBSSL */
 
+#endif /* HAVE_LIBCRYPTO */
 #endif /* _MD5_H */

--- a/src/mdc2_fmt_plug.c
+++ b/src/mdc2_fmt_plug.c
@@ -8,6 +8,12 @@
  * modification, are permitted.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_mdc2;
 #elif FMT_REGISTERS_H
@@ -235,3 +241,4 @@ struct fmt_main fmt_mdc2 = {
 };
 
 #endif
+#endif /* OpenSSL */

--- a/src/mdc2dgst_plug.c
+++ b/src/mdc2dgst_plug.c
@@ -56,6 +56,12 @@
  * [including the GNU Public Licence.]
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -179,3 +185,5 @@ int JtR_MDC2_Final(unsigned char *md, JtR_MDC2_CTX *c)
 	memcpy(&(md[JtR_MDC2_BLOCK]),(char *)c->hh,JtR_MDC2_BLOCK);
 	return 1;
 }
+
+#endif /* OpenSSL */

--- a/src/mic.h
+++ b/src/mic.h
@@ -57,32 +57,6 @@
 #define BF_X2				1
 #endif
 
-#if !defined(JOHN_NO_SIMD) && (__AVX512F__ || JOHN_AVX512F)
-#undef CPU_DETECT
-#define CPU_DETECT			1
-#define CPU_REQ				1
-#define CPU_REQ_AVX512F			1
-#undef CPU_NAME
-#define CPU_NAME			"AVX512F"
-#if CPU_FALLBACK && !defined(CPU_FALLBACK_BINARY)
-#define CPU_FALLBACK_BINARY		"john-non-avx512f"
-#define CPU_FALLBACK_BINARY_DEFAULT
-#endif
-#endif
-
-#if !defined(JOHN_NO_SIMD) && (__AVX512BW__ || JOHN_AVX512BW)
-#undef CPU_DETECT
-#define CPU_DETECT			1
-#define CPU_REQ				1
-#define CPU_REQ_AVX512BW		1
-#undef CPU_NAME
-#define CPU_NAME			"AVX512BW"
-#if CPU_FALLBACK && !defined(CPU_FALLBACK_BINARY)
-#define CPU_FALLBACK_BINARY		"john-non-avx512bw"
-#define CPU_FALLBACK_BINARY_DEFAULT
-#endif
-#endif
-
 #define SIMD_COEF_32		16
 #define SIMD_COEF_64		8
 

--- a/src/mongodb_scram_fmt_plug.c
+++ b/src/mongodb_scram_fmt_plug.c
@@ -12,7 +12,6 @@ extern struct fmt_main fmt_mongodb_scram;
 john_register_one(&fmt_mongodb_scram);
 #else
 
-#include <openssl/sha.h>
 #include <string.h>
 
 #ifdef _OPENMP

--- a/src/mozilla_ng_fmt_plug.c
+++ b/src/mozilla_ng_fmt_plug.c
@@ -14,6 +14,12 @@
  * modification, are permitted.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_mozilla;
 #elif FMT_REGISTERS_H
@@ -452,3 +458,4 @@ struct fmt_main fmt_mozilla = {
 };
 
 #endif
+#endif /* OpenSSL */

--- a/src/mscash2_fmt_plug.c
+++ b/src/mscash2_fmt_plug.c
@@ -424,17 +424,17 @@ static void pbkdf2_sse2(int t)
 
 		// we memcopy from flat into SIMD_COEF_32 output buffer's (our 'temp' ctx buffer).
 		// This data will NOT need to be BE swapped (it already IS BE swapped).
-		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))]               = ctx1.h0;
-		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+SIMD_COEF_32]      = ctx1.h1;
-		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<1)] = ctx1.h2;
-		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+SIMD_COEF_32*3]    = ctx1.h3;
-		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<2)] = ctx1.h4;
+		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))]               = ctx1.SHA_H0;
+		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+SIMD_COEF_32]      = ctx1.SHA_H1;
+		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<1)] = ctx1.SHA_H2;
+		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+SIMD_COEF_32*3]    = ctx1.SHA_H3;
+		i1[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<2)] = ctx1.SHA_H4;
 
-		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))]               = ctx2.h0;
-		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+SIMD_COEF_32]      = ctx2.h1;
-		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<1)] = ctx2.h2;
-		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+SIMD_COEF_32*3]    = ctx2.h3;
-		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<2)] = ctx2.h4;
+		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))]               = ctx2.SHA_H0;
+		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+SIMD_COEF_32]      = ctx2.SHA_H1;
+		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<1)] = ctx2.SHA_H2;
+		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+SIMD_COEF_32*3]    = ctx2.SHA_H3;
+		i2[(k/SIMD_COEF_32)*SIMD_COEF_32*5+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<2)] = ctx2.SHA_H4;
 
 		SHA1_Update(&ctx1,salt_buffer,salt_len);
 		SHA1_Update(&ctx1,"\x0\x0\x0\x1",4);
@@ -446,11 +446,11 @@ static void pbkdf2_sse2(int t)
 		// now convert this from flat into SIMD_COEF_32 buffers.
 		// Also, perform the 'first' ^= into the crypt buffer.  NOTE, we are doing that in BE format
 		// so we will need to 'undo' that in the end.
-		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))]                = t_crypt[k*4+0] = ctx2.h0;
-		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))+SIMD_COEF_32]       = t_crypt[k*4+1] = ctx2.h1;
-		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<1)]  = t_crypt[k*4+2] = ctx2.h2;
-		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))+SIMD_COEF_32*3]     = t_crypt[k*4+3] = ctx2.h3;
-		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<2)]                   = ctx2.h4;
+		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))]                = t_crypt[k*4+0] = ctx2.SHA_H0;
+		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))+SIMD_COEF_32]       = t_crypt[k*4+1] = ctx2.SHA_H1;
+		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<1)]  = t_crypt[k*4+2] = ctx2.SHA_H2;
+		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))+SIMD_COEF_32*3]     = t_crypt[k*4+3] = ctx2.SHA_H3;
+		o1[(k/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(k&(SIMD_COEF_32-1))+(SIMD_COEF_32<<2)]                   = ctx2.SHA_H4;
 	}
 
 	for (i = 1; i < iteration_cnt; i++)

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -68,6 +68,12 @@
  *
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_MSCHAPv2_new;
 extern struct fmt_main fmt_NETNTLM_new;
@@ -1484,3 +1490,4 @@ struct fmt_main fmt_NETNTLM_new = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/o10glogon_fmt_plug.c
+++ b/src/o10glogon_fmt_plug.c
@@ -16,6 +16,12 @@
  *
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_o10glogon;
 #elif FMT_REGISTERS_H
@@ -437,3 +443,4 @@ struct fmt_main fmt_o10glogon = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/o3logon_fmt_plug.c
+++ b/src/o3logon_fmt_plug.c
@@ -12,6 +12,12 @@
  *
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_o3logon;
 #elif FMT_REGISTERS_H
@@ -410,3 +416,4 @@ struct fmt_main fmt_o3logon = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/odf_common_plug.c
+++ b/src/odf_common_plug.c
@@ -2,6 +2,12 @@
  * Common code for the ODF/StarOffice/LibreOffice format.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include <openssl/blowfish.h>
 
 #include "arch.h"
@@ -9,7 +15,7 @@
 #include "common.h"
 #include "odf_common.h"
 #include "johnswap.h"
-#include "sha.h"
+#include "sha2.h"
 #include "aes.h"
 #define OPENCL_FORMAT
 #include "pbkdf2_hmac_sha1.h"
@@ -488,3 +494,5 @@ void SHA1_odf_buggy(unsigned char *data, int len, uint32_t results[5]) {
 	SHA1Update_buggy(&ctx, data, len);
 	SHA1Final_buggy((unsigned char*)results, &ctx);
 }
+
+#endif /* OpenSSL */

--- a/src/odf_fmt_plug.c
+++ b/src/odf_fmt_plug.c
@@ -18,6 +18,12 @@
  * Also look at "odfencrypt.groovy" for OpenDocument encryption details.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_odf;
 #elif FMT_REGISTERS_H
@@ -288,3 +294,4 @@ struct fmt_main fmt_odf = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/openbsdsoftraid_fmt_plug.c
+++ b/src/openbsdsoftraid_fmt_plug.c
@@ -147,7 +147,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			}
 
 			/* get SHA1 of mask_key */
-			SHA1(mask_key[i], 32, hashed_mask_key);
+			SHA_CTX ctx;
+			SHA1_Init(&ctx);
+			SHA1_Update(&ctx, mask_key[i], 32);
+			SHA1_Final(hashed_mask_key, &ctx);
 
 			hmac_sha1(hashed_mask_key, OPENBSD_SOFTRAID_MACLENGTH,
 					unmasked_keys, OPENBSD_SOFTRAID_KEYLENGTH * OPENBSD_SOFTRAID_KEYS,

--- a/src/opencl_electrum_modern_fmt_plug.c
+++ b/src/opencl_electrum_modern_fmt_plug.c
@@ -8,12 +8,17 @@
  * Based on opencl_pbkdf2_hmac_sha512_fmt_plug.c file.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
 #include "arch.h"
 #if !AC_BUILT
 #define HAVE_LIBZ 1
 #endif
 #if HAVE_LIBZ
-#ifdef HAVE_OPENCL
+
+#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_opencl_electrum_modern;

--- a/src/opencl_gpg_fmt_plug.c
+++ b/src/opencl_gpg_fmt_plug.c
@@ -11,7 +11,11 @@
  * Converted to use 'common' code, Feb29-Mar1 2016, JimF.
  */
 
-#ifdef HAVE_OPENCL
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_opencl_gpg;

--- a/src/opencl_odf_fmt_plug.c
+++ b/src/opencl_odf_fmt_plug.c
@@ -9,7 +9,11 @@
  * modification, are permitted.
  */
 
-#ifdef HAVE_OPENCL
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_opencl_odf_aes;

--- a/src/opencl_pem_fmt_plug.c
+++ b/src/opencl_pem_fmt_plug.c
@@ -16,10 +16,6 @@
 #if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
 
 #include "arch.h"
-#if !AC_BUILT
-#define HAVE_LIBZ 1 /* legacy build has -lz in LDFLAGS */
-#endif
-#if HAVE_LIBZ
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_opencl_pem;
@@ -391,7 +387,5 @@ struct fmt_main fmt_opencl_pem = {
 };
 
 #endif /* plugin stanza */
-
-#endif /* HAVE_LIBZ */
 
 #endif /* HAVE_OPENCL */

--- a/src/opencl_pem_fmt_plug.c
+++ b/src/opencl_pem_fmt_plug.c
@@ -9,7 +9,11 @@
  * The OpenCL boilerplate code is borrowed from other OpenCL formats.
  */
 
-#ifdef HAVE_OPENCL
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
 
 #include "arch.h"
 #if !AC_BUILT

--- a/src/opencl_rawsha256_fmt_plug.c
+++ b/src/opencl_rawsha256_fmt_plug.c
@@ -23,7 +23,6 @@ john_register_one(&fmt_opencl_rawsha256);
 
 #include <string.h>
 
-#include "sha.h"
 #include "sha2.h"
 #include "johnswap.h"
 #include "opencl_common.h"

--- a/src/opencl_rawsha512_gpl_fmt_plug.c
+++ b/src/opencl_rawsha512_gpl_fmt_plug.c
@@ -25,7 +25,6 @@ john_register_one(&fmt_opencl_xsha512_gpl);
 
 #include <string.h>
 
-#include "sha.h"
 #include "sha2.h"
 #include "johnswap.h"
 #include "opencl_common.h"

--- a/src/opencl_telegram_fmt_plug.c
+++ b/src/opencl_telegram_fmt_plug.c
@@ -9,7 +9,11 @@
  * The OpenCL boilerplate code is borrowed from other OpenCL formats.
  */
 
-#ifdef HAVE_OPENCL
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
 
 #include "arch.h"
 

--- a/src/openssl_code_plug.c
+++ b/src/openssl_code_plug.c
@@ -1,5 +1,6 @@
 #include "md5.h"
 #include "sha.h"
+#include "sha2.h"
 #include "openssl_code.h"
 
 void BytesToKey(int key_sz, hash_type h, const unsigned char *salt,

--- a/src/oracle12c_fmt_plug.c
+++ b/src/oracle12c_fmt_plug.c
@@ -14,7 +14,6 @@ extern struct fmt_main fmt_oracle12c;
 john_register_one(&fmt_oracle12c);
 #else
 
-#include <openssl/sha.h>
 #include <string.h>
 
 #ifdef _OPENMP

--- a/src/oracle_fmt_plug.c
+++ b/src/oracle_fmt_plug.c
@@ -9,6 +9,12 @@
  * modification, is permitted.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_oracle;
 #elif FMT_REGISTERS_H
@@ -446,3 +452,4 @@ struct fmt_main fmt_oracle = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/pbkdf2_hmac_sha1.h
+++ b/src/pbkdf2_hmac_sha1.h
@@ -215,18 +215,18 @@ static void pbkdf2_sha1_sse(const unsigned char *K[SSE_GROUP_SZ_SHA1], int KL[SS
 	_pbkdf2_sha1_sse_load_hmac(K, KL, ipad, opad);
 	for (j = 0; j < SSE_GROUP_SZ_SHA1; ++j) {
 		ptmp = &i1[(j/SIMD_COEF_32)*SIMD_COEF_32*(SHA_DIGEST_LENGTH/sizeof(uint32_t))+(j&(SIMD_COEF_32-1))];
-		ptmp[0]          = ipad[j].h0;
-		ptmp[SIMD_COEF_32]   = ipad[j].h1;
-		ptmp[SIMD_COEF_32*2] = ipad[j].h2;
-		ptmp[SIMD_COEF_32*3] = ipad[j].h3;
-		ptmp[SIMD_COEF_32*4] = ipad[j].h4;
+		ptmp[0]          = ipad[j].SHA_H0;
+		ptmp[SIMD_COEF_32]   = ipad[j].SHA_H1;
+		ptmp[SIMD_COEF_32*2] = ipad[j].SHA_H2;
+		ptmp[SIMD_COEF_32*3] = ipad[j].SHA_H3;
+		ptmp[SIMD_COEF_32*4] = ipad[j].SHA_H4;
 
 		ptmp = &i2[(j/SIMD_COEF_32)*SIMD_COEF_32*(SHA_DIGEST_LENGTH/sizeof(uint32_t))+(j&(SIMD_COEF_32-1))];
-		ptmp[0]          = opad[j].h0;
-		ptmp[SIMD_COEF_32]   = opad[j].h1;
-		ptmp[SIMD_COEF_32*2] = opad[j].h2;
-		ptmp[SIMD_COEF_32*3] = opad[j].h3;
-		ptmp[SIMD_COEF_32*4] = opad[j].h4;
+		ptmp[0]          = opad[j].SHA_H0;
+		ptmp[SIMD_COEF_32]   = opad[j].SHA_H1;
+		ptmp[SIMD_COEF_32*2] = opad[j].SHA_H2;
+		ptmp[SIMD_COEF_32*3] = opad[j].SHA_H3;
+		ptmp[SIMD_COEF_32*4] = opad[j].SHA_H4;
 	}
 
 	loops = (skip_bytes + outlen + (SHA_DIGEST_LENGTH-1)) / SHA_DIGEST_LENGTH;
@@ -256,11 +256,11 @@ static void pbkdf2_sha1_sse(const unsigned char *K[SSE_GROUP_SZ_SHA1], int KL[SS
 			// Also, perform the 'first' ^= into the crypt buffer.  NOTE, we are doing that in BE format
 			// so we will need to 'undo' that in the end.
 			ptmp = &o1[(j/SIMD_COEF_32)*SIMD_COEF_32*SHA_BUF_SIZ+(j&(SIMD_COEF_32-1))];
-			ptmp[0]           = dgst[j][0] = ctx.h0;
-			ptmp[SIMD_COEF_32]    = dgst[j][1] = ctx.h1;
-			ptmp[SIMD_COEF_32*2]  = dgst[j][2] = ctx.h2;
-			ptmp[SIMD_COEF_32*3]  = dgst[j][3] = ctx.h3;
-			ptmp[SIMD_COEF_32*4]  = dgst[j][4] = ctx.h4;
+			ptmp[0]           = dgst[j][0] = ctx.SHA_H0;
+			ptmp[SIMD_COEF_32]    = dgst[j][1] = ctx.SHA_H1;
+			ptmp[SIMD_COEF_32*2]  = dgst[j][2] = ctx.SHA_H2;
+			ptmp[SIMD_COEF_32*3]  = dgst[j][3] = ctx.SHA_H3;
+			ptmp[SIMD_COEF_32*4]  = dgst[j][4] = ctx.SHA_H4;
 		}
 
 		// Here is the inner loop.  We loop from 1 to count.  iteration 0 was done in the ipad/opad computation.

--- a/src/pem_common_plug.c
+++ b/src/pem_common_plug.c
@@ -5,6 +5,12 @@
  * and the GPU formats, and places it into one common location.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include <openssl/des.h>
 
 #include "arch.h"
@@ -257,3 +263,5 @@ unsigned int pem_cipher(void *salt)
 
 	return cs->cid;
 }
+
+#endif /* OpenSSL */

--- a/src/pem_fmt_plug.c
+++ b/src/pem_fmt_plug.c
@@ -12,6 +12,12 @@
  * possible.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_pem;
 #elif FMT_REGISTERS_H
@@ -201,3 +207,4 @@ struct fmt_main fmt_pem = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/pgpdisk_common.h
+++ b/src/pgpdisk_common.h
@@ -3,7 +3,6 @@
  */
 
 #include <string.h>
-#include <openssl/cast.h>
 
 #include "formats.h"
 #include "sha.h"

--- a/src/pgpdisk_fmt_plug.c
+++ b/src/pgpdisk_fmt_plug.c
@@ -8,6 +8,12 @@
  * are permitted.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_pgpdisk;
 #elif FMT_REGISTERS_H
@@ -261,3 +267,4 @@ struct fmt_main fmt_pgpdisk = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/pgpsda_common.h
+++ b/src/pgpsda_common.h
@@ -3,7 +3,6 @@
  */
 
 #include <string.h>
-#include <openssl/cast.h>
 
 #include "formats.h"
 #include "sha.h"

--- a/src/pgpsda_fmt_plug.c
+++ b/src/pgpsda_fmt_plug.c
@@ -8,6 +8,12 @@
  * are permitted.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_pgpsda;
 #elif FMT_REGISTERS_H
@@ -220,3 +226,4 @@ struct fmt_main fmt_pgpsda = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -9,7 +9,7 @@
  */
 
 #include "arch.h"
-#if !AC_BUILT
+#if !AC_BUILT && !__MIC__
 #define HAVE_LIBZ 1 /* legacy build has -lz in LDFLAGS */
 #endif
 

--- a/src/racf_fmt_plug.c
+++ b/src/racf_fmt_plug.c
@@ -16,6 +16,12 @@
  * racfdump format => userid:$racf$*userid*deshash
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_racf;
 #elif FMT_REGISTERS_H
@@ -365,3 +371,4 @@ struct fmt_main fmt_racf = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/racf_kdfaes_fmt_plug.c
+++ b/src/racf_kdfaes_fmt_plug.c
@@ -9,6 +9,12 @@
  * modification, are permitted.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_racf_kdfaes;
 #elif FMT_REGISTERS_H
@@ -478,3 +484,4 @@ struct fmt_main fmt_racf_kdfaes = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/rsvp_fmt_plug.c
+++ b/src/rsvp_fmt_plug.c
@@ -30,6 +30,7 @@ john_register_one(&fmt_rsvp);
 #include "arch.h"
 #include "md5.h"
 #include "sha.h"
+#include "sha2.h"
 #include "misc.h"
 #include "common.h"
 #include "formats.h"

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -10,6 +10,12 @@
  *
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_rvary;
 #elif FMT_REGISTERS_H
@@ -320,3 +326,4 @@ struct fmt_main fmt_rvary = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/sap_pse_fmt_plug.c
+++ b/src/sap_pse_fmt_plug.c
@@ -11,6 +11,12 @@
  * for making this work possible.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_sappse;
 #elif FMT_REGISTERS_H
@@ -243,3 +249,4 @@ struct fmt_main fmt_sappse = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/sha.h
+++ b/src/sha.h
@@ -1,7 +1,11 @@
 #ifndef JOHN_SHA_H
 #define JOHN_SHA_H
 
-#include "aligned.h"
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 #include <openssl/opensslv.h>
 
 #include "arch.h"
@@ -23,4 +27,31 @@
 #else
 #include <openssl/sha.h>
 #endif
+
+/* For the abuse in pbkdf2_hmac_sha1.h and mscash2_fmt_plug.c */
+#define SHA_H0 h0
+#define SHA_H1 h1
+#define SHA_H2 h2
+#define SHA_H3 h3
+#define SHA_H4 h4
+
+#else /* !(HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO) */
+#include "sph_sha1.h"
+#define SHA_CTX sph_sha1_context
+#define SHA1_Init sph_sha1_init
+#define SHA1_Update sph_sha1
+#define SHA1_Final(dst, ctx) sph_sha1_close((ctx), (dst))
+#define SHA_CBLOCK 64
+#define SHA_LBLOCK 16
+#define SHA_H0 val[0]
+#define SHA_H1 val[1]
+#define SHA_H2 val[2]
+#define SHA_H3 val[3]
+#define SHA_H4 val[4]
+#endif
+
+#ifndef SHA_DIGEST_LENGTH
+#define SHA_DIGEST_LENGTH 20
+#endif
+
 #endif

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -1,0 +1,378 @@
+/* $Id: sha1.c 216 2010-06-08 09:46:57Z tp $ */
+/*
+ * SHA-1 implementation.
+ *
+ * ==========================(LICENSE BEGIN)============================
+ *
+ * Copyright (c) 2007-2010  Projet RNRT SAPHIR
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * ===========================(LICENSE END)=============================
+ *
+ * @author   Thomas Pornin <thomas.pornin@cryptolog.com>
+ */
+
+#include <stddef.h>
+#include <string.h>
+
+#include "sph_sha1.h"
+
+#define F(B, C, D)     ((((C) ^ (D)) & (B)) ^ (D))
+#define G(B, C, D)     ((B) ^ (C) ^ (D))
+#define H(B, C, D)     (((D) & (C)) | (((D) | (C)) & (B)))
+#define I(B, C, D)     G(B, C, D)
+
+#define ROTL    SPH_ROTL32
+
+#define K1     SPH_C32(0x5A827999)
+#define K2     SPH_C32(0x6ED9EBA1)
+#define K3     SPH_C32(0x8F1BBCDC)
+#define K4     SPH_C32(0xCA62C1D6)
+
+static const sph_u32 IV[5] = {
+	SPH_C32(0x67452301), SPH_C32(0xEFCDAB89),
+	SPH_C32(0x98BADCFE), SPH_C32(0x10325476),
+	SPH_C32(0xC3D2E1F0)
+};
+
+/*
+ * This macro defines the body for a SHA-1 compression function
+ * implementation. The "in" parameter should evaluate, when applied to a
+ * numerical input parameter from 0 to 15, to an expression which yields
+ * the corresponding input block. The "r" parameter should evaluate to
+ * an array or pointer expression designating the array of 5 words which
+ * contains the input and output of the compression function.
+ */
+
+#define SHA1_ROUND_BODY(in, r)   do { \
+		sph_u32 A, B, C, D, E; \
+		sph_u32 W00, W01, W02, W03, W04, W05, W06, W07; \
+		sph_u32 W08, W09, W10, W11, W12, W13, W14, W15; \
+ \
+		A = (r)[0]; \
+		B = (r)[1]; \
+		C = (r)[2]; \
+		D = (r)[3]; \
+		E = (r)[4]; \
+ \
+		W00 = in(0); \
+		E = SPH_T32(ROTL(A, 5) + F(B, C, D) + E + W00 + K1); \
+		B = ROTL(B, 30); \
+		W01 = in(1); \
+		D = SPH_T32(ROTL(E, 5) + F(A, B, C) + D + W01 + K1); \
+		A = ROTL(A, 30); \
+		W02 = in(2); \
+		C = SPH_T32(ROTL(D, 5) + F(E, A, B) + C + W02 + K1); \
+		E = ROTL(E, 30); \
+		W03 = in(3); \
+		B = SPH_T32(ROTL(C, 5) + F(D, E, A) + B + W03 + K1); \
+		D = ROTL(D, 30); \
+		W04 = in(4); \
+		A = SPH_T32(ROTL(B, 5) + F(C, D, E) + A + W04 + K1); \
+		C = ROTL(C, 30); \
+		W05 = in(5); \
+		E = SPH_T32(ROTL(A, 5) + F(B, C, D) + E + W05 + K1); \
+		B = ROTL(B, 30); \
+		W06 = in(6); \
+		D = SPH_T32(ROTL(E, 5) + F(A, B, C) + D + W06 + K1); \
+		A = ROTL(A, 30); \
+		W07 = in(7); \
+		C = SPH_T32(ROTL(D, 5) + F(E, A, B) + C + W07 + K1); \
+		E = ROTL(E, 30); \
+		W08 = in(8); \
+		B = SPH_T32(ROTL(C, 5) + F(D, E, A) + B + W08 + K1); \
+		D = ROTL(D, 30); \
+		W09 = in(9); \
+		A = SPH_T32(ROTL(B, 5) + F(C, D, E) + A + W09 + K1); \
+		C = ROTL(C, 30); \
+		W10 = in(10); \
+		E = SPH_T32(ROTL(A, 5) + F(B, C, D) + E + W10 + K1); \
+		B = ROTL(B, 30); \
+		W11 = in(11); \
+		D = SPH_T32(ROTL(E, 5) + F(A, B, C) + D + W11 + K1); \
+		A = ROTL(A, 30); \
+		W12 = in(12); \
+		C = SPH_T32(ROTL(D, 5) + F(E, A, B) + C + W12 + K1); \
+		E = ROTL(E, 30); \
+		W13 = in(13); \
+		B = SPH_T32(ROTL(C, 5) + F(D, E, A) + B + W13 + K1); \
+		D = ROTL(D, 30); \
+		W14 = in(14); \
+		A = SPH_T32(ROTL(B, 5) + F(C, D, E) + A + W14 + K1); \
+		C = ROTL(C, 30); \
+		W15 = in(15); \
+		E = SPH_T32(ROTL(A, 5) + F(B, C, D) + E + W15 + K1); \
+		B = ROTL(B, 30); \
+		W00 = ROTL(W13 ^ W08 ^ W02 ^ W00, 1); \
+		D = SPH_T32(ROTL(E, 5) + F(A, B, C) + D + W00 + K1); \
+		A = ROTL(A, 30); \
+		W01 = ROTL(W14 ^ W09 ^ W03 ^ W01, 1); \
+		C = SPH_T32(ROTL(D, 5) + F(E, A, B) + C + W01 + K1); \
+		E = ROTL(E, 30); \
+		W02 = ROTL(W15 ^ W10 ^ W04 ^ W02, 1); \
+		B = SPH_T32(ROTL(C, 5) + F(D, E, A) + B + W02 + K1); \
+		D = ROTL(D, 30); \
+		W03 = ROTL(W00 ^ W11 ^ W05 ^ W03, 1); \
+		A = SPH_T32(ROTL(B, 5) + F(C, D, E) + A + W03 + K1); \
+		C = ROTL(C, 30); \
+		W04 = ROTL(W01 ^ W12 ^ W06 ^ W04, 1); \
+		E = SPH_T32(ROTL(A, 5) + G(B, C, D) + E + W04 + K2); \
+		B = ROTL(B, 30); \
+		W05 = ROTL(W02 ^ W13 ^ W07 ^ W05, 1); \
+		D = SPH_T32(ROTL(E, 5) + G(A, B, C) + D + W05 + K2); \
+		A = ROTL(A, 30); \
+		W06 = ROTL(W03 ^ W14 ^ W08 ^ W06, 1); \
+		C = SPH_T32(ROTL(D, 5) + G(E, A, B) + C + W06 + K2); \
+		E = ROTL(E, 30); \
+		W07 = ROTL(W04 ^ W15 ^ W09 ^ W07, 1); \
+		B = SPH_T32(ROTL(C, 5) + G(D, E, A) + B + W07 + K2); \
+		D = ROTL(D, 30); \
+		W08 = ROTL(W05 ^ W00 ^ W10 ^ W08, 1); \
+		A = SPH_T32(ROTL(B, 5) + G(C, D, E) + A + W08 + K2); \
+		C = ROTL(C, 30); \
+		W09 = ROTL(W06 ^ W01 ^ W11 ^ W09, 1); \
+		E = SPH_T32(ROTL(A, 5) + G(B, C, D) + E + W09 + K2); \
+		B = ROTL(B, 30); \
+		W10 = ROTL(W07 ^ W02 ^ W12 ^ W10, 1); \
+		D = SPH_T32(ROTL(E, 5) + G(A, B, C) + D + W10 + K2); \
+		A = ROTL(A, 30); \
+		W11 = ROTL(W08 ^ W03 ^ W13 ^ W11, 1); \
+		C = SPH_T32(ROTL(D, 5) + G(E, A, B) + C + W11 + K2); \
+		E = ROTL(E, 30); \
+		W12 = ROTL(W09 ^ W04 ^ W14 ^ W12, 1); \
+		B = SPH_T32(ROTL(C, 5) + G(D, E, A) + B + W12 + K2); \
+		D = ROTL(D, 30); \
+		W13 = ROTL(W10 ^ W05 ^ W15 ^ W13, 1); \
+		A = SPH_T32(ROTL(B, 5) + G(C, D, E) + A + W13 + K2); \
+		C = ROTL(C, 30); \
+		W14 = ROTL(W11 ^ W06 ^ W00 ^ W14, 1); \
+		E = SPH_T32(ROTL(A, 5) + G(B, C, D) + E + W14 + K2); \
+		B = ROTL(B, 30); \
+		W15 = ROTL(W12 ^ W07 ^ W01 ^ W15, 1); \
+		D = SPH_T32(ROTL(E, 5) + G(A, B, C) + D + W15 + K2); \
+		A = ROTL(A, 30); \
+		W00 = ROTL(W13 ^ W08 ^ W02 ^ W00, 1); \
+		C = SPH_T32(ROTL(D, 5) + G(E, A, B) + C + W00 + K2); \
+		E = ROTL(E, 30); \
+		W01 = ROTL(W14 ^ W09 ^ W03 ^ W01, 1); \
+		B = SPH_T32(ROTL(C, 5) + G(D, E, A) + B + W01 + K2); \
+		D = ROTL(D, 30); \
+		W02 = ROTL(W15 ^ W10 ^ W04 ^ W02, 1); \
+		A = SPH_T32(ROTL(B, 5) + G(C, D, E) + A + W02 + K2); \
+		C = ROTL(C, 30); \
+		W03 = ROTL(W00 ^ W11 ^ W05 ^ W03, 1); \
+		E = SPH_T32(ROTL(A, 5) + G(B, C, D) + E + W03 + K2); \
+		B = ROTL(B, 30); \
+		W04 = ROTL(W01 ^ W12 ^ W06 ^ W04, 1); \
+		D = SPH_T32(ROTL(E, 5) + G(A, B, C) + D + W04 + K2); \
+		A = ROTL(A, 30); \
+		W05 = ROTL(W02 ^ W13 ^ W07 ^ W05, 1); \
+		C = SPH_T32(ROTL(D, 5) + G(E, A, B) + C + W05 + K2); \
+		E = ROTL(E, 30); \
+		W06 = ROTL(W03 ^ W14 ^ W08 ^ W06, 1); \
+		B = SPH_T32(ROTL(C, 5) + G(D, E, A) + B + W06 + K2); \
+		D = ROTL(D, 30); \
+		W07 = ROTL(W04 ^ W15 ^ W09 ^ W07, 1); \
+		A = SPH_T32(ROTL(B, 5) + G(C, D, E) + A + W07 + K2); \
+		C = ROTL(C, 30); \
+		W08 = ROTL(W05 ^ W00 ^ W10 ^ W08, 1); \
+		E = SPH_T32(ROTL(A, 5) + H(B, C, D) + E + W08 + K3); \
+		B = ROTL(B, 30); \
+		W09 = ROTL(W06 ^ W01 ^ W11 ^ W09, 1); \
+		D = SPH_T32(ROTL(E, 5) + H(A, B, C) + D + W09 + K3); \
+		A = ROTL(A, 30); \
+		W10 = ROTL(W07 ^ W02 ^ W12 ^ W10, 1); \
+		C = SPH_T32(ROTL(D, 5) + H(E, A, B) + C + W10 + K3); \
+		E = ROTL(E, 30); \
+		W11 = ROTL(W08 ^ W03 ^ W13 ^ W11, 1); \
+		B = SPH_T32(ROTL(C, 5) + H(D, E, A) + B + W11 + K3); \
+		D = ROTL(D, 30); \
+		W12 = ROTL(W09 ^ W04 ^ W14 ^ W12, 1); \
+		A = SPH_T32(ROTL(B, 5) + H(C, D, E) + A + W12 + K3); \
+		C = ROTL(C, 30); \
+		W13 = ROTL(W10 ^ W05 ^ W15 ^ W13, 1); \
+		E = SPH_T32(ROTL(A, 5) + H(B, C, D) + E + W13 + K3); \
+		B = ROTL(B, 30); \
+		W14 = ROTL(W11 ^ W06 ^ W00 ^ W14, 1); \
+		D = SPH_T32(ROTL(E, 5) + H(A, B, C) + D + W14 + K3); \
+		A = ROTL(A, 30); \
+		W15 = ROTL(W12 ^ W07 ^ W01 ^ W15, 1); \
+		C = SPH_T32(ROTL(D, 5) + H(E, A, B) + C + W15 + K3); \
+		E = ROTL(E, 30); \
+		W00 = ROTL(W13 ^ W08 ^ W02 ^ W00, 1); \
+		B = SPH_T32(ROTL(C, 5) + H(D, E, A) + B + W00 + K3); \
+		D = ROTL(D, 30); \
+		W01 = ROTL(W14 ^ W09 ^ W03 ^ W01, 1); \
+		A = SPH_T32(ROTL(B, 5) + H(C, D, E) + A + W01 + K3); \
+		C = ROTL(C, 30); \
+		W02 = ROTL(W15 ^ W10 ^ W04 ^ W02, 1); \
+		E = SPH_T32(ROTL(A, 5) + H(B, C, D) + E + W02 + K3); \
+		B = ROTL(B, 30); \
+		W03 = ROTL(W00 ^ W11 ^ W05 ^ W03, 1); \
+		D = SPH_T32(ROTL(E, 5) + H(A, B, C) + D + W03 + K3); \
+		A = ROTL(A, 30); \
+		W04 = ROTL(W01 ^ W12 ^ W06 ^ W04, 1); \
+		C = SPH_T32(ROTL(D, 5) + H(E, A, B) + C + W04 + K3); \
+		E = ROTL(E, 30); \
+		W05 = ROTL(W02 ^ W13 ^ W07 ^ W05, 1); \
+		B = SPH_T32(ROTL(C, 5) + H(D, E, A) + B + W05 + K3); \
+		D = ROTL(D, 30); \
+		W06 = ROTL(W03 ^ W14 ^ W08 ^ W06, 1); \
+		A = SPH_T32(ROTL(B, 5) + H(C, D, E) + A + W06 + K3); \
+		C = ROTL(C, 30); \
+		W07 = ROTL(W04 ^ W15 ^ W09 ^ W07, 1); \
+		E = SPH_T32(ROTL(A, 5) + H(B, C, D) + E + W07 + K3); \
+		B = ROTL(B, 30); \
+		W08 = ROTL(W05 ^ W00 ^ W10 ^ W08, 1); \
+		D = SPH_T32(ROTL(E, 5) + H(A, B, C) + D + W08 + K3); \
+		A = ROTL(A, 30); \
+		W09 = ROTL(W06 ^ W01 ^ W11 ^ W09, 1); \
+		C = SPH_T32(ROTL(D, 5) + H(E, A, B) + C + W09 + K3); \
+		E = ROTL(E, 30); \
+		W10 = ROTL(W07 ^ W02 ^ W12 ^ W10, 1); \
+		B = SPH_T32(ROTL(C, 5) + H(D, E, A) + B + W10 + K3); \
+		D = ROTL(D, 30); \
+		W11 = ROTL(W08 ^ W03 ^ W13 ^ W11, 1); \
+		A = SPH_T32(ROTL(B, 5) + H(C, D, E) + A + W11 + K3); \
+		C = ROTL(C, 30); \
+		W12 = ROTL(W09 ^ W04 ^ W14 ^ W12, 1); \
+		E = SPH_T32(ROTL(A, 5) + I(B, C, D) + E + W12 + K4); \
+		B = ROTL(B, 30); \
+		W13 = ROTL(W10 ^ W05 ^ W15 ^ W13, 1); \
+		D = SPH_T32(ROTL(E, 5) + I(A, B, C) + D + W13 + K4); \
+		A = ROTL(A, 30); \
+		W14 = ROTL(W11 ^ W06 ^ W00 ^ W14, 1); \
+		C = SPH_T32(ROTL(D, 5) + I(E, A, B) + C + W14 + K4); \
+		E = ROTL(E, 30); \
+		W15 = ROTL(W12 ^ W07 ^ W01 ^ W15, 1); \
+		B = SPH_T32(ROTL(C, 5) + I(D, E, A) + B + W15 + K4); \
+		D = ROTL(D, 30); \
+		W00 = ROTL(W13 ^ W08 ^ W02 ^ W00, 1); \
+		A = SPH_T32(ROTL(B, 5) + I(C, D, E) + A + W00 + K4); \
+		C = ROTL(C, 30); \
+		W01 = ROTL(W14 ^ W09 ^ W03 ^ W01, 1); \
+		E = SPH_T32(ROTL(A, 5) + I(B, C, D) + E + W01 + K4); \
+		B = ROTL(B, 30); \
+		W02 = ROTL(W15 ^ W10 ^ W04 ^ W02, 1); \
+		D = SPH_T32(ROTL(E, 5) + I(A, B, C) + D + W02 + K4); \
+		A = ROTL(A, 30); \
+		W03 = ROTL(W00 ^ W11 ^ W05 ^ W03, 1); \
+		C = SPH_T32(ROTL(D, 5) + I(E, A, B) + C + W03 + K4); \
+		E = ROTL(E, 30); \
+		W04 = ROTL(W01 ^ W12 ^ W06 ^ W04, 1); \
+		B = SPH_T32(ROTL(C, 5) + I(D, E, A) + B + W04 + K4); \
+		D = ROTL(D, 30); \
+		W05 = ROTL(W02 ^ W13 ^ W07 ^ W05, 1); \
+		A = SPH_T32(ROTL(B, 5) + I(C, D, E) + A + W05 + K4); \
+		C = ROTL(C, 30); \
+		W06 = ROTL(W03 ^ W14 ^ W08 ^ W06, 1); \
+		E = SPH_T32(ROTL(A, 5) + I(B, C, D) + E + W06 + K4); \
+		B = ROTL(B, 30); \
+		W07 = ROTL(W04 ^ W15 ^ W09 ^ W07, 1); \
+		D = SPH_T32(ROTL(E, 5) + I(A, B, C) + D + W07 + K4); \
+		A = ROTL(A, 30); \
+		W08 = ROTL(W05 ^ W00 ^ W10 ^ W08, 1); \
+		C = SPH_T32(ROTL(D, 5) + I(E, A, B) + C + W08 + K4); \
+		E = ROTL(E, 30); \
+		W09 = ROTL(W06 ^ W01 ^ W11 ^ W09, 1); \
+		B = SPH_T32(ROTL(C, 5) + I(D, E, A) + B + W09 + K4); \
+		D = ROTL(D, 30); \
+		W10 = ROTL(W07 ^ W02 ^ W12 ^ W10, 1); \
+		A = SPH_T32(ROTL(B, 5) + I(C, D, E) + A + W10 + K4); \
+		C = ROTL(C, 30); \
+		W11 = ROTL(W08 ^ W03 ^ W13 ^ W11, 1); \
+		E = SPH_T32(ROTL(A, 5) + I(B, C, D) + E + W11 + K4); \
+		B = ROTL(B, 30); \
+		W12 = ROTL(W09 ^ W04 ^ W14 ^ W12, 1); \
+		D = SPH_T32(ROTL(E, 5) + I(A, B, C) + D + W12 + K4); \
+		A = ROTL(A, 30); \
+		W13 = ROTL(W10 ^ W05 ^ W15 ^ W13, 1); \
+		C = SPH_T32(ROTL(D, 5) + I(E, A, B) + C + W13 + K4); \
+		E = ROTL(E, 30); \
+		W14 = ROTL(W11 ^ W06 ^ W00 ^ W14, 1); \
+		B = SPH_T32(ROTL(C, 5) + I(D, E, A) + B + W14 + K4); \
+		D = ROTL(D, 30); \
+		W15 = ROTL(W12 ^ W07 ^ W01 ^ W15, 1); \
+		A = SPH_T32(ROTL(B, 5) + I(C, D, E) + A + W15 + K4); \
+		C = ROTL(C, 30); \
+ \
+		(r)[0] = SPH_T32(r[0] + A); \
+		(r)[1] = SPH_T32(r[1] + B); \
+		(r)[2] = SPH_T32(r[2] + C); \
+		(r)[3] = SPH_T32(r[3] + D); \
+		(r)[4] = SPH_T32(r[4] + E); \
+	} while (0)
+
+/*
+ * One round of SHA-1. The data must be aligned for 32-bit access.
+ */
+static void
+sha1_round(const unsigned char *data, sph_u32 r[5])
+{
+#define SHA1_IN(x)   sph_dec32be_aligned(data + (4 * (x)))
+	SHA1_ROUND_BODY(SHA1_IN, r);
+#undef SHA1_IN
+}
+
+/* see sph_sha1.h */
+void
+sph_sha1_init(void *cc)
+{
+	sph_sha1_context *sc;
+
+	sc = cc;
+	memcpy(sc->val, IV, sizeof IV);
+#if SPH_64
+	sc->count = 0;
+#else
+	sc->count_high = sc->count_low = 0;
+#endif
+}
+
+#define RFUN   sha1_round
+#define HASH   sha1
+#define BE32   1
+#include "md_helper.c"
+
+/* see sph_sha1.h */
+void
+sph_sha1_close(void *cc, void *dst)
+{
+	sha1_close(cc, dst, 5);
+	sph_sha1_init(cc);
+}
+
+/* see sph_sha1.h */
+void
+sph_sha1_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
+{
+	sha1_addbits_and_close(cc, ub, n, dst, 5);
+	sph_sha1_init(cc);
+}
+
+/* see sph_sha1.h */
+void
+sph_sha1_comp(const sph_u32 msg[16], sph_u32 val[5])
+{
+#define SHA1_IN(x)   msg[x]
+	SHA1_ROUND_BODY(SHA1_IN, val);
+#undef SHA1_IN
+}

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -30,6 +30,8 @@
  * @author   Thomas Pornin <thomas.pornin@cryptolog.com>
  */
 
+#if !(HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
+
 #include <stddef.h>
 #include <string.h>
 
@@ -357,9 +359,12 @@ void
 sph_sha1_close(void *cc, void *dst)
 {
 	sha1_close(cc, dst, 5);
+#if 0 /* JtR hack: our PBKDF2 code relies on hash value staying after Final */
 	sph_sha1_init(cc);
+#endif
 }
 
+#if 0 /* JtR hack: this would be dead code */
 /* see sph_sha1.h */
 void
 sph_sha1_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst)
@@ -376,3 +381,6 @@ sph_sha1_comp(const sph_u32 msg[16], sph_u32 val[5])
 	SHA1_ROUND_BODY(SHA1_IN, val);
 #undef SHA1_IN
 }
+#endif /* dead code */
+
+#endif /* OpenSSL */

--- a/src/sha2.h
+++ b/src/sha2.h
@@ -34,7 +34,11 @@
 #include <stdint.h>
 #include "arch.h"
 #include "aligned.h"
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 #include <openssl/opensslv.h>
+#elif !defined(FORCE_GENERIC_SHA2)
+#define FORCE_GENERIC_SHA2 1
+#endif
 #include "openssl_local_overrides.h"
 
 #if (AC_BUILT && HAVE_SHA256 && !FORCE_GENERIC_SHA2) ||	  \
@@ -60,7 +64,9 @@
 
 #else	// OPENSSL_VERSION_NUMBER ! >= 0x00908000
 
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 #include <openssl/sha.h>
+#endif
 #include "jtr_sha2.h"
 
 #define SHA2_LIB
@@ -75,6 +81,22 @@
  * - It must be available for a SIMD or non-SIMD build.
  */
 void sha512_reverse(uint64_t *hash);
+#endif
+
+#ifndef SHA224_DIGEST_LENGTH
+#define SHA224_DIGEST_LENGTH 28
+#endif
+
+#ifndef SHA256_DIGEST_LENGTH
+#define SHA256_DIGEST_LENGTH 32
+#endif
+
+#ifndef SHA384_DIGEST_LENGTH
+#define SHA384_DIGEST_LENGTH 48
+#endif
+
+#ifndef SHA512_DIGEST_LENGTH
+#define SHA512_DIGEST_LENGTH 64
 #endif
 
 #endif /* _JOHN_SHA2_h */

--- a/src/solarwinds_fmt_plug.c
+++ b/src/solarwinds_fmt_plug.c
@@ -38,6 +38,7 @@ john_register_one(&fmt_solarwinds);
 #include "params.h"
 #include "options.h"
 #include "sha.h"
+#include "sha2.h"
 #include "jumbo.h"
 #include "johnswap.h"
 #include "solarwinds_common.h"

--- a/src/sph_sha1.h
+++ b/src/sph_sha1.h
@@ -1,0 +1,131 @@
+/* $Id: sph_sha1.h 216 2010-06-08 09:46:57Z tp $ */
+/**
+ * SHA-1 interface.
+ *
+ * SHA-1 is described in FIPS 180-1 (now superseded by FIPS 180-2, but the
+ * description of SHA-1 is still included and has not changed). FIPS
+ * standards can be found at: http://csrc.nist.gov/publications/fips/
+ *
+ * @warning   A theoretical collision attack against SHA-1, with work
+ * factor 2^63, has been published. SHA-1 should not be used in new
+ * protocol designs.
+ *
+ * ==========================(LICENSE BEGIN)============================
+ *
+ * Copyright (c) 2007-2010  Projet RNRT SAPHIR
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * ===========================(LICENSE END)=============================
+ *
+ * @file     sph_sha1.h
+ * @author   Thomas Pornin <thomas.pornin@cryptolog.com>
+ */
+
+#ifndef SPH_SHA1_H__
+#define SPH_SHA1_H__
+
+#include <stddef.h>
+#include "sph_types.h"
+
+/**
+ * Output size (in bits) for SHA-1.
+ */
+#define SPH_SIZE_sha1   160
+
+/**
+ * This structure is a context for SHA-1 computations: it contains the
+ * intermediate values and some data from the last entered block. Once
+ * a SHA-1 computation has been performed, the context can be reused for
+ * another computation.
+ *
+ * The contents of this structure are private. A running SHA-1 computation
+ * can be cloned by copying the context (e.g. with a simple
+ * <code>memcpy()</code>).
+ */
+typedef struct {
+#ifndef DOXYGEN_IGNORE
+	unsigned char buf[64];    /* first field, for alignment */
+	sph_u32 val[5];
+#if SPH_64
+	sph_u64 count;
+#else
+	sph_u32 count_high, count_low;
+#endif
+#endif
+} sph_sha1_context;
+
+/**
+ * Initialize a SHA-1 context. This process performs no memory allocation.
+ *
+ * @param cc   the SHA-1 context (pointer to a <code>sph_sha1_context</code>)
+ */
+void sph_sha1_init(void *cc);
+
+/**
+ * Process some data bytes. It is acceptable that <code>len</code> is zero
+ * (in which case this function does nothing).
+ *
+ * @param cc     the SHA-1 context
+ * @param data   the input data
+ * @param len    the input data length (in bytes)
+ */
+void sph_sha1(void *cc, const void *data, size_t len);
+
+/**
+ * Terminate the current SHA-1 computation and output the result into the
+ * provided buffer. The destination buffer must be wide enough to
+ * accomodate the result (20 bytes). The context is automatically
+ * reinitialized.
+ *
+ * @param cc    the SHA-1 context
+ * @param dst   the destination buffer
+ */
+void sph_sha1_close(void *cc, void *dst);
+
+/**
+ * Add a few additional bits (0 to 7) to the current computation, then
+ * terminate it and output the result in the provided buffer, which must
+ * be wide enough to accomodate the result (20 bytes). If bit number i
+ * in <code>ub</code> has value 2^i, then the extra bits are those
+ * numbered 7 downto 8-n (this is the big-endian convention at the byte
+ * level). The context is automatically reinitialized.
+ *
+ * @param cc    the SHA-1 context
+ * @param ub    the extra bits
+ * @param n     the number of extra bits (0 to 7)
+ * @param dst   the destination buffer
+ */
+void sph_sha1_addbits_and_close(void *cc, unsigned ub, unsigned n, void *dst);
+
+/**
+ * Apply the SHA-1 compression function on the provided data. The
+ * <code>msg</code> parameter contains the 16 32-bit input blocks,
+ * as numerical values (hence after the big-endian decoding). The
+ * <code>val</code> parameter contains the 5 32-bit input blocks for
+ * the compression function; the output is written in place in this
+ * array.
+ *
+ * @param msg   the message block (16 values)
+ * @param val   the function 160-bit input and output
+ */
+void sph_sha1_comp(const sph_u32 msg[16], sph_u32 val[5]);
+
+#endif

--- a/src/ssh_fmt_plug.c
+++ b/src/ssh_fmt_plug.c
@@ -20,6 +20,12 @@
  * modification, are permitted.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_ssh;
 #elif FMT_REGISTERS_H
@@ -555,3 +561,4 @@ struct fmt_main fmt_ssh = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/telegram_common_plug.c
+++ b/src/telegram_common_plug.c
@@ -5,6 +5,12 @@
  * and the GPU formats, and places it into one common location.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #include "arch.h"
 /* We undefine these locally, for scalar PBKDF2 functions used in check_unset_password() */
 #undef SIMD_COEF_32
@@ -197,3 +203,5 @@ unsigned int telegram_iteration_count(void *salt)
 
 	return cs->iterations;
 }
+
+#endif /* OpenSSL */

--- a/src/telegram_fmt_plug.c
+++ b/src/telegram_fmt_plug.c
@@ -11,6 +11,12 @@
  * making this work possible.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_telegram;
 #elif FMT_REGISTERS_H
@@ -271,3 +277,4 @@ struct fmt_main fmt_telegram = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/vnc_fmt_plug.c
+++ b/src/vnc_fmt_plug.c
@@ -24,6 +24,12 @@
  * 02111-1307 USA.
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_vnc;
 #elif FMT_REGISTERS_H
@@ -345,3 +351,4 @@ struct fmt_main fmt_vnc = {
 };
 
 #endif /* plugin stanza */
+#endif /* OpenSSL */

--- a/src/whirlpool_fmt_plug.c
+++ b/src/whirlpool_fmt_plug.c
@@ -33,7 +33,12 @@ john_register_one(&fmt_whirlpool);
 #include "options.h"
 #include "sph_whirlpool.h"
 #include "openssl_local_overrides.h"
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
 #include <openssl/opensslv.h>
+#endif
 #if (AC_BUILT && HAVE_WHIRLPOOL) ||	\
    (!AC_BUILT && OPENSSL_VERSION_NUMBER >= 0x10000000 && !HAVE_NO_SSL_WHIRLPOOL)
 #include <openssl/whrlpool.h>

--- a/src/wow_srp_fmt_plug.c
+++ b/src/wow_srp_fmt_plug.c
@@ -41,16 +41,21 @@
  * NOTE, we need to add split() to canonize this format (remove LPad 0's)
  */
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if !AC_BUILT && !__MIC__
+#define HAVE_LIBGMP 1 /* legacy build uses libgmp by default, except for MIC */
+#endif
+
+#if HAVE_LIBGMP || HAVE_LIBCRYPTO /* we need one of these for bignum */
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_blizzard;
 #elif FMT_REGISTERS_H
 john_register_one(&fmt_blizzard);
 #else
-
-#if AC_BUILT
-/* we need to know if HAVE_LIBGMP is defined */
-#include "autoconfig.h"
-#endif
 
 #include <string.h>
 #ifdef HAVE_LIBGMP
@@ -566,3 +571,4 @@ struct fmt_main fmt_blizzard = {
 };
 
 #endif /* plugin stanza */
+#endif /* HAVE_LIBGMP || HAVE_LIBCRYPTO */

--- a/src/wpapmk_fmt_plug.c
+++ b/src/wpapmk_fmt_plug.c
@@ -30,11 +30,11 @@ john_register_one(&fmt_wpapsk_pmk);
 #include "john.h"
 
 #define FORMAT_LABEL		"wpapsk-pmk"
-#if AC_BUILT && !HAVE_OPENSSL_CMAC_H
+#if !HAVE_OPENSSL_CMAC_H
 #ifdef _MSC_VER
-#pragma message ("Notice: WPAPSK-PMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.")
+#pragma message("Notice: WPAPSK-PMK (CPU) format built without support for 802.11w (this needs recent OpenSSL)")
 #else
-#warning Notice: WPAPSK-PMK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.
+#warning Notice: WPAPSK-PMK (CPU) format built without support for 802.11w (this needs recent OpenSSL)
 #endif
 #define FORMAT_NAME		"WPA/WPA2/PMKID master key"
 #else

--- a/src/wpapsk.h
+++ b/src/wpapsk.h
@@ -12,9 +12,19 @@
 #ifndef _WPAPSK_H
 #define _WPAPSK_H
 
+#if AC_BUILT
+#include "autoconfig.h"
+#endif
+
+#if !HAVE_LIBCRYPTO
+#undef HAVE_OPENSSL_CMAC_H
+#elif !AC_BUILT && HAVE_LIBCRYPTO && !defined(HAVE_OPENSSL_CMAC_H)
+#define HAVE_OPENSSL_CMAC_H 1
+#endif
+
 #include <stdint.h>
 #include <assert.h>
-#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
+#if HAVE_OPENSSL_CMAC_H
 #include <openssl/cmac.h>
 #endif
 
@@ -78,7 +88,7 @@ static struct fmt_tests tests[] = {
 #ifdef WPAPMK
 	{"$WPAPSK$test#..qHuv0A..ZPYJBRzZwAKpEXUJwpza/b69itFaq4.OWoGHfonpc13zCAUsRIfQN2Zar6EXp2BYcRuSkWEJIWjEJJvb4DWZCspbZ51.21.3zy.EY.6........../zZwAKpEXUJwpza/b69itFaq4.OWoGHfonpc13zCAUsQ..................................................................BoK.31m.E2..31m.U2..31m.U2..31m.U................................................................................................................................................................................/X.....E...AkkDQmDg9837LBHG.dGlKA", "cdd79a5acfb070c7e9d1023b870285d639e430b32f31aa37ac825a55b55524ee"},
 	{"$WPAPSK$Coherer#..l/Uf7J..qHUXMunTE3nfbMWSwxv27Ua0XutIOrfRSuv9gOCIugIVGlosMyXdNxfBZUAYmgKqeb6GBPxLiIZr56NtWTGR/Cp5ldAk61.5I0.Ec.2...........nTE3nfbMWSwxv27Ua0XutIOrfRSuv9gOCIugIVGlosM.................................................................3X.I.E..1uk0.E..1uk2.E..1uk0....................................................................................................................................................................................../t.....U...8FWdk8OpPckhewBwt4MXYI", "a288fcf0caaacda9a9f58633ff35e8992a01d9c10ba5e02efdf8cb5d730ce7bc"},
-#if (!AC_BUILT || HAVE_OPENSSL_CMAC_H) || defined(JOHN_OCL_WPAPSK)
+#if HAVE_OPENSSL_CMAC_H || defined(JOHN_OCL_WPAPSK)
 	{"$WPAPSK$Neheb#g9a8Jcre9D0WrPnEN4QXDbA5NwAy5TVpkuoChMdFfL/8Dus4i/X.lTnfwuw04ASqHgvo12wJYJywulb6pWM6C5uqiMPNKNe9pkr6LE61.5I0.Eg.2..........1N4QXDbA5NwAy5TVpkuoChMdFfL/8Dus4i/X.lTnfwuw.................................................................3X.I.E..1uk2.E..1uk2.E..1uk4X...................................................................................................................................................................................../t.....k...0sHl.mVkiHW.ryNchcMd4g", "fb57668cd338374412c26208d79aa5c30ce40a110224f3cfb592a8f2e8bf53e8"},
 #endif
 	/* WPAPSK PMKID */
@@ -92,7 +102,7 @@ static struct fmt_tests tests[] = {
 	/* Maximum length, 63 characters */
 	{"$WPAPSK$Greased Lighting#kA5.CDNB.07cofsOMXEEUwFTkO/RX2sQUaW9eteI8ynpFMwRgFZC6kk7bGqgvfcXnuF1f7L5fgn4fQMLmDrKjdBNjb6LClRmfLiTYk21.5I0.Ec............7MXEEUwFTkO/RX2sQUaW9eteI8ynpFMwRgFZC6kk7bGo.................................................................3X.I.E..1uk2.E..1uk2.E..1uk00...................................................................................................................................................................................../t.....U...D06LUdWVfGPaP1Oa3AV9Hg", "W*A5z&1?op2_L&Hla-OA$#5i_Lu@F+6d?je?u5!6+6766eluu7-l+jOEkIwLe90"},
 	{"$WPAPSK$hello#JUjQmBbOHUY4RTqMpGc9EjqGdCxMZPWNXBNd1ejNDoFuemrLl27juYlDDUDMgZfery1qJTHYVn2Faso/kUDDjr3y8gspK7viz8BCJE21.5I0.Ec............/pGc9EjqGdCxMZPWNXBNd1ejNDoFuemrLl27juYlDDUA.................................................................3X.I.E..1uk2.E..1uk2.E..1uk0....................................................................................................................................................................................../t.....U...9Py59nqygwiar49oOKA3RY", "12345678"},
-#if (!AC_BUILT || HAVE_OPENSSL_CMAC_H) || defined(JOHN_OCL_WPAPSK)
+#if HAVE_OPENSSL_CMAC_H || defined(JOHN_OCL_WPAPSK)
 	/* 802.11w with WPA-PSK-SHA256 */
 	{"$WPAPSK$hello#HY6.hTXZv.v27BkPGuhkCnLAKxYHlTWYs.4yuqVSNAip3SeixhErtNMV30LZAA3uaEfy2U2tJQi.VICk4hqn3V5m7W3lNHSJYW5vLE21.5I0.Eg............/GuhkCnLAKxYHlTWYs.4yuqVSNAip3SeixhErtNMV30I.................................................................3X.I.E..1uk2.E..1uk2.E..1uk4....................................................................................................................................................................................../t.....k.../Ms4UxzvlNw5hOM1igIeo6", "password"},
 	/* 802.11w with WPA-PSK-SHA256, https://github.com/neheb */
@@ -322,7 +332,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		return 0;
 	if (hccap->keyver < 1)
 		return 0;
-#if (!AC_BUILT || HAVE_OPENSSL_CMAC_H) || defined(JOHN_OCL_WPAPSK)
+#if HAVE_OPENSSL_CMAC_H || defined(JOHN_OCL_WPAPSK)
 	if (hccap->keyver > 3)
 		return 0;
 #else
@@ -404,7 +414,7 @@ static char *get_key(int index)
 }
 #endif /* WPAPMK */
 
-#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
+#if HAVE_OPENSSL_CMAC_H
 
 /* Code borrowed from https://w1.fi/wpa_supplicant/ starts */
 
@@ -582,7 +592,7 @@ static int cmp_all(void *binary, int count)
 			hmac_sha1((unsigned char*)prf, 16, hccap->eapol,
 			          hccap->eapol_size, mic[i].keymic, 16);
 		}
-#if !AC_BUILT || HAVE_OPENSSL_CMAC_H
+#if HAVE_OPENSSL_CMAC_H
 	} else if (hccap->keyver == 3) { // 802.11w, WPA-PSK-SHA256
 #ifdef _OPENMP
 #pragma omp parallel for default(none) private(i) shared(count, outbuffer, data, hccap, mic)

--- a/src/wpapsk_fmt_plug.c
+++ b/src/wpapsk_fmt_plug.c
@@ -37,11 +37,11 @@ john_register_one(&fmt_wpapsk);
 #include "unicode.h"
 
 #define FORMAT_LABEL		"wpapsk"
-#if AC_BUILT && !HAVE_OPENSSL_CMAC_H
+#if !HAVE_OPENSSL_CMAC_H
 #ifdef _MSC_VER
-#pragma message("Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.")
+#pragma message("Notice: WPAPSK (CPU) format built without support for 802.11w (this needs recent OpenSSL)")
 #else
-#warning Notice: WPAPSK (CPU) format built without support for 802.11w. Upgrade your OpenSSL.
+#warning Notice: WPAPSK (CPU) format built without support for 802.11w (this needs recent OpenSSL)
 #endif
 #define FORMAT_NAME		"WPA/WPA2/PMKID PSK"
 #else


### PR DESCRIPTION
In my testing on with OpenSSL, `--test --format=cpu` reports 414 formats. Without OpenSSL, it reports 379. All tests pass.

I brought in a SHA-1 implementation from sphlib. Otherwise a lot more formats would need to be excluded. We do have several SHA-1 implementations of our own in various places in the tree, but none are the complete thing with the usual API.

While at it, this PR also repairs the `Makefile.legacy` targets corresponding to those added in 1.9.0 core. The way @magnumripper had merged those core changes resulted in almost all of those being broken (they needed an update to be right for jumbo, not blind merging).

This also updates `Makefile.legacy` and the logic in the source files to allow for legacy builds without OpenSSL, zlib, and GMP - as needed for easier cross-builds.

I also repaired (cross-)building for MIC, which was broken in a few ways.

Using the above, I am now getting this on MIC:

```
[user@super-mic0 run]$ OMP_NUM_THREADS=1 LD_LIBRARY_PATH=.. ./john -test=0
Warning: OpenMP is disabled; a non-OpenMP build may be faster
Testing: descrypt, traditional crypt(3) [DES 512/512 MIC]... PASS
[...]
Testing: aix-ssha512, AIX LPA {ssha512} [PBKDF2-SHA512 512/512 MIC 8x]... PASS
Testing: andOTP [SHA256 32/64]... ret 1762719909
FAILED (cmp_all(1))
Testing: ansible, Ansible Vault [PBKDF2-SHA256 HMAC-256 512/512 MIC 16x]... PASS
[...]
Testing: securezip, PKWARE SecureZIP [SHA1 AES 32/64]... PASS
Testing: 7z, 7-Zip archive encryption (512K iterations) [SHA256 512/512 MIC 16x AES]... FAILED (cmp_all(1))
Testing: Signal, Signal Android [PKCS#12 PBE (SHA1) 32/64]... PASS
[...]
Testing: dynamic_2014 [md5($s.md5($p).$s) (PW > 55 or salt > 11 bytes) 512/512 MIC 16x2]... PASS
Testing: dummy [N/A]... PASS
Testing: crypt, generic crypt(3) [?/64]... PASS
2 out of 372 tests have FAILED
```

I haven't yet looked into these 2 failed tests.

This PR will probably need to be cleaned up before merging. I might split the changes into several commits.