### PR TITLE
RAR formats: Optionally build without non-free unrar code

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -187,7 +187,12 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   [magnum; 2021]
 
 - Improved Monero support: Now supports legacy wallets from before 2016 that are
-  not using JSON format yet. [patrickd, magnumripper, solardiz; 2021]
+  not using JSON format yet.  [patrickd; 2021]
+
+- Add --without-unrar option to configure, for building without the non-free
+  ClamAV unrar code (crippling the RAR v3 formats a little).  Simply deleting
+  src/unrar*.[ch] will infer that option as well.  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/README-DISTROS
+++ b/doc/README-DISTROS
@@ -1,3 +1,10 @@
+Our source tree includes ClamAV unrar code which is non-free.  Distros can build
+without it using --without-unrar option to configure (crippling the RAR v3
+formats a little).  Simply deleting src/unrar*.[ch] before running configure
+will infer that option as well.
+
+--
+
 Here's how to build a CPU-fallback chain (with OpenMP fallback too) for
 distros. See params.h for some background detail. The only actually tricky
 part is escaping the quotes enough to survive just long enough.

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -93,7 +93,7 @@ JOHN_OBJS = \
 	dynamic_fmt.o dynamic_parser.o dynamic_preloads.o dynamic_utils.o dynamic_big_crypt.o \
 	dynamic_compiler.o dynamic_compiler_lib.o \
 	ripemd.o tiger.o \
-	unrarcmd.o unrarfilter.o unrarhlp.o unrar.o unrarppm.o unrarvm.o \
+	@UNRAR_OBJS@ \
 	rar2john.o \
 	zip2john.o pkzip.o \
 	$(PLUGFORMATS_OBJS) \

--- a/src/autoconfig.h.in
+++ b/src/autoconfig.h.in
@@ -324,6 +324,9 @@
 /* Define to 1 if you have the <unixlib/local.h> header file. */
 #undef HAVE_UNIXLIB_LOCAL_H
 
+/* Define to 1 if you have the ClamAV unrar files. */
+#undef HAVE_UNRAR
+
 /* Define to 1 if you have the `vfork' function. */
 #undef HAVE_VFORK
 

--- a/src/configure
+++ b/src/configure
@@ -663,6 +663,7 @@ CRYPT_LIBS
 Z_LIBS
 RT_LIBS
 M_LIBS
+UNRAR_OBJS
 OPENSSL_LIBS
 OPENSSL_CFLAGS
 JOHN_NO_SIMD
@@ -749,6 +750,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 with_openssl
+with_unrar
 with_endian
 with_systemwide
 enable_asan
@@ -1415,6 +1417,8 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --without-openssl       Do not use OpenSSL (exclude much functionality)
+  --without-unrar         Omit non-free unrar code (rendering RAR v3 support
+                          incomplete)
   --with-endian=little|big
                           Set endianness for target if it doesn't detect
                           properly
@@ -3408,6 +3412,14 @@ if test "${with_openssl+set}" = set; then :
   withval=$with_openssl;
 else
   with_openssl=yes
+fi
+
+
+# Check whether --with-unrar was given.
+if test "${with_unrar+set}" = set; then :
+  withval=$with_unrar;
+else
+  with_unrar=yes
 fi
 
 
@@ -12403,6 +12415,33 @@ fi
 
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for (non-free) ClamAV unrar code" >&5
+$as_echo_n "checking for (non-free) ClamAV unrar code... " >&6; }
+if test $with_unrar = yes; then
+  for sf in unrar.c unrarcmd.c unrarfilter.c unrarhlp.c unrarppm.c unrarvm.c unrar.h unrarcmd.h unrarfilter.h unrarhlp.h unrarppm.h unrarvm.h; do
+    if test ! -s $sf; then
+      unrar_files="no (files missing)"
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+      break
+    fi
+  done
+  if test -z "$unrar_files"; then
+    unrar_files="yes"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_UNRAR 1" >>confdefs.h
+
+    UNRAR_OBJS="unrarcmd.o unrarfilter.o unrarhlp.o unrar.o unrarppm.o unrarvm.o"
+
+  fi
+else
+  unrar_files="no (disabled)"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: disabled" >&5
+$as_echo "disabled" >&6; }
+fi
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sqrt in -lm" >&5
 $as_echo_n "checking for sqrt in -lm... " >&6; }
 if ${ac_cv_lib_m_sqrt+:} false; then :
@@ -16418,7 +16457,6 @@ else
   { $as_echo "$as_me:${as_lineno-$LINENO}: creating *_plug.c rules" >&5
 $as_echo "$as_me: creating *_plug.c rules" >&6;}
 fi
