### PR TITLE
Drop support for Common Crypto as it was defunct anyway

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -183,6 +183,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   and GMP dependencies are now also easy to exclude by commenting out lines in
   Makefile.legacy, for all targets.  [Solar; 2021]
 
+- Drop support for Apple's CommonCrypto, it was defunct for many years anyway.
+  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/KRB4_fmt_plug.c
+++ b/src/KRB4_fmt_plug.c
@@ -36,7 +36,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_KRB4;
@@ -315,4 +315,4 @@ struct fmt_main fmt_KRB4 = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/KRB4_std_plug.c
+++ b/src/KRB4_std_plug.c
@@ -17,7 +17,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #ifdef KRB4_USE_SYSTEM_CRYPT
 #define _XOPEN_SOURCE 4 /* for crypt(3) */
@@ -138,4 +138,4 @@ afs_string_to_key(char *str, char *cell, DES_cblock *key)
         afs_cmu_StringToKey (str, realm, key);
 }
 
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/KRB5_fmt_plug.c
+++ b/src/KRB5_fmt_plug.c
@@ -19,7 +19,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_KRB5;
@@ -362,4 +362,4 @@ struct fmt_main fmt_KRB5 = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/KRB5_std_plug.c
+++ b/src/KRB5_std_plug.c
@@ -24,7 +24,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #include <stdlib.h>
 #include <string.h>
@@ -282,4 +282,4 @@ void str2key(char *user, char *realm, char *passwd, krb5_key *krb5key) {
 }
 // }}}
 
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -593,7 +593,7 @@ poly1305-donna/poly1305-donna.a:
 # PTHREAD_CFLAGS and OPENMP_CFLAGS may actually contain linker options,
 # like -fopenmp
 ../run/john@EXE_EXT@: $(JOHN_OBJS) aes/aes.a secp256k1/secp256k1.a ed25519-donna/ed25519-donna.a poly1305-donna/poly1305-donna.a @ZTEX_SUBDIRS@
-	$(LD) $(JOHN_OBJS) $(LDFLAGS) @OPENSSL_LIBS@ @COMMONCRYPTO_LIBS@ @OPENMP_CFLAGS@ @GMP_LIBS@ @SKEY_LIBS@ @REXGEN_LIBS@ @CL_LIBS@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @M_LIBS@ @RT_LIBS@ @Z_LIBS@ @DL_LIBS@ @CRYPT_LIBS@ @BZ2_LIBS@ @ZTEX_LIBS@ aes/aes.a secp256k1/secp256k1.a ed25519-donna/ed25519-donna.a poly1305-donna/poly1305-donna.a -o $@
+	$(LD) $(JOHN_OBJS) $(LDFLAGS) @OPENSSL_LIBS@ @OPENMP_CFLAGS@ @GMP_LIBS@ @SKEY_LIBS@ @REXGEN_LIBS@ @CL_LIBS@ @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ @M_LIBS@ @RT_LIBS@ @Z_LIBS@ @DL_LIBS@ @CRYPT_LIBS@ @BZ2_LIBS@ @ZTEX_LIBS@ aes/aes.a secp256k1/secp256k1.a ed25519-donna/ed25519-donna.a poly1305-donna/poly1305-donna.a -o $@
 
 ../run/unshadow: ../run/john
 	$(RM) ../run/unshadow
@@ -719,7 +719,7 @@ poly1305-donna/poly1305-donna.a:
 
 # Note, this one is NOT build by default. To get it, do a make ../run/dynacomptest (or ../run/dynacomptest.exe for cygwin/mingw builds)
 ../run/dynacomptest@EXE_EXT@: dynamic_compiler.c dynamic_compiler_lib.c dynamic_utils.c misc.c unicode.c base64_convert.o base64.o common.o crc32.o KeccakDuplex.o KeccakF-1600-opt64.o KeccakHash.o KeccakSponge.o gost.o jumbo.o memory.o ripemd.o tiger.o haval.o skein.o md2.o panama.o whirlpool.o sha1.o sha2.o
-	$(CC) -DAC_BUILT -Wall -O2 @CPPFLAGS@ @CFLAGS@  @CFLAGS_EXTRA@ @OPENSSL_CFLAGS@ @OPENMP_CFLAGS@ -DWITH_MAIN -D_JOHN_MISC_NO_LOG -DUNICODE_NO_OPTIONS dynamic_compiler.c dynamic_compiler_lib.c dynamic_utils.c misc.c unicode.c base64_convert.o base64.o common.o crc32.o KeccakDuplex.o KeccakF-1600-opt64.o KeccakHash.o KeccakSponge.o gost.o jumbo.o memory.o ripemd.o tiger.o haval.o skein.o md2.o panama.o whirlpool.o sha1.o sha2.o $(LDFLAGS)  @OPENSSL_LIBS@ @COMMONCRYPTO_LIBS@  -o $@
+	$(CC) -DAC_BUILT -Wall -O2 @CPPFLAGS@ @CFLAGS@  @CFLAGS_EXTRA@ @OPENSSL_CFLAGS@ @OPENMP_CFLAGS@ -DWITH_MAIN -D_JOHN_MISC_NO_LOG -DUNICODE_NO_OPTIONS dynamic_compiler.c dynamic_compiler_lib.c dynamic_utils.c misc.c unicode.c base64_convert.o base64.o common.o crc32.o KeccakDuplex.o KeccakF-1600-opt64.o KeccakHash.o KeccakSponge.o gost.o jumbo.o memory.o ripemd.o tiger.o haval.o skein.o md2.o panama.o whirlpool.o sha1.o sha2.o $(LDFLAGS)  @OPENSSL_LIBS@ -o $@
 
 ../run/cprepair@EXE_EXT@: cprepair.c autoconfig.h unicode.c unicode.h options.h misc.h misc.c
 	$(CC) -DAC_BUILT -Wall -O3 @CFLAGS_EXTRA@ @OPENSSL_CFLAGS@ -DNOT_JOHN -D_JOHN_MISC_NO_LOG $(CPPFLAGS) cprepair.c unicode.c misc.c memory.c -o $@
@@ -810,7 +810,7 @@ tests/memory.o:	memory.c arch.h misc.h jumbo.h autoconfig.h memory.h common.h jo
 unit-tests:	../run/unit-tests@EXE_EXT@
 
 ../run/unit-tests@EXE_EXT@:	$(UNIT_TEST_OBJS)
