### PR TITLE
Fix integer overflow ubsan warning in adxcrypt_fmt_plug.c

### DIFF
--- a/src/adxcrypt_fmt_plug.c
+++ b/src/adxcrypt_fmt_plug.c
@@ -133,7 +133,7 @@ static void adxcrypt(char *input, unsigned char *output, int16_t length)
 
 	union {
 		char b[8];
-		int32_t w[2];
+		uint32_t w[2];
 	} buffer;
 
 	// setup work buffer


### PR DESCRIPTION
adxcrypt_fmt_plug.c:162:19: runtime error: signed integer overflow:
1916155959 + 2033990971 cannot be represented in type 'int'