### PR TITLE
OpenCL: Driver bug workaround for MacOS w/ AMD Vega

### DIFF
--- a/run/opencl/oldoffice_kernel.cl
+++ b/run/opencl/oldoffice_kernel.cl
@@ -497,6 +497,9 @@ void oldoffice_sha1(const nt_buffer_t *nt_buffer,
 		else if (cs->type != 3 || !cs->has_extra)
 			*result = 1;
 		else {
+#if __OS_X__
+			uint W[64/4]; /* Driver bug workaround for Apple w/ Vega */
+#endif
 			for (i = 0; i < 5; i++)
 				W[i] = key2[i];
 			W[5] = 0x01000000;


### PR DESCRIPTION
As usual, this was found by "throw stones at it and see what sticks". The `W` array is normally re-used for this block, and isn't used later. Yet adding this redundant local declaration stops AMD Radeon Pro Vega 20 from failing self-test under macOS (Big Sur 11.2.3), even though it should be a no-op after any optimizer.