-	$(LD) $(UNIT_TEST_OBJS) $(LDFLAGS) @OPENSSL_LIBS@ @COMMONCRYPTO_LIBS@ -o $@
+	$(LD) $(UNIT_TEST_OBJS) $(LDFLAGS) @OPENSSL_LIBS@ -o $@
 	@ echo "Now Running the Unit Tests"
 	@ ${POSSIBLE_WINE_MSG}
 	@ ${POSSIBLE_WINE_ENV}

--- a/src/NETLM_fmt_plug.c
+++ b/src/NETLM_fmt_plug.c
@@ -36,7 +36,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_NETLM;
@@ -385,4 +385,4 @@ struct fmt_main fmt_NETLM = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/NETSPLITLM_fmt_plug.c
+++ b/src/NETSPLITLM_fmt_plug.c
@@ -18,7 +18,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_NETHALFLM;
@@ -343,4 +343,4 @@ struct fmt_main fmt_NETHALFLM = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/aes_gcm.h
+++ b/src/aes_gcm.h
@@ -14,7 +14,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/aes.h>
 #endif
 

--- a/src/ansible_fmt_plug.c
+++ b/src/ansible_fmt_plug.c
@@ -37,7 +37,7 @@ john_register_one(&fmt_ansible);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          "PBKDF2-SHA256 HMAC-256 " SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA256 HMAC-256 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA256 HMAC-256 32/" ARCH_BITS_STR
 #endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        0x107

--- a/src/as400_des_fmt_plug.c
+++ b/src/as400_des_fmt_plug.c
@@ -21,7 +21,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_as400des;
@@ -398,4 +398,4 @@ struct fmt_main fmt_as400des = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/autoconfig.h.in
+++ b/src/autoconfig.h.in
@@ -42,9 +42,6 @@
 /* Define to 1 if you have the <CL/cl.h> header file. */
 #undef HAVE_CL_CL_H
 
-/* Define to 1 if you have the CommonCrypto library. */
-#undef HAVE_COMMONCRYPTO
-
 /* Define to 1 if you have the `crypt' library (-lcrypt). */
 #undef HAVE_CRYPT
 

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -52,9 +52,9 @@ john_register_one(&fmt_bitcoin);
 #define ALGORITHM_NAME          "SHA512 AES " SHA512_ALGORITHM_NAME
 #else
 #if ARCH_BITS >= 64
-#define ALGORITHM_NAME          "SHA512 AES 64/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "SHA512 AES 64/" ARCH_BITS_STR
 #else
-#define ALGORITHM_NAME          "SHA512 AES 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "SHA512 AES 32/" ARCH_BITS_STR
 #endif
 #endif
 
@@ -283,11 +283,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 			// Now copy and convert hash1 from flat into SIMD_COEF_64 buffers.
 			for (i = 0; i < SHA512_DIGEST_LENGTH/sizeof(uint64_t); ++i) {
-#if COMMON_DIGEST_FOR_OPENSSL
-				key_iv[SIMD_COEF_64*i + (index2&(SIMD_COEF_64-1)) + index2/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64] = sha_ctx.hash[i];  // this is in BE format
-#else
 				key_iv[SIMD_COEF_64*i + (index2&(SIMD_COEF_64-1)) + index2/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64] = sha_ctx.h[i];
-#endif
 			}
 
 			// We need to set ONE time, the upper half of the data buffer.  We put the 0x80 byte (in BE format), at offset

--- a/src/bitwarden_fmt_plug.c
+++ b/src/bitwarden_fmt_plug.c
@@ -39,7 +39,7 @@ john_register_one(&fmt_bitwarden);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          "PBKDF2-SHA256 AES " SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR
 #endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        0x107

--- a/src/configure
+++ b/src/configure
@@ -665,7 +665,6 @@ RT_LIBS
 M_LIBS
 OPENSSL_LIBS
 OPENSSL_CFLAGS
-COMMONCRYPTO_LIBS
 JOHN_NO_SIMD
 EGREP
 PKG_CONFIG_LIBDIR
@@ -750,7 +749,6 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 with_openssl
-with_commoncrypto
 with_endian
 with_systemwide
 enable_asan
@@ -1416,9 +1414,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --without-openssl       Do not use OpenSSL (can use CommonCrypto instead or
-                          exclude much functionality)
-  --with-commoncrypto     Use CommonCrypto
+  --without-openssl       Do not use OpenSSL (exclude much functionality)
   --with-endian=little|big
                           Set endianness for target if it doesn't detect
                           properly
@@ -3412,14 +3408,6 @@ if test "${with_openssl+set}" = set; then :
   withval=$with_openssl;
 else
   with_openssl=yes
-fi
-
-
-# Check whether --with-commoncrypto was given.
-if test "${with_commoncrypto+set}" = set; then :
-  withval=$with_commoncrypto;
-else
-  with_commoncrypto=no
 fi
 
 
