### PR TITLE
Get next multiple

### DIFF
--- a/src/opencl_androidbackup_fmt_plug.c
+++ b/src/opencl_androidbackup_fmt_plug.c
@@ -276,7 +276,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu

--- a/src/opencl_common.h
+++ b/src/opencl_common.h
@@ -314,9 +314,13 @@ void opencl_process_event(void);
 #define jtrReleaseKernel(kernel) ({ cl_kernel _k = (kernel); (kernel) = NULL; clReleaseKernel(_k); })
 #define jtrReleaseProgram(program) ({ cl_program _p = (program); (program) = NULL; clReleaseProgram(_p); })
 
-/* Macro for get a multiple of a given value */
+/* Macro for getting a multiple of a given value */
 #define GET_NEXT_MULTIPLE(dividend, divisor)	  \
-	(divisor) ? ((dividend + (ocl_v_width * divisor - 1)) / (ocl_v_width * divisor)) * divisor : (dividend) / ocl_v_width;
+	(divisor) ? (((dividend) + ((divisor) - 1)) / (divisor)) * (divisor) : (dividend);
+
+/* Macro for translating 'count' (kpc) to GWS, taking vector width into account */
+#define GET_KPC_MULTIPLE(count, lws)	  \
+	(lws) ? (((count) + (ocl_v_width * (lws) - 1)) / (ocl_v_width * (lws))) * (lws) : ((count) + ocl_v_width - 1) / ocl_v_width;
 
 #define GET_MULTIPLE_OR_ZERO(dividend, divisor)	  \
 	((divisor) ? ((dividend / divisor) * divisor) : (dividend))

--- a/src/opencl_dashlane_fmt_plug.c
+++ b/src/opencl_dashlane_fmt_plug.c
@@ -264,7 +264,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	if (any_cracked) {

--- a/src/opencl_dmg_fmt_plug.c
+++ b/src/opencl_dmg_fmt_plug.c
@@ -494,7 +494,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu

--- a/src/opencl_encfs_fmt_plug.c
+++ b/src/opencl_encfs_fmt_plug.c
@@ -287,7 +287,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu

--- a/src/opencl_enpass_fmt_plug.c
+++ b/src/opencl_enpass_fmt_plug.c
@@ -326,7 +326,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int i, j;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
 	if (ocl_autotune_running || new_keys) {

--- a/src/opencl_iwork_fmt_plug.c
+++ b/src/opencl_iwork_fmt_plug.c
@@ -255,7 +255,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int i, j;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
 	if (ocl_autotune_running || new_keys) {

--- a/src/opencl_krb5_asrep_aes_fmt_plug.c
+++ b/src/opencl_krb5_asrep_aes_fmt_plug.c
@@ -331,7 +331,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int i, j;
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
-	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
+	size_t gws = GET_KPC_MULTIPLE(count, local_work_size);
 
 	scalar_gws = gws * ocl_v_width;
 

--- a/src/opencl_krb5pa-sha1_fmt_plug.c
+++ b/src/opencl_krb5pa-sha1_fmt_plug.c
@@ -500,7 +500,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int i, j;
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
-	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
+	size_t gws = GET_KPC_MULTIPLE(count, local_work_size);
 
 	scalar_gws = gws * ocl_v_width;
 

--- a/src/opencl_openbsdsoftraid_fmt_plug.c
+++ b/src/opencl_openbsdsoftraid_fmt_plug.c
@@ -265,7 +265,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu

--- a/src/opencl_pbkdf2_hmac_md4_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_md4_fmt_plug.c
@@ -266,7 +266,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	/// Copy data to gpu

--- a/src/opencl_pbkdf2_hmac_md5_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_md5_fmt_plug.c
@@ -263,7 +263,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	/// Copy data to gpu

--- a/src/opencl_pbkdf2_hmac_sha1_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha1_fmt_plug.c
@@ -287,7 +287,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	/// Copy data to gpu

--- a/src/opencl_pem_fmt_plug.c
+++ b/src/opencl_pem_fmt_plug.c
@@ -282,7 +282,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu

--- a/src/opencl_phpass_fmt_plug.c
+++ b/src/opencl_phpass_fmt_plug.c
@@ -220,7 +220,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	const int count = *pcount;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
 	if (new_keys) {

--- a/src/opencl_rakp_fmt_plug.c
+++ b/src/opencl_rakp_fmt_plug.c
@@ -379,7 +379,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" sgws "Zu" kidx %u\n", __FUNCTION__, count, local_work_size, global_work_size, scalar_gws, key_idx);

--- a/src/opencl_sha1crypt_fmt_plug.c
+++ b/src/opencl_sha1crypt_fmt_plug.c
@@ -161,10 +161,6 @@ static void init(struct fmt_main *_self)
 	self = _self;
 
 	opencl_prepare_dev(gpu_id);
-	/* Nvidia Kepler benefits from 2x interleaved code */
-	if (!options.v_width && nvidia_sm_3x(device_info[gpu_id]))
-		ocl_v_width = 2;
-	else
 	/* VLIW5 does better with just 2x vectors due to GPR pressure */
 	if (!options.v_width && amd_vliw5(device_info[gpu_id]))
 		ocl_v_width = 2;

--- a/src/opencl_sha1crypt_fmt_plug.c
+++ b/src/opencl_sha1crypt_fmt_plug.c
@@ -261,7 +261,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 #if 0
 	fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" sgws "Zu"\n", __FUNCTION__,

--- a/src/opencl_solarwinds_fmt_plug.c
+++ b/src/opencl_solarwinds_fmt_plug.c
@@ -265,7 +265,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int i, j;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
 	if (ocl_autotune_running || new_keys) {

--- a/src/opencl_telegram_fmt_plug.c
+++ b/src/opencl_telegram_fmt_plug.c
@@ -315,7 +315,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu

--- a/src/opencl_vmx_fmt_plug.c
+++ b/src/opencl_vmx_fmt_plug.c
@@ -260,7 +260,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int i, j;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
 	if (ocl_autotune_running || new_keys) {

--- a/src/opencl_wpapmk_fmt_plug.c
+++ b/src/opencl_wpapmk_fmt_plug.c
@@ -283,7 +283,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu

--- a/src/opencl_wpapsk_fmt_plug.c
+++ b/src/opencl_wpapsk_fmt_plug.c
@@ -294,7 +294,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu

--- a/src/wpapsk.h
+++ b/src/wpapsk.h
@@ -639,7 +639,7 @@ static int cmp_all(void *binary, int count)
 	size_t scalar_gws;
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
-	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 	scalar_gws = global_work_size * ocl_v_width;
 
 	cur_data.eapol_size = hccap->eapol_size;


### PR DESCRIPTION
Bugfix for LWS auto-tune getting stuck from vector width of 2, see #4703 

Also sha1crypt-opencl: Stop using x2 vectorizing for Kepler (separate commit) because it's slower now (at some point in time it was faster).