### PR TITLE
Add --list=format-classes option

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -63,6 +63,30 @@ static void test_fmt_case(struct fmt_main *format, void *binary,
 #endif
 
 /*
+ * List of format classes valid for this build (actually all are valid
+ * to ask for but we don't list those that can't match).
+ *
+ * This list is used in listconf.c and john.c
+ */
+char fmt_class_list[] = "all, enabled, disabled"
+#if _OPENMP
+	", omp"
+#endif
+#if HAVE_OPENCL || HAVE_ZTEX
+	", mask"
+#endif
+#if HAVE_ZTEX
+	", ztex"
+#endif
+#if HAVE_OPENCL
+	", opencl"
+#endif
+#ifndef DYNAMIC_DISABLED
+	", dynamic"
+#endif
+	", cpu";
+
+/*
  * Does req_format match format?
  *
  * req_format can be an exact full match or a wildc*rd, for format label,

--- a/src/formats.h
+++ b/src/formats.h
@@ -426,6 +426,11 @@ struct fmt_main {
  */
 extern char fmt_null_key[PLAINTEXT_BUFFER_SIZE];
 
+/*
+ * List of valid format classes for this build
+ */
+extern char fmt_class_list[];
+
 /* Self-test is running */
 extern int self_test_running;
 

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -107,14 +107,12 @@ extern char CPU_req_name[];
  */
 static void listconf_list_options()
 {
-	puts("help[:WHAT], subformats, inc-modes, rules, externals, ext-modes");
-	puts("ext-hybrids, ext-filters, ext-filters-only, build-info, encodings");
-	puts("formats, format-details, format-all-details, format-methods[:WHICH],");
-	// With "opencl-devices, <conf section name>" added,
-	// the resulting line will get too long
-	puts("format-tests, sections, parameters:SECTION, list-data:SECTION,");
+	puts("help[:WHAT], subformats, inc-modes, rules, externals, ext-modes, ext-hybrids,");
+	puts("ext-filters, ext-filters-only, build-info, encodings, formats, format-classes,");
+	puts("format-details, format-all-details, format-methods[:WHICH], format-tests,");
+	printf("sections, parameters:SECTION, list-data:SECTION, ");
 #if HAVE_OPENCL
-	printf("opencl-devices, ");
+	puts("opencl-devices,");
 #endif
 	/* NOTE: The following must end the list. Anything listed after
 	   <conf section name> will be ignored by current
@@ -419,6 +417,11 @@ void listconf_parse_early(void)
 			error_msg("--format not allowed with \"--list=%s\"\n", options.listconf);
 
 		listEncodings(stdout);
+		exit(EXIT_SUCCESS);
+	}
+	if (!strcasecmp(options.listconf, "format-classes"))
+	{
+		puts(fmt_class_list);
 		exit(EXIT_SUCCESS);
 	}
 }

--- a/src/options.c
+++ b/src/options.c
@@ -359,8 +359,8 @@ FUZZ_USAGE \
 "--subformat=FORMAT         Pick a benchmark format for --format=crypt\n" \
 "--format=[NAME|CLASS][,..] Force hash of type NAME. The supported formats can\n" \
 "                           be seen with --list=formats and --list=subformats.\n" \
-"                           Valid classes: dynamic, cpu, opencl, ztex, mask, omp,\n" \
-"                           all, enabled, disabled.\n"
+"                           See also doc/OPTIONS for more advanced selection of\n" \
+"                           format(s), including using classes and wildcards.\n"
 
 #if defined(HAVE_OPENCL)
 #define JOHN_USAGE_GPU \


### PR DESCRIPTION
This is mainly for things like bash-completion.
Closes #4636