### PR TITLE
OpenCL: POCL fixes

### DIFF
--- a/doc/README-OPENCL
+++ b/doc/README-OPENCL
@@ -17,8 +17,9 @@ distribution, only the vendor-supplied drivers support OpenCL.  Either
 install fglrx (for old AMD cards) or nvidia dkms package or go directly
 with the ones provided by nvidia and ATI.
 
-Notice: Beignet, Mesa, and POCL are not officially supported, but may
-be usable in some OpenCL formats.
+Notice: Beignet and Mesa are not officially supported, but may be usable
+with some OpenCL formats.  POCL on the other hand has now been seen passing
+all self-tests (tested on Ubuntu 20.04 with bleeding-jumbo as of 2021/04/22).
 
 You can also use OpenCL with CPU, mostly useful if you have several
 (or loads of) cores.  This sometimes outperforms the CPU-only formats

--- a/run/opencl/gpg_kernel.cl
+++ b/run/opencl/gpg_kernel.cl
@@ -46,7 +46,7 @@ typedef struct {
 // Slower on CPU
 // 40% faster on Intel HD4000
 // Bugs out on nvidia
-#if !__CPU__ && !gpu_nvidia(DEVICE_INFO)
+#if __POCL__ || (!__CPU__ && !gpu_nvidia(DEVICE_INFO))
 #define LEAN
 #endif
 

--- a/run/opencl/opencl_DES_kernel_params.h
+++ b/run/opencl/opencl_DES_kernel_params.h
@@ -11,10 +11,10 @@ typedef unsigned WORD vtype;
  * Nvidia can build either kernel but GTX980 is significantly faster with the
  * "safe goto" version (7% faster for one salt, 16% for many salts).
  *
- * OSX' Intel HD4000 driver [1.2(Sep25 2014 22:26:04)] fails building the
- * "fast goto" version.
+ * macOS in general has problems building the "fast goto" version, and the
+ * same goes for MESA and POCL.
  */
-#if nvidia_sm_5x(DEVICE_INFO) || gpu_intel(DEVICE_INFO) || __MESA__ ||  \
+#if nvidia_sm_5x(DEVICE_INFO) || __OS_X__ || __MESA__ || __POCL__ || \
 	(gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR >= 1573 && !defined(__Tahiti__)) || \
 	(gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR >= 1702)
 //#warning Using 'safe goto' kernel

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1867,6 +1867,8 @@ void opencl_find_best_lws(size_t group_size_limit, int sequential_id,
 			fprintf(stderr, " %ss%s\n", ns2string(sumRunTime),
 			    ((double)(sumRunTime) / kernelExecTimeNs < 0.997)
 			        ? "+" : "");
+		if (sumRunTime > 2 * kernelExecTimeNs)
+			break;
 		if ((double)(sumRunTime) / kernelExecTimeNs < 0.997) {
 			kernelExecTimeNs = sumRunTime;
 			optimal_work_group = my_work_group;

--- a/src/options.c
+++ b/src/options.c
@@ -63,7 +63,8 @@ static char *costs_str;
 
 /* Common req_clr for --test, --test-full and --stress-test */
 #define TEST_REQ_CLR (~FLG_TEST_SET & ~FLG_FORMAT & ~FLG_SAVEMEM & ~FLG_MASK_CHK & ~FLG_NO_MASK_BENCH & \
-                      ~FLG_VERBOSITY & ~FLG_INPUT_ENC & ~FLG_SECOND_ENC & ~GETOPT_FLAGS & ~FLG_NOTESTS)
+                      ~FLG_VERBOSITY & ~FLG_INPUT_ENC & ~FLG_SECOND_ENC & ~GETOPT_FLAGS & ~FLG_NOTESTS & \
+                      ~FLG_SCALAR & ~FLG_VECTOR)
 
 static struct opt_entry opt_list[] = {
 	{"", FLG_PASSWD, 0, 0, 0, OPT_FMT_ADD_LIST, &options.passwd},


### PR DESCRIPTION
This stops GPG and DEScrypt OpenCL formats from crashing under POCL (as tested on Ubuntu 20.04) - making all formats pass self-test. It also adds a quick bail-out for when LWS auto-tune takes too long.