### PR TITLE
relbench enhancement to avoid reporting wrong speeds

### DIFF
--- a/run/relbench
+++ b/run/relbench
@@ -77,7 +77,7 @@ sub parse
 			return;
 		}
 	} else {
-		($name) = /^\t?Benchmarking: ([^\[]+) \[.*\].* (PASS, |SKIP, |.....\b\b\b\b\b)?(DONE|Warning:.*)$/;
+		($name) = /^.*Benchmarking: ([^\[]+) \[.*\].* (PASS, |SKIP, |.....\b\b\b\b\b)?(DONE|Warning:.*)$/;
 		$ok = defined($name);
 	}
 	print STDERR "Could not parse: $_\n" if (!$ok);


### PR DESCRIPTION
A sequence of
$ ./john --test=-1 --format=$f >> file
where some formats cause segfaults might result in lines
Benchmarking: format1 [algorithm 1]... Benchmarking: format2 [algorithm 2]... DONE
This change picks the Last "Benchmarking: " output per line.