### PR TITLE
Oldoffice formats: Tweaks and fixes

### DIFF
--- a/run/opencl/oldoffice_kernel.cl
+++ b/run/opencl/oldoffice_kernel.cl
@@ -30,6 +30,7 @@ typedef struct {
 	uint has_extra;
 	uint extra[32/4];
 	volatile uint has_mitm;
+	uint mitm_reported;
 	uint mitm[8/4]; /* Meet-in-the-middle hint, if we have one */
 } salt_t;
 

--- a/src/oldoffice_common.h
+++ b/src/oldoffice_common.h
@@ -69,10 +69,11 @@ typedef struct {
 typedef struct {
 	unsigned char verifier[16]; /* or encryptedVerifier */
 	unsigned char verifierHash[20];  /* or encryptedVerifierHash */
-	unsigned int has_mitm;
-	unsigned char mitm[5]; /* Meet-in-the-middle hint, if we have one */
 	unsigned int has_extra;
 	unsigned char extra[32]; /* Optional extra data for avoiding FP w/ type 3 */
+	unsigned int has_mitm;
+	unsigned int mitm_reported;
+	unsigned char mitm[5]; /* Meet-in-the-middle hint, if we have one */
 } binary_blob;
 
 extern int *oo_cracked;


### PR DESCRIPTION
CPU format: Early-reject when possible (eg. 43% boost).
OpenCL format: Adjust internal mask target for better speed.
Both: Consistently log (as opposed to print) MITM keys when found, and also log when they're read from uid field upon initial loading.

Closes #4664

On a side note, any logging during loading doesn't end up in the log file (presumably because `log_init()` happens later), but it can be seen using `-log-stderr`

Tested with TS and manually, with and without `--keep-guessing` and with or without initially known MITM. Hopefully I didn't break anything.