### PR TITLE
Fix for MPI with several GPU devices per node

### DIFF
--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -915,7 +915,7 @@ void opencl_load_environment(void)
 
 #ifdef HAVE_MPI
 		// Poor man's multi-device support.
-		if (mpi_p > 1 && mpi_p_local > 1) {
+		if (mpi_p > 1 && mpi_p_local != 1) {
 			// Pick device to use for this node
 			gpu_id = engaged_devices[mpi_id % get_number_of_devices_in_use()];
 


### PR DESCRIPTION
Under MPICH we can't know the local world size, so we can't draw any conclusions for how to pick GPU devices.  This fix moves the problem to mscash2-opencl only, as opposed to all formats but it.

Closes #4659