-
 if test "`echo *_plug.c`" != "*_plug.c"; then
    PLUGFORMATS_OBJS=`echo *_plug.c | sed 's/opencl[A-Za-z0-9_\-]*\.c //g;s/\.c/.o/g'`
 
@@ -17973,6 +18011,7 @@ libgmp (PRINCE mode and faster SRP formats)  ${ac_cv_lib_gmp___gmpz_init}
 libz (pkzip and some other formats) ........ ${using_zlib}
 libbz2 (gpg2john extra decompression logic)  ${using_bz2}
 libpcap (vncpcap2john and SIPdump) ......... ${using_pcap}
+Non-free unrar code (complete RAR support) . ${unrar_files}
 OpenMPI support (default disabled) ......... ${using_mpi}
 ZTEX USB-FPGA module 1.15y support ......... ${ztex}
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -55,6 +55,7 @@ AC_ARG_VAR([LD], [full pathname of linker to use])
 dnl Define Packages.
 dnl Use OpenSSL (default: yes).
 AC_ARG_WITH(openssl, [AS_HELP_STRING([--without-openssl],[Do not use OpenSSL (exclude much functionality)])],,[with_openssl=yes])
+AC_ARG_WITH(unrar, [AS_HELP_STRING([--without-unrar],[Omit non-free unrar code (rendering RAR v3 support incomplete)])],,[with_unrar=yes])
 dnl Cludge for endian (if not auto detected)
 AC_ARG_WITH(endian, [AS_HELP_STRING([--with-endian=little|big],[Set endianness for target if it doesn't detect properly])],,[endian=unknown])
 dnl -DJOHN_SYSTEMWIDE
@@ -614,6 +615,26 @@ else
   fi]
 )
 
+AC_MSG_CHECKING([for (non-free) ClamAV unrar code])
+if test $with_unrar = yes; then
+  for sf in unrar.c unrarcmd.c unrarfilter.c unrarhlp.c unrarppm.c unrarvm.c unrar.h unrarcmd.h unrarfilter.h unrarhlp.h unrarppm.h unrarvm.h; do
+    if test ! -s $sf; then
+      unrar_files="no (files missing)"
+      AC_MSG_RESULT([no])
+      break
+    fi
+  done
+  if test -z "$unrar_files"; then
+    unrar_files="yes"
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(HAVE_UNRAR, 1, [Define to 1 if you have the ClamAV unrar files.])
+    AC_SUBST([UNRAR_OBJS], "unrarcmd.o unrarfilter.o unrarhlp.o unrar.o unrarppm.o unrarvm.o")
+  fi
+else
+  unrar_files="no (disabled)"
+  AC_MSG_RESULT([disabled])
+fi
+
 AC_CHECK_LIB([m],[sqrt],[AC_DEFINE(HAVE_LIBM,1,[Define to 1 if you have the `m' library (-lm).])] [AC_SUBST(M_LIBS, [-lm])],[AC_MSG_FAILURE(JtR requires libm being installed,1)])
 AC_CHECK_LIB([rt],[clock_gettime],[AC_DEFINE(HAVE_LIBRT,1,[Define to 1 if you have clock_gettime in the `rt' library (-lrt).])] [AC_SUBST(RT_LIBS, [-lrt])])
 AC_CHECK_LIB([z],[deflate],[AC_DEFINE(HAVE_LIBZ,1,[Define to 1 if you have the `z' library (-lz).])] [AC_SUBST(Z_LIBS, [-lz])])
@@ -1065,7 +1086,6 @@ if test x$using_cl = xyes ; then
 else
   AC_MSG_NOTICE([creating *_plug.c rules])
 fi
-
 if test "`echo *_plug.c`" != "*_plug.c"; then
    AC_SUBST([PLUGFORMATS_OBJS],[`echo *_plug.c | sed 's/opencl[[A-Za-z0-9_\-]]*\.c //g;s/\.c/.o/g'`])
    AC_SUBST([OPENCL_PLUGFORMATS_OBJS],[`echo opencl*_plug.c | sed 's/\.c/.o/g'`])
@@ -1261,6 +1281,7 @@ libgmp (PRINCE mode and faster SRP formats)  ${ac_cv_lib_gmp___gmpz_init}
 libz (pkzip and some other formats) ........ ${using_zlib}
 libbz2 (gpg2john extra decompression logic)  ${using_bz2}
 libpcap (vncpcap2john and SIPdump) ......... ${using_pcap}
+Non-free unrar code (complete RAR support) . ${unrar_files}
 OpenMPI support (default disabled) ......... ${using_mpi}
 ZTEX USB-FPGA module 1.15y support ......... ${ztex}
 

--- a/src/rar_common.c
+++ b/src/rar_common.c
@@ -9,6 +9,11 @@
 #include "misc.h"	// error()
 #include "john.h"
 #include "loader.h"
+#if AC_BUILT
+#include "autoconfig.h"
+#else
+#define HAVE_UNRAR 1
+#endif
 
 #define BINARY_SIZE     sizeof(fmt_data)
 #define BINARY_ALIGN    sizeof(size_t)
@@ -39,11 +44,14 @@ static struct fmt_tests cpu_tests[] = {
 	{"$RAR3$*0*56ce6de6ddee17fb*4c957e533e00b0e18dfad6accc490ad9", "john"},
 	/* -p mode tests, -m0 and -m3 (in that order) */
 	{"$RAR3$*1*c47c5bef0bbd1e98*965f1453*48*47*1*c5e987f81d316d9dcfdb6a1b27105ce63fca2c594da5aa2f6fdf2f65f50f0d66314f8a09da875ae19d6c15636b65c815*30", "test"},
+#if HAVE_UNRAR
 	{"$RAR3$*1*b4eee1a48dc95d12*965f1453*64*47*1*0fe529478798c0960dd88a38a05451f9559e15f0cf20b4cac58260b0e5b56699d5871bdcc35bee099cc131eb35b9a116adaedf5ecc26b1c09cadf5185b3092e6*33", "test"},
 	/* issue #2899 unrar bug */
 	{"$RAR3$*1*00d7bc908cd4ad64*cc4b574e*16*7*1*58b582307dd07e0082a742d3f5d91ad3*33", "abc"},
 	//{"$RAR3$*1*fa0d20d2d9868510*cc4b574e*16*7*1*48a4b1de0795cd2adb2fab5f89b4d916*33", "1я1"}, /* UTF-8 needed */
+#endif /* HAVE_UNRAR */
 #ifdef DEBUG
+#if HAVE_UNRAR
 	/* Various lengths, these should be in self-test but not benchmark */
 	/* from CMIYC 2012 */
 	{"$RAR3$*1*0f263dd52eead558*834015cd*384*693*1*e28e9648f51b59e32f573b302f0e94aadf1050678b90c38dd4e750c7dd281d439ab4cccec5f1bd1ac40b6a1ead60c75625666307171e0fe2639d2397d5f68b97a2a1f733289eac0038b52ec6c3593ff07298fce09118c255b2747a02c2fa3175ab81166ebff2f1f104b9f6284a66f598764bd01f093562b5eeb9471d977bf3d33901acfd9643afe460e1d10b90e0e9bc8b77dc9ac40d40c2d211df9b0ecbcaea72c9d8f15859d59b3c85149b5bb5f56f0218cbbd9f28790777c39e3e499bc207289727afb2b2e02541b726e9ac028f4f05a4d7930efbff97d1ffd786c4a195bbed74997469802159f3b0ae05b703238da264087b6c2729d9023f67c42c5cbe40b6c67eebbfc4658dfb99bfcb523f62133113735e862c1430adf59c837305446e8e34fac00620b99f574fabeb2cd34dc72752014cbf4bd64d35f17cef6d40747c81b12d8c0cd4472089889a53f4d810b212fb314bf58c3dd36796de0feeefaf26be20c6a2fd00517152c58d0b1a95775ef6a1374c608f55f416b78b8c81761f1d*33:1::to-submit-challenges.txt", "wachtwoord"},
@@ -51,6 +59,7 @@ static struct fmt_tests cpu_tests[] = {
 	{"$RAR3$*1*79e17c26407a7d52*834015cd*384*693*1*6844a189e732e9390b5a958b623589d5423fa432d756fd00940ac31e245214983507a035d4e0ee09469491551759a66c12150fe6c5d05f334fb0d8302a96d48ef4da04954222e0705507aaa84f8b137f284dbec344eee9cea6b2c4f63540c64df3ee8be3013466d238c5999e9a98eb6375ec5462869bba43401ec95077d0c593352339902c24a3324178e08fe694d11bfec646c652ffeafbdda929052c370ffd89168c83194fedf7c50fc7d9a1fbe64332063d267a181eb07b5d70a5854067db9b66c12703fde62728d3680cf3fdb9933a0f02bfc94f3a682ad5e7c428d7ed44d5ff554a8a445dea28b81e3a2631870e17f3f3c0c0204136802c0701590cc3e4c0ccd9f15e8be245ce9caa6969fab9e8443ac9ad9e73e7446811aee971808350c38c16c0d3372c7f44174666d770e3dd321e8b08fb2dc5e8a6a5b2a1720bad66e54abc194faabc5f24225dd8fee137ba5d4c2ed48c6462618e6333300a5b8dfc75c65608925e786eb0988f7b3a5ab106a55168d1001adc47ce95bba77b38c35b*33:1::to-submit-challenges.txt", "P-i-r-A-T-E"},
 	{"$RAR3$*1*e1df79fd9ee1dadf*771a163b*64*39*1*edc483d67b94ab22a0a9b8375a461e06fa1108fa72970e16d962092c311970d26eb92a033a42f53027bdc0bb47231a12ed968c8d530a9486a90cbbc00040569b*33", "333"},
 	{"$RAR3$*1*c83c00534d4af2db*771a163b*64*39*1*05244526d6b32cb9c524a15c79d19bba685f7fc3007a9171c65fc826481f2dce70be6148f2c3497f0d549aa4e864f73d4e4f697fdb66ff528ed1503d9712a414*33", "11eleven111"},
+#endif /* HAVE_UNRAR */
 	{"$RAR3$*0*c203c4d80a8a09dc*49bbecccc08b5d893f308bce7ad36c0f", "sator"},
 	{"$RAR3$*0*672fca155cb74ac3*8d534cd5f47a58f6493012cf76d2a68b", "arepo"},
 	{"$RAR3$*0*c203c4d80a8a09dc*c3055efe7ca6587127fd541a5b88e0e4", "tenet"},
@@ -71,7 +80,7 @@ static struct fmt_tests cpu_tests[] = {
 	{"$RAR3$*0*5fa43f823a60da63*af2630863e12046e42c4501c915636c9", "eleven11111"},
 	{"$RAR3$*0*5fa43f823a60da63*88c0840d0bd98844173d35f867558ec2", "twelve121212"},
 	{"$RAR3$*0*4768100a172fa2b6*48edcb5283ee2e4f0e8edb25d0d85eaa", "subconsciousness"},
-#endif
+#endif /* DEBUG */
 	{NULL}
 };
 
@@ -84,16 +93,19 @@ static struct fmt_tests gpu_tests[] = {
 	{"$RAR3$*0*c203c4d80a8a09dc*1f406154556d4c895a8be207fd2b5d0c", "rotas"},
 	/* -p mode tests, -m0 and -m3 (in that order) */
 	{"$RAR3$*1*c47c5bef0bbd1e98*965f1453*48*47*1*c5e987f81d316d9dcfdb6a1b27105ce63fca2c594da5aa2f6fdf2f65f50f0d66314f8a09da875ae19d6c15636b65c815*30", "test"},
+#if HAVE_UNRAR
 	{"$RAR3$*1*b4eee1a48dc95d12*965f1453*64*47*1*0fe529478798c0960dd88a38a05451f9559e15f0cf20b4cac58260b0e5b56699d5871bdcc35bee099cc131eb35b9a116adaedf5ecc26b1c09cadf5185b3092e6*33", "test"},
 	/* issue #2899 unrar bug */
 	{"$RAR3$*1*00d7bc908cd4ad64*cc4b574e*16*7*1*58b582307dd07e0082a742d3f5d91ad3*33", "abc"},
 	//{"$RAR3$*1*fa0d20d2d9868510*cc4b574e*16*7*1*48a4b1de0795cd2adb2fab5f89b4d916*33", "1я1"}, /* UTF-8 needed */
+#endif /* HAVE_UNRAR */
 #ifdef DEBUG
 	{"$RAR3$*0*af24c0c95e9cafc7*e7f207f30dec96a5ad6f917a69d0209e", "magnum"},
 	{"$RAR3$*0*2653b9204daa2a8e*39b11a475f486206e2ec6070698d9bbc", "123456"},
 	{"$RAR3$*0*63f1649f16c2b687*8a89f6453297bcdb66bd756fa10ddd98", "abc123"},
 	/* -p mode tests, -m0 and -m3 (in that order) */
 	{"$RAR3$*1*575b083d78672e85*965f1453*48*47*1*cd3d8756438f43ab70e668792e28053f0ad7449af1c66863e3e55332bfa304b2c082b9f23b36cd4a8ebc0b743618c5b2*30", "magnum"},
+#if HAVE_UNRAR
 	{"$RAR3$*1*6f5954680c87535a*965f1453*64*47*1*c9bb398b9a5d54f035fd22be54bc6dc75822f55833f30eb4fb8cc0b8218e41e6d01824e3467475b90b994a5ddb7fe19366d293c9ee305316c2a60c3a7eb3ce5a*33", "magnum"},
 	/* Various lengths, these should be in self-test but not benchmark */
 	/* from CMIYC 2012 */
@@ -102,6 +114,7 @@ static struct fmt_tests gpu_tests[] = {
 	{"$RAR3$*1*79e17c26407a7d52*834015cd*384*693*1*6844a189e732e9390b5a958b623589d5423fa432d756fd00940ac31e245214983507a035d4e0ee09469491551759a66c12150fe6c5d05f334fb0d8302a96d48ef4da04954222e0705507aaa84f8b137f284dbec344eee9cea6b2c4f63540c64df3ee8be3013466d238c5999e9a98eb6375ec5462869bba43401ec95077d0c593352339902c24a3324178e08fe694d11bfec646c652ffeafbdda929052c370ffd89168c83194fedf7c50fc7d9a1fbe64332063d267a181eb07b5d70a5854067db9b66c12703fde62728d3680cf3fdb9933a0f02bfc94f3a682ad5e7c428d7ed44d5ff554a8a445dea28b81e3a2631870e17f3f3c0c0204136802c0701590cc3e4c0ccd9f15e8be245ce9caa6969fab9e8443ac9ad9e73e7446811aee971808350c38c16c0d3372c7f44174666d770e3dd321e8b08fb2dc5e8a6a5b2a1720bad66e54abc194faabc5f24225dd8fee137ba5d4c2ed48c6462618e6333300a5b8dfc75c65608925e786eb0988f7b3a5ab106a55168d1001adc47ce95bba77b38c35b*33:1::to-submit-challenges.txt", "P-i-r-A-T-E"},
 	{"$RAR3$*1*e1df79fd9ee1dadf*771a163b*64*39*1*edc483d67b94ab22a0a9b8375a461e06fa1108fa72970e16d962092c311970d26eb92a033a42f53027bdc0bb47231a12ed968c8d530a9486a90cbbc00040569b*33", "333"},
 	{"$RAR3$*1*c83c00534d4af2db*771a163b*64*39*1*05244526d6b32cb9c524a15c79d19bba685f7fc3007a9171c65fc826481f2dce70be6148f2c3497f0d549aa4e864f73d4e4f697fdb66ff528ed1503d9712a414*33", "11eleven111"},
+#endif /* HAVE_UNRAR */
 	{"$RAR3$*0*345f5f573a077ad7*638e388817cc7851e313406fd77730b9", "Boustrophedon"},
 	{"$RAR3$*0*c9dea41b149b53b4*fcbdb66122d8ebdb32532c22ca7ab9ec", "password"},
 	{"$RAR3$*0*7ce241baa2bd521b*f2b26d76424efa351c728b321671d074", "@"},
@@ -117,7 +130,7 @@ static struct fmt_tests gpu_tests[] = {
 	{"$RAR3$*0*5fa43f823a60da63*af2630863e12046e42c4501c915636c9", "eleven11111"},
 	{"$RAR3$*0*5fa43f823a60da63*88c0840d0bd98844173d35f867558ec2", "twelve121212"},
 	{"$RAR3$*0*4768100a172fa2b6*48edcb5283ee2e4f0e8edb25d0d85eaa", "subconsciousness"},
-#endif
+#endif /* DEBUG */
 	{NULL}
 };
 #endif
@@ -418,6 +431,15 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		}
 		if (!(ptr = strtokm(NULL, "*"))) /* method */
 			goto error;
+#if !HAVE_UNRAR
+		if (atoi(ptr) != 30) {
+			static int warned;
+
+			if (!warned++ && john_main_process)
+				fprintf(stderr, "Warning: Packed RAR hash(es) seen but ignored, this build does not support them.\n");
+			goto error;
+		}
+#endif
 	}
 	MEM_FREE(keeptr);
 	return 1;
@@ -590,7 +612,9 @@ inline static void check_rar(rar_file *cur_file, int index, unsigned char *key, 
 			/* Compare computed CRC with stored CRC */
 			cracked[index] = !memcmp(crc_out, &cur_file->crc.c, 4);
 			return;
-		} else {
+		}
+#if HAVE_UNRAR
+		else {
 			const int solid = 0;
 			unpack_data_t *unpack_t;
 			unsigned char pre_iv[16];
@@ -637,6 +661,7 @@ inline static void check_rar(rar_file *cur_file, int index, unsigned char *key, 
 			else
 				cracked[index] = 0;
 		}
+#endif /* HAVE_UNRAR */
 	}
 }
 


### PR DESCRIPTION
If unrar sources are missing or `--without-unrar` is used with `configure`, build RAR v3 formats without the unrar code.  We can then only attack stored files or archives with header protection.

Closes #4731