### PR TITLE
DEScrypt-opencl: Fix for cache files with systemwide builds.

### DIFF
--- a/src/opencl_DES_bs_b_plug.c
+++ b/src/opencl_DES_bs_b_plug.c
@@ -15,7 +15,12 @@
 #include "../run/opencl/opencl_DES_hst_dev_shared.h"
 #include "mask_ext.h"
 
-#define CONFIG_FILE 	"$JOHN/opencl/DES_bs_kernel_b_%s.config"
+#if JOHN_SYSTEMWIDE
+#define CONFIG_FILE	JOHN_PRIVATE_HOME "/opencl/DES_bs_kernel_b_%s.config"
+#else
+#define CONFIG_FILE	"$JOHN/opencl/DES_bs_kernel_b_%s.config"
+#endif
+
 #define PADDING 	2048
 
 static cl_kernel **kernels;

--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -21,8 +21,14 @@
 #include "john.h"
 
 #define PADDING 	2048
-#define CONFIG_FILE 	"$JOHN/opencl/DES_bs_kernel_f_%s.config"
+
+#if JOHN_SYSTEMWIDE
+#define CONFIG_FILE	JOHN_PRIVATE_HOME "/opencl/DES_bs_kernel_f_%s.config"
+#define BINARY_FILE	JOHN_PRIVATE_HOME "/opencl/DES_bs_kernel_f_"Zu"_%s_%d.bin"
+#else
+#define CONFIG_FILE	"$JOHN/opencl/DES_bs_kernel_f_%s.config"
 #define BINARY_FILE	"$JOHN/opencl/DES_bs_kernel_f_"Zu"_%s_%d.bin"
+#endif
 
 static cl_kernel **kernels;
 static cl_mem buffer_bs_keys, buffer_unchecked_hashes;

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -21,8 +21,14 @@
 #include "john.h"
 
 #define PADDING 	2048
-#define CONFIG_FILE 	"$JOHN/opencl/DES_bs_kernel_h_%s.config"
+
+#if JOHN_SYSTEMWIDE
+#define CONFIG_FILE	JOHN_PRIVATE_HOME "/opencl/DES_bs_kernel_h_%s.config"
+#define BINARY_FILE	JOHN_PRIVATE_HOME "/opencl/DES_bs_kernel_h_"Zu"_%s_%d.bin"
+#else
+#define CONFIG_FILE	"$JOHN/opencl/DES_bs_kernel_h_%s.config"
 #define BINARY_FILE	"$JOHN/opencl/DES_bs_kernel_h_"Zu"_%s_%d.bin"
+#endif
 
 static cl_kernel **kernels;
 static cl_mem buffer_map, buffer_bs_keys, buffer_unchecked_hashes;

--- a/src/opencl_DES_bs_plug.c
+++ b/src/opencl_DES_bs_plug.c
@@ -1236,7 +1236,8 @@ void save_lws_config(const char* config_file, int id_gpu, size_t lws, unsigned i
 		fclose(file);
 		return;
 	}
-	file = fopen(config_file_name, "w");
+	if (!(file = fopen(config_file_name, "w")))
+		pexit("%s", config_file_name);
 
 	jtr_lock(fileno(file), F_SETLKW, F_WRLCK, config_file_name);
 

--- a/src/path.c
+++ b/src/path.c
@@ -78,6 +78,13 @@ void path_init(char **argv)
 		if (errno != EEXIST) pexit("mkdir: %s", private);
 	} else
 		fprintf(stderr, "Created directory: %s\n", private);
+#if HAVE_OPENCL
+	private = path_expand(JOHN_PRIVATE_HOME "/opencl");
+	if (mkdir(private, S_IRUSR | S_IWUSR | S_IXUSR)) {
+		if (errno != EEXIST) pexit("mkdir: %s", private);
+	} else
+		fprintf(stderr, "Created directory: %s\n", private);
+#endif
 #endif
 #else
 	if (argv[0]) {


### PR DESCRIPTION
We need to use JOHN_PRIVATE_HOME for files we write to.
Also, create the opencl subdirectory inside private home directory. This
was needed for the existing shared code as well.