### PR TITLE
Avoid left-over dependencies on OpenSSL headers, re-enable Telegram

### DIFF
--- a/src/aes_ige.h
+++ b/src/aes_ige.h
@@ -52,9 +52,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
-#include <openssl/aes.h>
 
-// #include "aes.h"
+#include "aes.h"
 
 /* NB: the IV is _two_ blocks long */
 void JtR_AES_ige_encrypt(const unsigned char *in, unsigned char *out,

--- a/src/aes_ige_plug.c
+++ b/src/aes_ige_plug.c
@@ -49,15 +49,9 @@
  *
  */
 
-#if AC_BUILT
-#include "autoconfig.h"
-#endif
-
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
-
 #include <string.h>
 
-#include <openssl/aes.h>
+#include "aes.h"
 
 #define N_WORDS (AES_BLOCK_SIZE / sizeof(unsigned long))
 typedef struct {
@@ -198,5 +192,3 @@ void JtR_AES_ige_encrypt(const unsigned char *in, unsigned char *out,
         }
     }
 }
-
-#endif /* OpenSSL */

--- a/src/eapmd5tojohn.c
+++ b/src/eapmd5tojohn.c
@@ -8,10 +8,11 @@
 #include <unistd.h>
 #include <netinet/in.h>
 #include <signal.h>
-#include <openssl/md5.h>
 #include <pcap.h>
 #include <errno.h>
 #include <getopt.h>
+
+#include "md5.h"
 
 /* $FreeBSD: src/sys/net80211/ieee80211_radiotap.h,v 1.5 2005/01/22 20:12:05 sam Exp $ */
 /* $NetBSD: ieee80211_radiotap.h,v 1.11 2005/06/22 06:16:02 dyoung Exp $ */

--- a/src/opencl_telegram_fmt_plug.c
+++ b/src/opencl_telegram_fmt_plug.c
@@ -13,7 +13,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
+#if HAVE_OPENCL
 
 #include "arch.h"
 

--- a/src/opencl_telegram_fmt_plug.c
+++ b/src/opencl_telegram_fmt_plug.c
@@ -28,7 +28,6 @@ john_register_one(&fmt_opencl_telegram);
 
 #include "formats.h"
 #include "common.h"
-#define OPENCL_FORMAT
 #include "telegram_common.h"
 #include "options.h"
 #include "jumbo.h"
@@ -249,7 +248,7 @@ static void *get_salt(char *ciphertext)
 	memset(&cs, 0, sizeof(struct custom_salt));
 	ctcopy += TAG_LENGTH;
 	p = strtokm(ctcopy, "*");
-	/* cs.version = atoi(p); */
+	cs.version = atoi(p); /* must be 1 for now; 2 is rejected in valid() */
 	p = strtokm(NULL, "*");
 	cs.iterations = atoi(p);
 	p = strtokm(NULL, "*");

--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -19,7 +19,6 @@ john_register_one(&fmt_opencl_zip);
 
 #include <string.h>
 #include <stdint.h>
-#include <openssl/des.h>
 
 #include "arch.h"
 #include "formats.h"

--- a/src/telegram_common.h
+++ b/src/telegram_common.h
@@ -17,9 +17,7 @@
 #define ENCRYPTED_BLOB_LEN      512
 
 struct custom_salt {
-#ifndef OPENCL_FORMAT
 	uint32_t version;
-#endif
 	uint32_t iterations;
 	unsigned char salt[SALTLEN];
 	uint32_t salt_length;

--- a/src/telegram_common_plug.c
+++ b/src/telegram_common_plug.c
@@ -5,12 +5,6 @@
  * and the GPU formats, and places it into one common location.
  */
 
-#if AC_BUILT
-#include "autoconfig.h"
-#endif
-
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
-
 #include "arch.h"
 /* We undefine these locally, for scalar PBKDF2 functions used in check_unset_password() */
 #undef SIMD_COEF_32
@@ -203,5 +197,3 @@ unsigned int telegram_iteration_count(void *salt)
 
 	return cs->iterations;
 }
-
-#endif /* OpenSSL */

--- a/src/telegram_fmt_plug.c
+++ b/src/telegram_fmt_plug.c
@@ -11,12 +11,6 @@
  * making this work possible.
  */
 
-#if AC_BUILT
-#include "autoconfig.h"
-#endif
-
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
-
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_telegram;
 #elif FMT_REGISTERS_H
@@ -277,4 +271,3 @@ struct fmt_main fmt_telegram = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */


### PR DESCRIPTION
I was a bit too quick to merge the previous one - turns out `--without-openssl` still needed OpenSSL headers in a couple of places. Trivially fixed here.

Also re-enable Telegram formats (CPU and OpenCL) in `--without-openssl` builds. However, this is weird:

```
$ ../run/john -test=0 -form=telegram-opencl -dev=4
Device 4: GeForce GTX 1080
Testing: telegram-opencl [PBKDF2-SHA1 AES OpenCL]... PASS
Testing: telegram-opencl [PBKDF2-SHA1 AES OpenCL]... PASS
Testing: telegram-opencl [PBKDF2-SHA1 AES OpenCL]... PASS
PASSing: telegram-opencl [PBKDF2-SHA1 AES OpenCL]... ^CWait...
Session aborted
```

That is, it keeps re-testing as if I had requested `--stress-test`. What's this, some kind of memory overwrite affecting option flags?!

Edit: Oh, also weird iteration count reported here:

```
$ ../run/john -te -form=telegram-opencl -dev=4
Device 4: GeForce GTX 1080
Benchmarking: telegram-opencl [PBKDF2-SHA1 AES OpenCL]... LWS=256 GWS=10240 (40 blocks) DONE
Speed for cost 1 (iteration count) of 2143458278
Raw:    23063 c/s real, 23167 c/s virtual, Dev#4 util: 100%
```

and it keeps re-testing, too. (Don't mind the actual speeds - the GPU is in other concurrent use. However, the speeds certainly don't correspond to the obviously wrong reported iteration count.)