### PR TITLE
OpenCL SHA-2: Reintroduce rotate-by-8 workaround for AMD Catalyst

### DIFF
--- a/run/opencl/opencl_sha2.h
+++ b/run/opencl/opencl_sha2.h
@@ -419,12 +419,18 @@ __constant ulong K[] = {
 
 #if gpu_amd(DEVICE_INFO) && SCALAR && defined(cl_amd_media_ops) && !__MESA__
 #pragma OPENCL EXTENSION cl_amd_media_ops : enable
-#define ror64(x, n)	((n) < 32 ? \
+#define opt_ror64(x, n)	((n) < 32 ? \
 	 (amd_bitalign((uint)((x) >> 32), (uint)(x), (uint)(n)) | \
 	  ((ulong)amd_bitalign((uint)(x), (uint)((x) >> 32), (uint)(n)) << 32)) \
 	 : \
 	 (amd_bitalign((uint)(x), (uint)((x) >> 32), (uint)(n) - 32) | \
 	  ((ulong)amd_bitalign((uint)((x) >> 32), (uint)(x), (uint)(n) - 32) << 32)))
+#if amd_gcn(DEVICE_INFO) && DEV_VER_MAJOR < 1912
+/* Bug seen with multiples of 8 */
+#define ror64(x, n) (((n) != 8) ? opt_ror64(x, n) : rotate(x, (ulong)(64 - n)))
+#else
+#define ror64(x, n) opt_ror64(x, n)
+#endif
 #elif __OS_X__ && gpu_nvidia(DEVICE_INFO)
 /* Bug workaround for OSX nvidia 10.2.7 310.41.25f01 */
 #define ror64(x, n)       ((x >> n) | (x << (64 - n)))


### PR DESCRIPTION
This workaround was dropped in 0c8a15685aad5214c53b4634170838318698f841 and is now being reintroduced for Catalyst only (not for newer AMD software).

This commit reduces the number of formats failing self-test on a certain old system with Tahiti and Catalyst from 22 to 13 (plus 1 for rar-opencl, which segfaults) out of 90 total.

See #4670