### PR TITLE
Fix tunable cost names and enhance self tests

### DIFF
--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -292,7 +292,7 @@ struct fmt_main fmt_KeePass = {
 		{
 			"iteration count",
 			"version",
-			"algorithm [0=AES, 1=TwoFish, 2=ChaCha]",
+			"algorithm [0=AES 1=TwoFish 2=ChaCha]",
 		},
 		{ FORMAT_TAG },
 		keepass_tests

--- a/src/odf_fmt_plug.c
+++ b/src/odf_fmt_plug.c
@@ -256,7 +256,7 @@ struct fmt_main fmt_odf = {
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
 		{
 			"iteration count",
-			"crypto [0=Blowfish, 1=AES]",
+			"crypto [0=Blowfish 1=AES]",
 		},
 		{ FORMAT_TAG },
 		odf_tests

--- a/src/opencl_keepass_fmt_plug.c
+++ b/src/opencl_keepass_fmt_plug.c
@@ -320,7 +320,7 @@ struct fmt_main fmt_ocl_KeePass = {
 		{
 			"iteration count",
 			"version",
-			"algorithm [0=AES, 1=TwoFish, 2=ChaCha]",
+			"algorithm [0=AES 1=TwoFish 2=ChaCha]",
 		},
 		{ FORMAT_TAG },
 		keepass_tests

--- a/src/opencl_odf_fmt_plug.c
+++ b/src/opencl_odf_fmt_plug.c
@@ -293,7 +293,7 @@ struct fmt_main fmt_opencl_odf_aes = {
 		FMT_CASE | FMT_8_BIT | FMT_HUGE_INPUT,
 		{
 			"iteration count",
-			"crypto [0=Blowfish, 1=AES]",
+			"crypto [0=Blowfish 1=AES]",
 		},
 		{ FORMAT_TAG },
 		odf_tests

--- a/src/opencl_pem_fmt_plug.c
+++ b/src/opencl_pem_fmt_plug.c
@@ -349,7 +349,7 @@ struct fmt_main fmt_opencl_pem = {
 		FMT_CASE | FMT_8_BIT | FMT_HUGE_INPUT,
 		{
 			"iteration count",
-			"cipher [1=3DES, 2/3/4=AES-128/192/256]",
+			"cipher [1=3DES 2/3/4=AES-128/192/256]",
 		},
 		{ FORMAT_TAG },
 		pem_tests

--- a/src/opencl_pgpdisk_fmt_plug.c
+++ b/src/opencl_pgpdisk_fmt_plug.c
@@ -330,7 +330,7 @@ struct fmt_main fmt_opencl_pgpdisk = {
 		FMT_CASE | FMT_8_BIT,
 		{
 			"iteration count",
-			"algorithm [3=CAST, 4=TwoFish, 5/6/7=AES]",
+			"algorithm [3=CAST 4=TwoFish 5/6/7=AES]",
 		},
 		{ FORMAT_TAG },
 		pgpdisk_tests,

--- a/src/pem_fmt_plug.c
+++ b/src/pem_fmt_plug.c
@@ -169,7 +169,7 @@ struct fmt_main fmt_pem = {
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
 		{
 			"iteration count",
-			"cipher [1=3DES, 2/3/4=AES-128/192/256]",
+			"cipher [1=3DES 2/3/4=AES-128/192/256]",
 		},
 		{ FORMAT_TAG },
 		pem_tests

--- a/src/pgpdisk_fmt_plug.c
+++ b/src/pgpdisk_fmt_plug.c
@@ -229,7 +229,7 @@ struct fmt_main fmt_pgpdisk = {
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
 		{
 			"iteration count",
-			"algorithm [3=CAST, 4=TwoFish, 5/6/7=AES]",
+			"algorithm [3=CAST 4=TwoFish 5/6/7=AES]",
 		},
 		{ FORMAT_TAG },
 		pgpdisk_tests


### PR DESCRIPTION
First commit: Fix tunable cost names, removing commas.

Second commit: Add tunable cost specific tests to format self tests.