### PR TITLE
Incremental mode restore bug fix and safety

### DIFF
--- a/src/inc.c
+++ b/src/inc.c
@@ -806,8 +806,10 @@ void do_incremental_crack(struct db_main *db, const char *mode)
 		    count >= CHARSET_SIZE)
 			inc_format_error(charset);
 
-		if (entry != rec_entry)
+		if (entry != rec_entry) {
 			memset(numbers, 0, sizeof(numbers));
+			status.resume_salt = 0; /* safety for manual edits */
+		}
 
 		if (count >= real_count || (fixed && !count))
 			continue;

--- a/src/inc.c
+++ b/src/inc.c
@@ -782,6 +782,7 @@ void do_incremental_crack(struct db_main *db, const char *mode)
 		}
 	}
 
+	length = rec_length; /* should also match *ptr */
 	memcpy(numbers, rec_numbers, sizeof(numbers));
 
 	crk_init(db, fix_state, NULL);


### PR DESCRIPTION
"Incremental mode: Correct length written to .rec right after --restore" fixes a bug coming from core (which I've also reproduced even on 1.8.0 core, and also needing to be fixed in core). The bug resulted in a wrong length and a wrong set of per-length indices written to the initial .rec overwritten right after `--restore`. Correct data was then written after a save interval or when interrupting the session, so this only affected cases of abnormal termination (e.g., power outage) during the first save interval after a restore. Even when that happened, I think the impact was minor - either none at all (if a larger length was written) or some work redone (if a smaller length was written, leaving the last few should-be-restored indices as 0's).

"Incremental mode: Auto-disable salt restore on some manual edits of .rec" doesn't fix any bug, but helps avoid wrong skipping of candidates against some salts when a .rec file is edited manually such that some entries would be skipped right upon restore - that is, if (different) length constraints are added than were used in the interrupted session. Oh, I just realized this also applies when editing MinLen/MaxLen in `john.conf`.