### PR TITLE
sha1crypt, sha1crypt-opencl: Benchmark for 20000 iterations only; Minor cleanups

### DIFF
--- a/doc/README-MIC
+++ b/doc/README-MIC
@@ -1,8 +1,8 @@
 
 Intel MIC (Xeon Phi) is a coprocessor computer architecture developed by Intel.
-Program built for MIC cannot run on normal Intel processors. So you need to 
-have a MIC coprocessor and related enviroments setup before trying to build 
-John the Ripper (JtR) for MIC. Tutorial on how to setup the software 
+Program built for MIC cannot run on normal Intel processors. So you need to
+have a MIC coprocessor and related enviroments setup before trying to build
+John the Ripper (JtR) for MIC. Tutorial on how to setup the software
 environments for MIC can be found on Intel's website.
 
 
@@ -10,15 +10,15 @@ environments for MIC can be found on Intel's website.
 Library Denpendencies:
 -----------------------
 
-JtR can use some libraries that are not available on MIC, which means you'll 
+JtR can use some libraries that are not available on MIC, which means you'll
 need to build them for MIC by yourself.
 These libraries are:
     Zlib (libz)
     GMP (libgmp)
     OpenSSL/LibreSSL (libssl & libcrypto)
 
-They can be downloaded from their websites. But building them requires some 
-effort, and only the mentioned versions are guaranteed to work.  
+They can be downloaded from their websites. But building them requires some
+effort, and only the mentioned versions are guaranteed to work.
 Assuming those libraries are to be installed under path $MIC and the path to
 JtR is $JOHN, then follow the steps below.
 
@@ -60,12 +60,12 @@ After building those libraries, now it's straightforward to build JtR for MIC.
 
 $ cd $JOHN/src
 $ ./configure CC="icc -mmic" CPPFLAGS="-I$MIC/include" LDFLAGS="-L$MIC/lib" --host=mic-linux
-$ make && make install
+$ make
 
-After that, you can use scp to transfer the executables and config files you 
-need under directory $JOHN/run to MIC. 
-You also need to transfer some dynamic libraries to MIC, which is requried by 
-JtR at runtime, including those mentioned above (under $MIC/lib) and the 
+After that, you can use scp to transfer the executables and config files you
+need under directory $JOHN/run to MIC.
+You also need to transfer some dynamic libraries to MIC, which is requried by
+JtR at runtime, including those mentioned above (under $MIC/lib) and the
 following:
     libiomp*
     libimf

--- a/src/mic.h
+++ b/src/mic.h
@@ -73,6 +73,7 @@
 #define SIMD_PARA_SHA256	1
 #endif
 #ifndef SIMD_PARA_SHA512
+/* 2 is faster at least for Bitcoin, but makes sha512crypt fail self-test */
 #define SIMD_PARA_SHA512	1
 #endif
 

--- a/src/sha1crypt_common.h
+++ b/src/sha1crypt_common.h
@@ -11,7 +11,7 @@
 #include "formats.h"
 
 #define BENCHMARK_COMMENT           ""
-#define BENCHMARK_LENGTH            0x107
+#define BENCHMARK_LENGTH            0x507
 
 #define SHA1_MAGIC "$sha1$"
 #define SHA1_MAGIC_LEN (sizeof(SHA1_MAGIC)-1)

--- a/src/sha1crypt_common_plug.c
+++ b/src/sha1crypt_common_plug.c
@@ -14,6 +14,7 @@
 
 
 struct fmt_tests sha1crypt_common_tests[] = {
+	{"$sha1$20000$75552156$HhYMDdaEHiK3eMIzTldOFPnw.s2Q", "hashcat"},
 	{"$sha1$64000$wnUR8T1U$vt1TFQ50tBMFgkflAFAOer2CwdYZ", "password"},
 	{"$sha1$40000$jtNX3nZ2$hBNaIXkt4wBI2o5rsi8KejSjNqIq", "password"},
 	{"$sha1$64000$wnUR8T1U$wmwnhQ4lpo/5isi5iewkrHN7DjrT", "123456"},

--- a/src/sha512crypt_fmt_plug.c
+++ b/src/sha512crypt_fmt_plug.c
@@ -96,7 +96,7 @@ john_register_one(&fmt_cryptsha512);
 // them in groups that all 'fit' together, and do so until we exhaust all from a given length
 // range, then do all in the next range.  Thus, until we get to the last set within a length
 // range, we are doing a fully packed SSE run, and having a LOT less wasted space. This will
-// get even more interesting, when we start doing OMP, but it should just be the same principal,
+// get even more interesting, when we start doing OMP, but it should just be the same principle,
 // preload more passwords, and group them, then run the OMP threads over a single length, then
 // go to the next length, until done, trying to keep each thread running, and keeping each block
 // of SSE data full, until the last in a range.  We probably can simply build all the rearrangments,
@@ -186,7 +186,7 @@ typedef struct cryptloopstruct_t {
 								// NOTE, datlen could be changed to a number, and then we could do > 2 block crypts. Would take a little
 								// more memory (and longer PW's certainly DO take more time), but it should work fine. It may be an issue
 								// especially when doing OMP, that the memory footprint of this 'hot' inner loop simply gets too big, and
-								// things slow down. For now, we are limiting ourselves to 35 byte password, which fits into 2 SHA512 buffers
+								// things slow down. For now, we are limiting ourselves to 79 byte password, which fits into 2 SHA512 buffers
 } cryptloopstruct;
 
 static int (*saved_len);
@@ -717,7 +717,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			if (cnt == cur_salt->rounds)
 				break;
 			{
-				int j, k;
+				unsigned int j, k;
 				for (k = 0; k < MIN_KEYS_PER_CRYPT; ++k) {
 					uint64_t *o = (uint64_t *)crypt_struct->cptr[k][idx];
 #if !ARCH_ALLOWS_UNALIGNED
@@ -739,7 +739,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				idx = 0;
 		}
 		{
-			int j, k;
+			unsigned int j, k;
 			for (k = 0; k < MIN_KEYS_PER_CRYPT; ++k) {
 				uint64_t *o = (uint64_t *)crypt_out[MixOrder[index+k]];
 				for (j = 0; j < 8; ++j)
@@ -849,7 +849,7 @@ static int cmp_exact(char *source, int index)
 	return 1;
 }
 
-static unsigned int sha512crypt_iterations(void *salt)
+static unsigned int iteration_count(void *salt)
 {
 	struct saltstruct *sha512crypt_salt;
 
@@ -902,7 +902,7 @@ struct fmt_main fmt_cryptsha512 = {
 		get_binary,
 		get_salt,
 		{
-			sha512crypt_iterations,
+			iteration_count,
 		},
 		fmt_default_source,
 		{


### PR DESCRIPTION
It was weird that we benchmarked sha1crypt for two different iteration counts. I looked for a standard/default iteration count, but didn't find one, except 40000 here: https://rchouinard.github.io/phpass/api/class-PHPassLib.Hash.SHA1Crypt.html

I also found https://github.com/hashcat/hashcat/issues/1204 where sha1crypt was added to hashcat. @roycewilliams posted many test vectors to there, and all of those use various random'ish iteration counts around 20000. The actual hashcat tree now includes a test vector with exactly 20000. Since it's sometimes needed to compare JtR vs. hashcat benchmarks, I decided to go with 20000 in JtR as well, by simply adding hashcat's test vector and limiting our benchmark to it (but also using our other test vectors for self-test).

I squeeze a couple of unrelated cleanups into this PR (separate commits, and should be kept as such on rebase-and-merge, so they wouldn't be in any way associated with the sha1crypt changes in git history).