### PR TITLE
pcap2john: fix python3 incompatibility in pcap_parser_ah

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.exe
 *.dSYM
 .DS_Store
+*.pyc
 
 Makefile
 john-local.conf

--- a/run/pcap2john.py
+++ b/run/pcap2john.py
@@ -1227,12 +1227,12 @@ def pcap_parser_ah(fname):
                 # zero mutable fields (tos, flags, chksum)
                 salt[1] = 0  # tos
                 salt[6] = 0  # flags
-                salt[10:12] = "\x00\x00"  # checksum
+                salt[10:12] = b"\x00\x00"  # checksum
                 icv_offset = iphdr_len + icv_length
                 h = salt[icv_offset:icv_offset+icv_length]
                 # zero ah icv
-                salt[icv_offset:icv_offset+icv_length] = "\x00" * icv_length
-                sys.stdout.write("$net-ah$0$%s$%s\n" % (hexlify(salt), hexlify(h)))
+                salt[icv_offset:icv_offset+icv_length] = b"\x00" * icv_length
+                sys.stdout.write("$net-ah$0$%s$%s\n" % (hexlify(salt).decode('ascii'), hexlify(h).decode('ascii')))
 
     f.close()
 


### PR DESCRIPTION
Fixes the problem spotted in #4653 that `pcap2john` does not produce hashes for VRRPv2 AH packets when run under python3.

But note that this does not fix the problem that john can't crack these hashes. The script produces now the same output with python2 and python3 and john is able to load these hashes. But they won't be cracked.