@@ -12125,116 +12113,6 @@ See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 
-
-if test "x$with_commoncrypto" = xyes; then :
-  ac_fn_c_check_header_mongrel "$LINENO" "CommonCrypto/CommonDigest.h" "ac_cv_header_CommonCrypto_CommonDigest_h" "$ac_includes_default"
-if test "x$ac_cv_header_CommonCrypto_CommonDigest_h" = xyes; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for CCKeyDerivationPBKDF in -lSystem" >&5
-$as_echo_n "checking for CCKeyDerivationPBKDF in -lSystem... " >&6; }
-if ${ac_cv_lib_System_CCKeyDerivationPBKDF+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lSystem  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char CCKeyDerivationPBKDF ();
-int
-main ()
-{
-return CCKeyDerivationPBKDF ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_System_CCKeyDerivationPBKDF=yes
-else
-  ac_cv_lib_System_CCKeyDerivationPBKDF=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_System_CCKeyDerivationPBKDF" >&5
-$as_echo "$ac_cv_lib_System_CCKeyDerivationPBKDF" >&6; }
-if test "x$ac_cv_lib_System_CCKeyDerivationPBKDF" = xyes; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for CCCryptorCreate in -lSystem" >&5
-$as_echo_n "checking for CCCryptorCreate in -lSystem... " >&6; }
-if ${ac_cv_lib_System_CCCryptorCreate+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lSystem  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char CCCryptorCreate ();
-int
-main ()
-{
-return CCCryptorCreate ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_System_CCCryptorCreate=yes
-else
-  ac_cv_lib_System_CCCryptorCreate=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_System_CCCryptorCreate" >&5
-$as_echo "$ac_cv_lib_System_CCCryptorCreate" >&6; }
-if test "x$ac_cv_lib_System_CCCryptorCreate" = xyes; then :
-
-   for i in "-DCOMMON_DIGEST_FOR_OPENSSL"; do
-      jtr_list_add_dupe=0
-      for j in $CFLAGS; do
-         if test "x$i" = "x$j"; then
-            jtr_list_add_dupe=1
-            break
-         fi
-      done
-      if test $jtr_list_add_dupe = 0; then
-         CFLAGS="$CFLAGS $i"
-         jtr_list_add_result="$jtr_list_add_result $i"
-      fi
-   done
- COMMONCRYPTO_LIBS=-lSystem
-
-$as_echo "#define HAVE_COMMONCRYPTO 1" >>confdefs.h
-
-else
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 1 "No CommonCrypto found
-See \`config.log' for more details" "$LINENO" 5; }
-fi
-
-fi
-
-fi
-
-
-fi
-
 if test "x$with_openssl" != xno; then :
   if test "x$enable_native_tests" != xno -a "x$PKG_CONFIG" != xno; then
 
@@ -12296,14 +12174,12 @@ fi
 $as_echo "no" >&6; }
                 { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 1 "JtR requires OpenSSL and OpenSSL-devel being installed. Install if not installed.
-Try using --disable-pkg-config and possibly helping configure find oSSL by providing hints in CFLAGS and LDFLAGS
+as_fn_error 1 "OpenSSL and/or its development libraries not found. Try using --disable-pkg-config and possibly helping configure find them by providing hints in CPPFLAGS and LDFLAGS (or use --without-openssl option)
 See \`config.log' for more details" "$LINENO" 5; }
 elif test $pkg_failed = untried; then
 	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 1 "JtR requires OpenSSL and OpenSSL-devel being installed. Install if not installed.
-Try using --disable-pkg-config and possibly helping configure find oSSL by providing hints in CFLAGS and LDFLAGS
+as_fn_error 1 "OpenSSL and/or its development libraries not found. Try using --disable-pkg-config and possibly helping configure find them by providing hints in CPPFLAGS and LDFLAGS (or use --without-openssl option)
 See \`config.log' for more details" "$LINENO" 5; }
 else
 	OPENSSL_CFLAGS=$pkg_cv_OPENSSL_CFLAGS
@@ -12499,14 +12375,14 @@ $as_echo "#define HAVE_LIBCRYPTO 1" >>confdefs.h
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 1 "JtR requires libssl/libcrypto being installed
+as_fn_error 1 "libssl/libcrypto not found, install them or use --without-openssl option
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 1 "JtR requires libssl being installed
+as_fn_error 1 "libssl not found, install it or use --without-openssl option
 See \`config.log' for more details" "$LINENO" 5; }
 
 fi
@@ -12515,7 +12391,7 @@ fi
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 1 "JtR requires OpenSSL headers being installed
+as_fn_error 1 "OpenSSL headers not found, install them or use --without-openssl option
 See \`config.log' for more details" "$LINENO" 5; }
 
 fi
@@ -13298,13 +13174,8 @@ fi
 
 LIBS_ORIG="$LIBS"
 CFLAGS_ORIG="$CFLAGS"
-LIBS="$OPENSSL_LIBS $COMMONCRYPTO_LIBS $LIBS"
+LIBS="$OPENSSL_LIBS $LIBS"
 CFLAGS="$OPENSSL_CFLAGS $CFLAGS"
-if test "$with_commoncrypto" = yes; then :
-
-$as_echo "#define HAVE_SHA256 1" >>confdefs.h
-
-fi
 for ac_func in SHA256 WHIRLPOOL RIPEMD160 AES_encrypt DSA_get0_pqg
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
@@ -15395,7 +15266,7 @@ fi
 
 if test "x$aesni_options" != xDISABLED -a "x$ac_path_YASM_found" != xfalse; then
    using_aesni="run-time detection"
-elif test "$cpu_family" = intel; then
+elif test "$with_openssl" = "yes" -a "$cpu_family" = intel; then
    using_aesni="depends on OpenSSL"
 else
    using_aesni=no
@@ -18096,6 +17967,7 @@ Fork support ............................... ${ac_cv_func_fork_works}
 OpenMP support ............................. ${using_omp}
 OpenCL support ............................. ${using_cl}
 Generic crypt(3) format .................... ${using_crypt}
+OpenSSL (many additional formats) .......... ${with_openssl}
 libgmp (PRINCE mode and faster SRP formats)  ${ac_cv_lib_gmp___gmpz_init}
 128-bit integer (faster PRINCE mode) ....... ${have_int128}
 libz (pkzip and some other formats) ........ ${using_zlib}

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -54,9 +54,7 @@ AC_ARG_VAR([LD], [full pathname of linker to use])
 
 dnl Define Packages.
 dnl Use OpenSSL (default: yes).
-AC_ARG_WITH(openssl, [AS_HELP_STRING([--without-openssl],[Do not use OpenSSL (can use CommonCrypto instead or exclude much functionality)])],,[with_openssl=yes])
-dnl Use CommonCrypto (default: no)
-AC_ARG_WITH(commoncrypto, [AS_HELP_STRING([--with-commoncrypto],[Use CommonCrypto])],,[with_commoncrypto=no])
+AC_ARG_WITH(openssl, [AS_HELP_STRING([--without-openssl],[Do not use OpenSSL (exclude much functionality)])],,[with_openssl=yes])
 dnl Cludge for endian (if not auto detected)
 AC_ARG_WITH(endian, [AS_HELP_STRING([--with-endian=little|big],[Set endianness for target if it doesn't detect properly])],,[endian=unknown])
 dnl -DJOHN_SYSTEMWIDE
@@ -581,22 +579,12 @@ dnl is specified, the -llibname will NOT get appended to LIBS. So it has to be
 dnl done by 'hand'.
 dnl ======================================================================
 
-dnl AS_IF([test "x$with_commoncrypto" != xyes && test "x$with_openssl" = xno],
-dnl    [AC_MSG_FAILURE([At least one of OpenSSL and CommonCrypto must be used],1)]
-dnl )
-
-AS_IF([test "x$with_commoncrypto" = xyes],
-  [AC_CHECK_HEADER([CommonCrypto/CommonDigest.h],
-    [AC_CHECK_LIB([System], [CCKeyDerivationPBKDF],
-      [AC_CHECK_LIB([System], [CCCryptorCreate], [JTR_LIST_ADD(CFLAGS,"-DCOMMON_DIGEST_FOR_OPENSSL")] [AC_SUBST(COMMONCRYPTO_LIBS, [-lSystem])] [AC_DEFINE(HAVE_COMMONCRYPTO,1,[Define to 1 if you have the CommonCrypto library.])], [AC_MSG_FAILURE([No CommonCrypto found],1)] )] )] )] )
-
 AS_IF([test "x$with_openssl" != xno],
    [if test "x$enable_native_tests" != xno -a "x$PKG_CONFIG" != xno; then
    PKG_CHECK_MODULES([OPENSSL], [openssl],
       AC_DEFINE(HAVE_LIBCRYPTO,1,[Define to 1 if you have the `crypto' library (-lcrypto).])
          AC_DEFINE(HAVE_LIBSSL,1,[Define to 1 if you have the `ssl' library (-lssl).]),
-         AC_MSG_FAILURE([JtR requires OpenSSL and OpenSSL-devel being installed. Install if not installed.
-Try using --disable-pkg-config and possibly helping configure find oSSL by providing hints in CFLAGS and LDFLAGS],1))
+         AC_MSG_FAILURE([OpenSSL and/or its development libraries not found. Try using --disable-pkg-config and possibly helping configure find them by providing hints in CPPFLAGS and LDFLAGS (or use --without-openssl option)],1))
 else
    AS_IF([test "x${OPENSSL_CFLAGS}${OPENSSL_LIBS}" != "x" -o "x$cross_compiling" = "xyes" -o "x$enable_native_tests" = xno -o "x$PKG_CONFIG" = xno],
       [AC_MSG_CHECKING([supplied paths for OpenSSL])]
@@ -616,11 +604,11 @@ else
          [AC_DEFINE(HAVE_LIBSSL,1,[Define to 1 if you have the `ssl' library (-lssl).])]
          [AC_DEFINE(HAVE_LIBCRYPTO,1,[Define to 1 if you have the `crypto' library (-lcrypto).])]
          [OPENSSL_LIBS="${OPENSSL_LIBS} -lssl -lcrypto"],
-         [AC_MSG_FAILURE(JtR requires libssl/libcrypto being installed,1)])],
-         [AC_MSG_FAILURE(JtR requires libssl being installed,1)]
+         [AC_MSG_FAILURE([libssl/libcrypto not found, install them or use --without-openssl option],1)])],
+         [AC_MSG_FAILURE([libssl not found, install it or use --without-openssl option],1)]
       )
     LIBS="$LIBS_ORIG"],
-    [AC_MSG_FAILURE(JtR requires OpenSSL headers being installed,1)]
+    [AC_MSG_FAILURE([OpenSSL headers not found, install them or use --without-openssl option],1)]
    )]
   )
   fi]
@@ -708,9 +696,8 @@ ACX_HEADER_STRING
 dnl Check missing stuff in OpenSSL (too old, or disabled features)
 LIBS_ORIG="$LIBS"
 CFLAGS_ORIG="$CFLAGS"
-LIBS="$OPENSSL_LIBS $COMMONCRYPTO_LIBS $LIBS"
+LIBS="$OPENSSL_LIBS $LIBS"
 CFLAGS="$OPENSSL_CFLAGS $CFLAGS"
-AS_IF([test "$with_commoncrypto" = yes], [AC_DEFINE([HAVE_SHA256],1,[Define to 1 if you have the `SHA256' function.])])
 AC_CHECK_FUNCS([SHA256 WHIRLPOOL RIPEMD160 AES_encrypt DSA_get0_pqg])
 LIBS="$LIBS_ORIG"
 CFLAGS="$CFLAGS_ORIG"
@@ -960,7 +947,7 @@ fi
 
 if test "x$aesni_options" != xDISABLED -a "x$ac_path_YASM_found" != xfalse; then
    using_aesni="run-time detection"
-elif test "$cpu_family" = intel; then
+elif test "$with_openssl" = "yes" -a "$cpu_family" = intel; then
    using_aesni="depends on OpenSSL"
 else
    using_aesni=no
@@ -1268,6 +1255,7 @@ Fork support ............................... ${ac_cv_func_fork_works}
 OpenMP support ............................. ${using_omp}
 OpenCL support ............................. ${using_cl}
 Generic crypt(3) format .................... ${using_crypt}
+OpenSSL (many additional formats) .......... ${with_openssl}
 libgmp (PRINCE mode and faster SRP formats)  ${ac_cv_lib_gmp___gmpz_init}
 128-bit integer (faster PRINCE mode) ....... ${have_int128}
 libz (pkzip and some other formats) ........ ${using_zlib}

--- a/src/diskcryptor_fmt_plug.c
+++ b/src/diskcryptor_fmt_plug.c
@@ -41,9 +41,9 @@ john_register_one(&fmt_diskcryptor);
 #define ALGORITHM_NAME          "PBKDF2-SHA512 " SHA512_ALGORITHM_NAME
 #else
 #if ARCH_BITS >= 64
-#define ALGORITHM_NAME          "PBKDF2-SHA512 64/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA512 64/" ARCH_BITS_STR
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA512 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA512 32/" ARCH_BITS_STR
 #endif
 #endif
 #define BENCHMARK_COMMENT       ""

--- a/src/dmg_fmt_plug.c
+++ b/src/dmg_fmt_plug.c
@@ -45,7 +45,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_dmg;
@@ -748,4 +748,4 @@ struct fmt_main fmt_dmg = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/dpapimk_fmt_plug.c
+++ b/src/dpapimk_fmt_plug.c
@@ -18,7 +18,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_DPAPImk;
@@ -537,4 +537,4 @@ struct fmt_main fmt_DPAPImk = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/dragonfly3_fmt_plug.c
+++ b/src/dragonfly3_fmt_plug.c
@@ -35,7 +35,7 @@ john_register_one(&fmt_dragonfly3_64);
 #define FORMAT_LABEL_64			"dragonfly3-64"
 #define FORMAT_NAME_32			"DragonFly BSD $3$ w/ bug, 32-bit"
 #define FORMAT_NAME_64			"DragonFly BSD $3$ w/ bug, 64-bit"
-#define ALGORITHM_NAME			"SHA256 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME			"SHA256 32/" ARCH_BITS_STR
 #define FORMAT_TAG				"$3$"
 #define FORMAT_TAG_LEN			(sizeof(FORMAT_TAG)-1)
 

--- a/src/dragonfly4_fmt_plug.c
+++ b/src/dragonfly4_fmt_plug.c
@@ -36,9 +36,9 @@ john_register_one(&fmt_dragonfly4_64);
 #define FORMAT_TAG				"$4$"
 #define FORMAT_TAG_LEN			(sizeof(FORMAT_TAG)-1)
 #if ARCH_BITS >= 64
-#define ALGORITHM_NAME			"SHA512 64/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME			"SHA512 64/" ARCH_BITS_STR
 #else
-#define ALGORITHM_NAME			"SHA512 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME			"SHA512 32/" ARCH_BITS_STR
 #endif
 
 #define BENCHMARK_COMMENT		""

--- a/src/dynamic.h
+++ b/src/dynamic.h
@@ -33,7 +33,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/opensslv.h>
 #endif
 

--- a/src/dynamic_big_crypt_header.cin
+++ b/src/dynamic_big_crypt_header.cin
@@ -117,7 +117,7 @@
 #define sph_skein384_close(a,b) sph_skein384_close(b,a)
 #define sph_skein512_close(a,b) sph_skein512_close(b,a)
 
-#if defined(HAVE_LIBCRYPTO) || defined(HAVE_COMMONCRYPTO)
+#if HAVE_LIBCRYPTO
 #include <openssl/opensslv.h>
 #endif
 #if (AC_BUILT && HAVE_WHIRLPOOL) ||	  \

--- a/src/dynamic_types.h
+++ b/src/dynamic_types.h
@@ -245,10 +245,7 @@ typedef struct private_subformat_data
 #define ALGORITHM_NAME_S2_256		BITS " " SIMD_TYPE " " SHA256_N_STR
 #define ALGORITHM_NAME_S2_512		BITS " " SIMD_TYPE " " SHA512_N_STR
 
-#if defined (COMMON_DIGEST_FOR_OPENSSL)
-#define ALGORITHM_NAME_X86_S2_256	"32/"ARCH_BITS_STR " CommonCrypto"
-#define ALGORITHM_NAME_X86_S2_512	ARCH_BITS_STR"/64 CommonCrypto"
-#elif defined (GENERIC_SHA2)
+#if defined (GENERIC_SHA2)
 #define ALGORITHM_NAME_X86_S2_256	"32/"ARCH_BITS_STR
 #define ALGORITHM_NAME_X86_S2_512	ARCH_BITS_STR"/64"
 #else

--- a/src/electrum_fmt_plug.c
+++ b/src/electrum_fmt_plug.c
@@ -14,7 +14,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #include "arch.h"
 #if !AC_BUILT
@@ -519,4 +519,4 @@ struct fmt_main fmt_electrum = {
 #endif
 
 #endif /* HAVE_LIBZ */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/episerver_fmt_plug.c
+++ b/src/episerver_fmt_plug.c
@@ -97,7 +97,7 @@ john_register_one(&fmt_episerver);
 #define MAX_KEYS_PER_CRYPT      (NBKEYS * 2)
 #endif
 #else
-#define ALGORITHM_NAME          "SHA1/SHA256 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "SHA1/SHA256 32/" ARCH_BITS_STR
 #define PLAINTEXT_LENGTH        32
 #define MIN_KEYS_PER_CRYPT      1
 #define MAX_KEYS_PER_CRYPT      1024

--- a/src/fvde_fmt_plug.c
+++ b/src/fvde_fmt_plug.c
@@ -40,7 +40,7 @@ john_register_one(&fmt_fvde);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          "PBKDF2-SHA256 AES " SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR
 #endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        0x107

--- a/src/gpg_common_plug.c
+++ b/src/gpg_common_plug.c
@@ -15,7 +15,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #include <stdio.h>
 #include <string.h>
@@ -1701,4 +1701,4 @@ unsigned int gpg_common_gpg_cipher_algorithm(void *salt)
 	return (unsigned int) my_salt->cipher_algorithm;
 }
 
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/gpg_fmt_plug.c
+++ b/src/gpg_fmt_plug.c
@@ -28,7 +28,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_gpg;
@@ -218,4 +218,4 @@ struct fmt_main fmt_gpg = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -49,7 +49,7 @@ john_register_one(&fmt_KeePass);
 
 #define FORMAT_LABEL            "KeePass"
 #define FORMAT_NAME             ""
-#define ALGORITHM_NAME          "SHA256 AES 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "SHA256 AES 32/" ARCH_BITS_STR
 
 static keepass_salt_t *cur_salt;
 static int any_cracked, *cracked;

--- a/src/keychain_common_plug.c
+++ b/src/keychain_common_plug.c
@@ -6,7 +6,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_OPENCL || HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_OPENCL || HAVE_LIBCRYPTO
 
 #include "arch.h"
 #include "misc.h"
@@ -82,4 +82,4 @@ void *keychain_get_salt(char *ciphertext)
 	return (void *)&cs;
 }
 
-#endif /* HAVE_OPENCL || HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO */
+#endif /* HAVE_OPENCL || HAVE_LIBCRYPTO */

--- a/src/keychain_fmt_plug.c
+++ b/src/keychain_fmt_plug.c
@@ -18,7 +18,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_keychain;
@@ -236,4 +236,4 @@ struct fmt_main fmt_keychain = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/krb5_asrep_fmt_plug.c
+++ b/src/krb5_asrep_fmt_plug.c
@@ -58,7 +58,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_krb5asrep;
@@ -406,4 +406,4 @@ struct fmt_main fmt_krb5asrep = {
 };
 
 #endif
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/krb5_common_plug.c
+++ b/src/krb5_common_plug.c
@@ -2,7 +2,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #include <openssl/des.h>
 
@@ -337,4 +337,4 @@ int des_string_to_key_shishi(char *string, size_t stringlen,
 	return 0;
 }
 
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/krb5_db_fmt_plug.c
+++ b/src/krb5_db_fmt_plug.c
@@ -28,7 +28,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_krb5_18;
@@ -508,4 +508,4 @@ struct fmt_main fmt_krb5_3 = {
 
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/krb5pa-sha1_fmt_plug.c
+++ b/src/krb5pa-sha1_fmt_plug.c
@@ -36,7 +36,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_krb5pa;
@@ -487,4 +487,4 @@ struct fmt_main fmt_krb5pa = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/kwallet_fmt_plug.c
+++ b/src/kwallet_fmt_plug.c
@@ -15,7 +15,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_kwallet;
@@ -441,4 +441,4 @@ struct fmt_main fmt_kwallet = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/leet_cc_fmt_plug.c
+++ b/src/leet_cc_fmt_plug.c
@@ -27,7 +27,7 @@ john_register_one(&fmt_leet);
 #endif
 
 #include "openssl_local_overrides.h"
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/opensslv.h>
 #endif
 #if (AC_BUILT && HAVE_WHIRLPOOL) ||	  \
@@ -60,7 +60,7 @@ john_register_one(&fmt_leet);
 #define SHA512_TYPE          SHA512_ALGORITHM_NAME
 #define NBKEYS					(SIMD_COEF_64*SIMD_PARA_SHA512)
 #else
-#define SHA512_TYPE          "32/" ARCH_BITS_STR SHA2_LIB
+#define SHA512_TYPE          "32/" ARCH_BITS_STR
 #define NBKEYS					1
 #endif
 

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -42,7 +42,7 @@
  #endif
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
 #endif
@@ -231,9 +231,8 @@ static void listconf_list_build_info(void)
 #endif
 #if HAVE_LIBCRYPTO
 	printf("Crypto library: OpenSSL\n");
-#endif
-#if HAVE_COMMONCRYPTO
-	printf("Crypto library: CommonCrypto\n");
+#else
+	printf("Crypto library: None\n");
 #endif
 
 #if HAVE_LIBDL && defined(RTLD_DEFAULT)

--- a/src/lotus85_fmt_plug.c
+++ b/src/lotus85_fmt_plug.c
@@ -12,7 +12,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_lotus_85;
@@ -487,4 +487,4 @@ struct fmt_main fmt_lotus_85 =
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/mdc2_fmt_plug.c
+++ b/src/mdc2_fmt_plug.c
@@ -12,7 +12,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_mdc2;
@@ -241,4 +241,4 @@ struct fmt_main fmt_mdc2 = {
 };
 
 #endif
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/mdc2dgst_plug.c
+++ b/src/mdc2dgst_plug.c
@@ -60,7 +60,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -186,4 +186,4 @@ int JtR_MDC2_Final(unsigned char *md, JtR_MDC2_CTX *c)
 	return 1;
 }
 
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/mozilla_ng_fmt_plug.c
+++ b/src/mozilla_ng_fmt_plug.c
@@ -18,7 +18,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_mozilla;
@@ -458,4 +458,4 @@ struct fmt_main fmt_mozilla = {
 };
 
 #endif
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/notes_fmt_plug.c
+++ b/src/notes_fmt_plug.c
@@ -36,7 +36,7 @@ john_register_one(&fmt_notes);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          "PBKDF2-SHA256 AES " SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR
 #endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        0x107

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -72,7 +72,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_MSCHAPv2_new;
@@ -1490,4 +1490,4 @@ struct fmt_main fmt_NETNTLM_new = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/o10glogon_fmt_plug.c
+++ b/src/o10glogon_fmt_plug.c
@@ -20,7 +20,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_o10glogon;
@@ -443,4 +443,4 @@ struct fmt_main fmt_o10glogon = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/o3logon_fmt_plug.c
+++ b/src/o3logon_fmt_plug.c
@@ -16,7 +16,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_o3logon;
@@ -416,4 +416,4 @@ struct fmt_main fmt_o3logon = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/odf_common_plug.c
+++ b/src/odf_common_plug.c
@@ -6,7 +6,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #include <openssl/blowfish.h>
 
@@ -495,4 +495,4 @@ void SHA1_odf_buggy(unsigned char *data, int len, uint32_t results[5]) {
 	SHA1Final_buggy((unsigned char*)results, &ctx);
 }
 
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/odf_fmt_plug.c
+++ b/src/odf_fmt_plug.c
@@ -22,7 +22,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_odf;
@@ -53,7 +53,7 @@ john_register_one(&fmt_odf);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          "PBKDF2-SHA1 " SHA1_ALGORITHM_NAME " BF/AES"
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA1 BF/AES 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA1 BF/AES 32/" ARCH_BITS_STR
 #endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        0x107
@@ -294,4 +294,4 @@ struct fmt_main fmt_odf = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/opencl_electrum_modern_fmt_plug.c
+++ b/src/opencl_electrum_modern_fmt_plug.c
@@ -18,7 +18,7 @@
 #endif
 #if HAVE_LIBZ
 
-#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
+#if HAVE_OPENCL && HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_opencl_electrum_modern;
@@ -572,6 +572,6 @@ struct fmt_main fmt_opencl_electrum_modern = {
 
 #endif /* plugin stanza */
 
-#endif /* HAVE_OPENCL */
+#endif /* HAVE_OPENCL && HAVE_LIBCRYPTO */
 
 #endif /* HAVE_LIBZ */

--- a/src/opencl_gpg_fmt_plug.c
+++ b/src/opencl_gpg_fmt_plug.c
@@ -15,7 +15,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
+#if HAVE_OPENCL && HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_opencl_gpg;
@@ -416,4 +416,4 @@ struct fmt_main fmt_opencl_gpg = {
 
 #endif /* plugin stanza */
 
-#endif /* HAVE_OPENCL */
+#endif /* HAVE_OPENCL && HAVE_LIBCRYPTO */

--- a/src/opencl_odf_fmt_plug.c
+++ b/src/opencl_odf_fmt_plug.c
@@ -13,7 +13,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
+#if HAVE_OPENCL && HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_opencl_odf_aes;
@@ -332,4 +332,4 @@ struct fmt_main fmt_opencl_odf_aes = {
 
 #endif /* plugin stanza */
 
-#endif /* HAVE_OPENCL */
+#endif /* HAVE_OPENCL && HAVE_LIBCRYPTO */

--- a/src/opencl_pem_fmt_plug.c
+++ b/src/opencl_pem_fmt_plug.c
@@ -13,7 +13,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_OPENCL && (HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
+#if HAVE_OPENCL && HAVE_LIBCRYPTO
 
 #include "arch.h"
 
@@ -388,4 +388,4 @@ struct fmt_main fmt_opencl_pem = {
 
 #endif /* plugin stanza */
 
-#endif /* HAVE_OPENCL */
+#endif /* HAVE_OPENCL && HAVE_LIBCRYPTO */

--- a/src/oracle_fmt_plug.c
+++ b/src/oracle_fmt_plug.c
@@ -13,7 +13,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_oracle;
@@ -452,4 +452,4 @@ struct fmt_main fmt_oracle = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/padlock_fmt_plug.c
+++ b/src/padlock_fmt_plug.c
@@ -37,7 +37,7 @@ john_register_one(&fmt_padlock);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          "PBKDF2-SHA256 AES " SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA256 AES 32/" ARCH_BITS_STR
 #endif
 #define PLAINTEXT_LENGTH        125
 #define SALT_SIZE               sizeof(struct custom_salt)

--- a/src/pbkdf2-hmac-sha512_fmt_plug.c
+++ b/src/pbkdf2-hmac-sha512_fmt_plug.c
@@ -45,9 +45,9 @@ john_register_one(&fmt_pbkdf2_hmac_sha512);
 #define ALGORITHM_NAME		"PBKDF2-SHA512 " SHA512_ALGORITHM_NAME
 #else
 #if ARCH_BITS >= 64
-#define ALGORITHM_NAME          "PBKDF2-SHA512 64/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA512 64/" ARCH_BITS_STR
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA512 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA512 32/" ARCH_BITS_STR
 #endif
 #endif
 

--- a/src/pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/pbkdf2_hmac_sha256_fmt_plug.c
@@ -47,7 +47,7 @@ john_register_one(&fmt_pbkdf2_hmac_sha256);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME		"PBKDF2-SHA256 " SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA256 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA256 32/" ARCH_BITS_STR
 #endif
 
 #define MAX_CIPHERTEXT_LENGTH   1024 /* Bump this and code will adopt */

--- a/src/pem_common_plug.c
+++ b/src/pem_common_plug.c
@@ -9,7 +9,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #include <openssl/des.h>
 
@@ -264,4 +264,4 @@ unsigned int pem_cipher(void *salt)
 	return cs->cid;
 }
 
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/pem_fmt_plug.c
+++ b/src/pem_fmt_plug.c
@@ -16,7 +16,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_pem;
@@ -207,4 +207,4 @@ struct fmt_main fmt_pem = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/pgpdisk_fmt_plug.c
+++ b/src/pgpdisk_fmt_plug.c
@@ -12,7 +12,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_pgpdisk;
@@ -267,4 +267,4 @@ struct fmt_main fmt_pgpdisk = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/pgpsda_fmt_plug.c
+++ b/src/pgpsda_fmt_plug.c
@@ -12,7 +12,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_pgpsda;
@@ -226,4 +226,4 @@ struct fmt_main fmt_pgpsda = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/pwsafe_fmt_plug.c
+++ b/src/pwsafe_fmt_plug.c
@@ -508,13 +508,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		// does get 5% gain, but 400% is so much better, lol. I put the other
 		// code in to be able to dump data out easier, getting dump_stuff()
 		// data in flat, to be able to help get the SIMD code working.
-#ifdef COMMON_DIGEST_FOR_OPENSSL
-		pwsafe_sha256_iterate(ctx.hash, cur_salt->iterations);
-		memcpy(crypt_out[index], ctx.hash, 32);
-#else
 		pwsafe_sha256_iterate(ctx.h, cur_salt->iterations);
 		memcpy(crypt_out[index], ctx.h, 32);
-#endif
 #else
 		{ int i;
 		for (i = 0; i <= cur_salt->iterations; ++i) {

--- a/src/qnx_fmt_plug.c
+++ b/src/qnx_fmt_plug.c
@@ -53,7 +53,7 @@ john_register_one(&fmt_qnx);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "32/" ARCH_BITS_STR
 #endif
 
 #define PLAINTEXT_LENGTH	48

--- a/src/racf_fmt_plug.c
+++ b/src/racf_fmt_plug.c
@@ -20,7 +20,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_racf;
@@ -371,4 +371,4 @@ struct fmt_main fmt_racf = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/racf_kdfaes_fmt_plug.c
+++ b/src/racf_kdfaes_fmt_plug.c
@@ -13,7 +13,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_racf_kdfaes;
@@ -484,4 +484,4 @@ struct fmt_main fmt_racf_kdfaes = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/rar5_fmt_plug.c
+++ b/src/rar5_fmt_plug.c
@@ -43,7 +43,7 @@ john_register_one(&fmt_rar5);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          "PBKDF2-SHA256 " SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA256 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA256 32/" ARCH_BITS_STR
 #endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        0x107

--- a/src/rawSHA224_fmt_plug.c
+++ b/src/rawSHA224_fmt_plug.c
@@ -43,7 +43,7 @@ john_register_one(&fmt_rawSHA224);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME			SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME			"32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME			"32/" ARCH_BITS_STR
 #endif
 
 #define BENCHMARK_COMMENT		""

--- a/src/rawSHA256_fmt_plug.c
+++ b/src/rawSHA256_fmt_plug.c
@@ -47,7 +47,7 @@ john_register_one(&fmt_rawSHA256);
 #ifdef SIMD_COEF_32
 #define ALGORITHM_NAME          SHA256_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "32/" ARCH_BITS_STR
 #endif
 
 /* Note: Cisco hashes are truncated at length 25. We currently ignore this. */

--- a/src/rawSHA384_fmt_plug.c
+++ b/src/rawSHA384_fmt_plug.c
@@ -44,7 +44,7 @@ john_register_one(&fmt_rawSHA384);
 #ifdef SIMD_COEF_64
 #define ALGORITHM_NAME          SHA512_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "32/" ARCH_BITS_STR
 #endif
 
 #define BENCHMARK_COMMENT		""

--- a/src/rawSHA512_fmt_plug.c
+++ b/src/rawSHA512_fmt_plug.c
@@ -46,7 +46,7 @@ john_register_one(&fmt_raw0_SHA512);
 #ifdef SIMD_COEF_64
 #define ALGORITHM_NAME          SHA512_ALGORITHM_NAME
 #else
-#define ALGORITHM_NAME          "32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "32/" ARCH_BITS_STR
 #endif
 
 #ifdef SIMD_COEF_64

--- a/src/rvary_fmt_plug.c
+++ b/src/rvary_fmt_plug.c
@@ -14,7 +14,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_rvary;
@@ -326,4 +326,4 @@ struct fmt_main fmt_rvary = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/sap_pse_fmt_plug.c
+++ b/src/sap_pse_fmt_plug.c
@@ -15,7 +15,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_sappse;
@@ -249,4 +249,4 @@ struct fmt_main fmt_sappse = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/sha.h
+++ b/src/sha.h
@@ -5,28 +5,9 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/opensslv.h>
-
-#include "arch.h"
-#if HAVE_COMMONCRYPTO || (!AC_BUILT &&	  \
-	!defined(SIMD_COEF_32) && defined(__APPLE__) && defined(__MACH__) && \
-	 defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
-	 __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
-/* Mitigate CommonCrypto name clashes */
-#include "md4.h"
-#include "md5.h"
-#define COMMON_DIGEST_FOR_OPENSSL 1
-#include <CommonCrypto/CommonDigest.h>
-#ifndef SHA_CBLOCK
-#define SHA_CBLOCK CC_SHA1_BLOCK_BYTES
-#endif
-#ifndef SHA_LBLOCK
-#define SHA_LBLOCK CC_SHA1_BLOCK_LONG
-#endif
-#else
 #include <openssl/sha.h>
-#endif
 
 /* For the abuse in pbkdf2_hmac_sha1.h and mscash2_fmt_plug.c */
 #define SHA_H0 h0
@@ -35,7 +16,8 @@
 #define SHA_H3 h3
 #define SHA_H4 h4
 
-#else /* !(HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO) */
+#else /* ! HAVE_LIBCRYPTO */
+
 #include "sph_sha1.h"
 #define SHA_CTX sph_sha1_context
 #define SHA1_Init sph_sha1_init

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -30,7 +30,7 @@
  * @author   Thomas Pornin <thomas.pornin@cryptolog.com>
  */
 
-#if !(HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO)
+#if !HAVE_LIBCRYPTO
 
 #include <stddef.h>
 #include <string.h>
@@ -383,4 +383,4 @@ sph_sha1_comp(const sph_u32 msg[16], sph_u32 val[5])
 }
 #endif /* dead code */
 
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/sha2.h
+++ b/src/sha2.h
@@ -34,7 +34,7 @@
 #include <stdint.h>
 #include "arch.h"
 #include "aligned.h"
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/opensslv.h>
 #elif !defined(FORCE_GENERIC_SHA2)
 #define FORCE_GENERIC_SHA2 1
@@ -44,32 +44,17 @@
 #if (AC_BUILT && HAVE_SHA256 && !FORCE_GENERIC_SHA2) ||	  \
     (!AC_BUILT && OPENSSL_VERSION_NUMBER >= 0x00908000 && !FORCE_GENERIC_SHA2)
 
-#if HAVE_COMMONCRYPTO || (!AC_BUILT &&	  \
-	!defined(SIMD_COEF_32) && defined(__APPLE__) && defined(__MACH__) && \
-	 defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
-	 __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
-/* Mitigate CommonCrypto name clashes */
-#include "md4.h"
-#include "md5.h"
-#define COMMON_DIGEST_FOR_OPENSSL 1
-#define SHA2_LIB " CommonCrypto"
-#include <CommonCrypto/CommonDigest.h>
-#define JTR_INC_COMMON_CRYPTO_SHA2
-#else
-#define SHA2_LIB
 #include <openssl/sha.h>
-#endif
 
 #undef GENERIC_SHA2
 
 #else	// OPENSSL_VERSION_NUMBER ! >= 0x00908000
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/sha.h>
 #endif
 #include "jtr_sha2.h"
 
-#define SHA2_LIB
 #define GENERIC_SHA2
 
 

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -127,11 +127,11 @@ void sha384_unreverse(uint64_t *hash);
 #endif
 
 #else
-#define SHA256_ALGORITHM_NAME                 "32/" ARCH_BITS_STR SHA2_LIB
+#define SHA256_ALGORITHM_NAME                 "32/" ARCH_BITS_STR
 #if ARCH_BITS >= 64
-#define SHA512_ALGORITHM_NAME                 "64/" ARCH_BITS_STR SHA2_LIB
+#define SHA512_ALGORITHM_NAME                 "64/" ARCH_BITS_STR
 #else
-#define SHA512_ALGORITHM_NAME                 "32/" ARCH_BITS_STR SHA2_LIB
+#define SHA512_ALGORITHM_NAME                 "32/" ARCH_BITS_STR
 #endif
 
 #endif

--- a/src/ssh_fmt_plug.c
+++ b/src/ssh_fmt_plug.c
@@ -24,7 +24,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_ssh;
@@ -561,4 +561,4 @@ struct fmt_main fmt_ssh = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -36,9 +36,9 @@ john_register_one(&fmt_saltedsha2);
 #define ALGORITHM_NAME					"SHA512 " SHA512_ALGORITHM_NAME
 #else
 #if ARCH_BITS >= 64
-#define ALGORITHM_NAME					"SHA512 64/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME					"SHA512 64/" ARCH_BITS_STR
 #else
-#define ALGORITHM_NAME					"SHA512 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME					"SHA512 32/" ARCH_BITS_STR
 #endif
 #endif
 

--- a/src/tezos_fmt_plug.c
+++ b/src/tezos_fmt_plug.c
@@ -44,9 +44,9 @@ john_register_one(&fmt_tezos);
 #define ALGORITHM_NAME          "PBKDF2-SHA512 " SHA512_ALGORITHM_NAME
 #else
 #if ARCH_BITS >= 64
-#define ALGORITHM_NAME          "PBKDF2-SHA512 64/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA512 64/" ARCH_BITS_STR
 #else
-#define ALGORITHM_NAME          "PBKDF2-SHA512 32/" ARCH_BITS_STR SHA2_LIB
+#define ALGORITHM_NAME          "PBKDF2-SHA512 32/" ARCH_BITS_STR
 #endif
 #endif
 #define BENCHMARK_COMMENT       ""

--- a/src/vnc_fmt_plug.c
+++ b/src/vnc_fmt_plug.c
@@ -28,7 +28,7 @@
 #include "autoconfig.h"
 #endif
 
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_vnc;
@@ -351,4 +351,4 @@ struct fmt_main fmt_vnc = {
 };
 
 #endif /* plugin stanza */
-#endif /* OpenSSL */
+#endif /* HAVE_LIBCRYPTO */

--- a/src/whirlpool_fmt_plug.c
+++ b/src/whirlpool_fmt_plug.c
@@ -36,7 +36,7 @@ john_register_one(&fmt_whirlpool);
 #if AC_BUILT
 #include "autoconfig.h"
 #endif
-#if HAVE_LIBCRYPTO || HAVE_COMMONCRYPTO
+#if HAVE_LIBCRYPTO
 #include <openssl/opensslv.h>
 #endif
 #if (AC_BUILT && HAVE_WHIRLPOOL) ||	\


### PR DESCRIPTION
It hasn't worked at all for many years.  Closes #4098.

On a side note I first tried fixing the `--with-commoncrypto` option but there were more work needed than seemed reasonable to me, especially since a SIMD build would be nearly identical to a `--without-openssl` (*edited typo*) build anyway - and we do support SIMD for all and any Macs.