### PR TITLE
Update copies of the hash function from unique.c

### DIFF
--- a/src/dummy.c
+++ b/src/dummy.c
@@ -2,6 +2,8 @@
  * This file is part of John the Ripper password cracker,
  * Copyright (c) 2011,2012 by Solar Designer
  *
+ * With many minor changes in jumbo by other contributors.
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  *
@@ -156,9 +158,10 @@ static MAYBE_INLINE uint32_t string_hash(char *s)
 		goto out;
 
 	while (*p) {
-		hash <<= 3; extra <<= 2;
+		hash <<= 5;
 		hash += (unsigned char)p[0];
 		if (!p[1]) break;
+		extra *= hash | 1812433253;
 		extra += (unsigned char)p[1];
 		p += 2;
 		if (hash & 0xe0000000) {

--- a/src/plaintext_fmt_plug.c
+++ b/src/plaintext_fmt_plug.c
@@ -104,9 +104,10 @@ static MAYBE_INLINE uint32_t string_hash(char *s)
 		goto out;
 
 	while (*p) {
-		hash <<= 3; extra <<= 2;
+		hash <<= 5;
 		hash += (unsigned char)p[0];
 		if (!p[1]) break;
+		extra *= hash | 1812433253;
 		extra += (unsigned char)p[1];
 		p += 2;
 		if (hash & 0xe0000000) {

--- a/src/rules.c
+++ b/src/rules.c
@@ -2033,9 +2033,10 @@ static int Hash(struct cfg_line *pLine) {
 		goto out;
 
 	while (*p) {
-		hash <<= 3; extra <<= 2;
+		hash <<= 5;
 		hash += (unsigned char)p[0];
 		if (!p[1]) break;
+		extra *= hash | 1812433253;
 		extra += (unsigned char)p[1];
 		p += 2;
 		if (hash & 0xe0000000) {

--- a/src/unshadow.c
+++ b/src/unshadow.c
@@ -49,9 +49,10 @@ static unsigned int login_hash(char *login)
 #endif
 
 	while (*p) {
-		hash <<= 3; extra <<= 2;
+		hash <<= 5;
 		hash += (unsigned char)p[0];
 		if (!p[1]) break;
+		extra *= hash | 1812433253;
 		extra += (unsigned char)p[1];
 		p += 2;
 		if (hash & 0xe0000000) {

--- a/src/unshadow.c
+++ b/src/unshadow.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of John the Ripper password cracker,
- * Copyright (c) 1996-2001,2005,2006,2011 by Solar Designer
+ * Copyright (c) 1996-2001,2005,2006,2011,2021 by Solar Designer
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -96,17 +96,6 @@ static void read_file(char *name, void (*process_line)(char *line))
 	if (fclose(file)) pexit("fclose");
 }
 
-static int space_or_tab(char c) {
-	if (c == ' ') {
-		return 1;
-	}
-	if (c == '\t') {
-		return 1;
-	}
-
-	return 0;
-}
-
 static void process_shadow_line(char *line)
 {
 	static struct shadow_entry **entry = NULL;
@@ -116,16 +105,13 @@ static void process_shadow_line(char *line)
 	/* AIX "password = " */
 	if (!(passwd = strchr(line, ':'))) {
 		/* skip spaces and tabs */
-		while (space_or_tab(*line))
-			line++;
+		line += strspn(line, " \t");
 		if (!strncmp(line, "password", 8)) {
 			line += 8;
-			while (space_or_tab(*line))
+			line += strspn(line, " \t");
+			if (*line == '=') {
 				line++;
-			if (!strncmp(line, "=", 1)) {
-				line++;
-				while (space_or_tab(*line))
-					line++;
+				line += strspn(line, " \t");
 				if (entry)
 					(*entry)->passwd = str_alloc_copy(line);
 			}

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -370,9 +370,10 @@ static MAYBE_INLINE unsigned int line_hash(char *line)
 		goto out;
 
 	while (*p) {
-		hash <<= 3; extra <<= 2;
+		hash <<= 5;
 		hash += (unsigned char)p[0];
 		if (!p[1]) break;
+		extra *= hash | 1812433253;
 		extra += (unsigned char)p[1];
 		p += 2;
 		if (hash & 0xe0000000) {


### PR DESCRIPTION
This is expected to speed up those uses on recent CPUs (with fast integer multiplication) when the number of elements is large. I've confirmed that this does speed up cracking of 1M "dummy" "hashes" with incremental mode. I didn't test the effect of these changes on other 4 features patched here, but I expect it to also be positive.

We also have a similar but subtly different hash function in `ldr_cracked_hash()` and copied to many other places. I've tried making similar changes to its instance in `ldr_cracked_hash()`, but this actually slowed down `--show` of 10M NT hashes, so I am not patching any instances of that subtly different hash function. It is reasonable for these two to actually be different: one (being patched in this PR) is commonly applied to plaintexts or plaintext-equivalents, the other to ASCII-encoded hashes.

I also squeeze a mostly unrelated commit in here, replacing (cleaning up and simplifying) changes to unshadow.c that were part of an external PR in 2017. I've tested this on one passwd+shadow entry.