### PR TITLE
Review aliasing violations in OpenCL code

### DIFF
--- a/run/opencl/axcrypt2_kernel.cl
+++ b/run/opencl/axcrypt2_kernel.cl
@@ -15,16 +15,16 @@
 #include "opencl_aes.h"
 
 #define PUT_64BITS_XOR_LSB(cp, value) ( \
-		(cp)[4] ^= (unsigned char)((value) >> 24), \
-		(cp)[5] ^= (unsigned char)((value) >> 16), \
-		(cp)[6] ^= (unsigned char)((value) >> 8),  \
-		(cp)[7] ^= (unsigned char)((value)) )
+		(cp)[4] ^= (uchar)((value) >> 24), \
+		(cp)[5] ^= (uchar)((value) >> 16), \
+		(cp)[6] ^= (uchar)((value) >> 8),  \
+		(cp)[7] ^= (uchar)((value)) )
 
 typedef struct {
 	salt_t pbkdf2;
 	uint key_wrapping_rounds;
 	uchar salt[64];
-	uchar wrappedkey[144];
+	uint wrappedkey[144/4];
 } axcrypt2_salt_t;
 
 typedef struct {
@@ -32,8 +32,8 @@ typedef struct {
 } out_t;
 
 __kernel void axcrypt2_final(__global crack_t *pbkdf2,
-                         __constant axcrypt2_salt_t *salt,
-                         __global out_t *out)
+                             __constant axcrypt2_salt_t *salt,
+                             __global out_t *out)
 {
 	uint gid = get_global_id(0);
 
@@ -48,12 +48,16 @@ __kernel void axcrypt2_final(__global crack_t *pbkdf2,
 	for (i = 0; i < 8; i++)
 		key.u[i] = SWAP64(pbkdf2[gid].hash[i]);
 
-	unsigned char KEK[32];
+	uchar KEK[32];
 	AES_KEY akey;
 	int halfblocklen = 16 / 2;
 	int wrappedkeylen = 56 - halfblocklen;
-	unsigned char wrapped[144];
-	unsigned char block[16];
+	union {
+		uchar c[144];
+		uint w[144/4];
+		ulong l[144/8];
+	} wrapped;
+	uchar block[16];
 	int t;
 
 	memset_p(KEK, 0, 32);
@@ -66,25 +70,25 @@ __kernel void axcrypt2_final(__global crack_t *pbkdf2,
 
 	AES_set_decrypt_key(KEK, 256, &akey);
 
-	memcpy_macro(wrapped, salt->wrappedkey, 56);
+	memcpy_macro(wrapped.w, salt->wrappedkey, 56/4);
 
 	/* custom AES un-wrapping loop */
 	for (j = nb_iterations - 1; j >= 0; j--) {
 		for (k = wrappedkeylen / halfblocklen; k >= 1; --k) {
 			t = ((wrappedkeylen / halfblocklen) * j) + k;
 			// MSB(B) = A XOR t
-			memcpy_pp(block, wrapped, halfblocklen);
+			memcpy_pp(block, wrapped.c, halfblocklen);
 			PUT_64BITS_XOR_LSB(block, t);
 			// LSB(B) = R[i]
-			memcpy_pp(block + halfblocklen, wrapped + k * halfblocklen, halfblocklen);
+			memcpy_pp(block + halfblocklen, wrapped.c + k * halfblocklen, halfblocklen);
 			// B = AESD(K, X xor t | R[i]) where t = (n * j) + i
 			AES_decrypt(block, block, &akey);
 			// A = MSB(B)
-			memcpy_pp(wrapped, block, halfblocklen);
+			memcpy_pp(wrapped.c, block, halfblocklen);
 			// R[i] = LSB(B)
-			memcpy_pp(wrapped + k * halfblocklen, block + halfblocklen, halfblocklen);
+			memcpy_pp(wrapped.c + k * halfblocklen, block + halfblocklen, halfblocklen);
 		}
 	}
 
-	out[gid].cracked = !memcmp_pc(wrapped, "\xA6\xA6\xA6\xA6\xA6\xA6\xA6\xA6", 8);
+	out[gid].cracked = (wrapped.l[0] == 0xa6a6a6a6a6a6a6a6ULL);
 }

--- a/run/opencl/axcrypt_kernel.cl
+++ b/run/opencl/axcrypt_kernel.cl
@@ -38,10 +38,10 @@ typedef struct {
 } axcrypt_out;
 
 #define PUT_64BITS_XOR_MSB(cp, value) ( \
-                (cp)[0] ^= (unsigned char)((value)), \
-                (cp)[1] ^= (unsigned char)((value) >> 8), \
-                (cp)[2] ^= (unsigned char)((value) >> 16), \
-                (cp)[3] ^= (unsigned char)((value) >> 24 ) )
+                (cp)[0] ^= (uchar)((value)), \
+                (cp)[1] ^= (uchar)((value) >> 8), \
+                (cp)[2] ^= (uchar)((value) >> 16), \
+                (cp)[3] ^= (uchar)((value) >> 24 ) )
 
 inline int axcrypt_decrypt(__global const axcrypt_password *inbuffer, uint gid, __constant axcrypt_salt *cur_salt, __global axcrypt_out *output)
 {
@@ -49,14 +49,15 @@ inline int axcrypt_decrypt(__global const axcrypt_password *inbuffer, uint gid, 
 	uchar keyfile[4096];
 	int password_length = inbuffer[gid].length;
 	uchar salt[16];
-	unsigned char KEK[20];
+	uchar KEK[20];
         union {
-		unsigned char b[16];
+		uchar b[16];
 		uint32_t w[4];
 	} lsb;
 	union {
-		unsigned char b[16];
+		uchar b[16];
 		uint32_t w[4];
+		uint64_t l[2];
 	} cipher;
 	AES_KEY akey;
 	SHA_CTX ctx;
@@ -108,12 +109,7 @@ inline int axcrypt_decrypt(__global const axcrypt_password *inbuffer, uint gid, 
 		lsb.w[1] = cipher.w[3];
 	}
 
-	for (i = 0; i < 8; i++) {
-		if (cipher.b[i] != 0xa6)
-			return 0;
-	}
-
-	return 1;
+	return (cipher.l[0] == 0xa6a6a6a6a6a6a6a6ULL);
 }
 
 __kernel

--- a/run/opencl/bitcoin_kernel.cl
+++ b/run/opencl/bitcoin_kernel.cl
@@ -73,7 +73,7 @@ __kernel void loop_sha512(__global hash512_t *state, uint count)
 
 		for (j = 0; j < 8; j++)
 			W[j] = buf.W[j];
-		W[8] = 0x8000000000000000;
+		W[8] = 0x8000000000000000ULL;
 		W[15] = 64 << 3;
 		sha512_single_zeros(W, buf.W);
 	}

--- a/run/opencl/bitwarden_kernel.cl
+++ b/run/opencl/bitwarden_kernel.cl
@@ -46,7 +46,7 @@ __kernel void bitwarden_decrypt(MAYBE_CONSTANT bitwarden_salt_t *salt,
 
 	// Check padding
 	for (i = 0; i < 4; i++) {
-		if (0x10101010 != plaintext.w[4 + i]) {
+		if (plaintext.w[4 + i] != 0x10101010) {
 			success = 0;
 			break;
 		}

--- a/run/opencl/cryptsha512_kernel_DEFAULT.cl
+++ b/run/opencl/cryptsha512_kernel_DEFAULT.cl
@@ -31,6 +31,15 @@ inline void init_ctx(sha512_ctx * ctx) {
     ctx->buflen = 0;
 }
 
+#if __OS_X__
+
+#define FAST
+#define memcpy_R memcpy_pp
+#define memcpy_C memcpy_cp
+#define memcpy_G memcpy_gp
+
+#else /* These violate strict aliasing rules */
+
 inline void memcpy_R(      uint8_t * dest,
                      const uint8_t * src,
                      const uint32_t srclen) {
@@ -72,6 +81,8 @@ inline void memcpy_G(               uint8_t * dest,
         i += 8;
     }
 }
+
+#endif /* __OS_X__ */
 
 inline void sha512_block(sha512_ctx * ctx) {
     uint64_t a = ctx->H[0];

--- a/run/opencl/opencl_cast.h
+++ b/run/opencl/opencl_cast.h
@@ -586,16 +586,10 @@ __constant uint S[8][256] = {
 #define _CAST_F2(l, r, i, j) _CAST_f2(l, r, K[i], K[i+j])
 #define _CAST_F3(l, r, i, j) _CAST_f3(l, r, K[i], K[i+j])
 
-#if __ENDIAN_LITTLE__
-#define BE32(x) SWAP32(x)
-#else
-#define BE32(x) (x)
-#endif
-
 inline void Cast5Encrypt(const uchar *inBlock, uchar *outBlock, CAST_KEY *key)
 {
-	uint l = BE32(((uint *)inBlock)[0]);
-	uint r = BE32(((uint *)inBlock)[1]);
+	uint l; GET_UINT32BE(l, inBlock, 0);
+	uint r; GET_UINT32BE(r, inBlock, 4);
 	uint *K = key->K;
 	uint t;
 
@@ -618,14 +612,14 @@ inline void Cast5Encrypt(const uchar *inBlock, uchar *outBlock, CAST_KEY *key)
 	_CAST_F1(r, l, 15, 16);
 
 	/* Put l,r into outblock */
-	((uint *)outBlock)[0] = BE32(r);
-	((uint *)outBlock)[1] = BE32(l);
+	PUT_UINT32BE(r, outBlock, 0);
+	PUT_UINT32BE(l, outBlock, 4);
 }
 
 inline void Cast5Decrypt(const uchar *inBlock, uchar *outBlock, CAST_KEY *key)
 {
-	uint r = BE32(((uint *)inBlock)[0]);
-	uint l = BE32(((uint *)inBlock)[1]);
+	uint l; GET_UINT32BE(l, inBlock, 0);
+	uint r; GET_UINT32BE(r, inBlock, 4);
 	uint *K = key->K;
 	uint t;
 
@@ -647,8 +641,8 @@ inline void Cast5Decrypt(const uchar *inBlock, uchar *outBlock, CAST_KEY *key)
 	_CAST_F2(r, l,  1, 16);
 	_CAST_F1(l, r,  0, 16);
 	/* Put l,r into outblock */
-	((uint *)outBlock)[0] = BE32(l);
-	((uint *)outBlock)[1] = BE32(r);
+	PUT_UINT32BE(r, outBlock, 0);
+	PUT_UINT32BE(l, outBlock, 4);
 	/* Wipe clean */
 	t = l = r = 0;
 }
@@ -659,10 +653,10 @@ inline void Cast5SetKey(CAST_KEY *key, uint keylength, const uchar *userKey)
 	uint *K = key->K;
 	uint X[4], Z[4];
 
-	X[0] = BE32(((uint *)userKey)[0]);
-	X[1] = BE32(((uint *)userKey)[1]);
-	X[2] = BE32(((uint *)userKey)[2]);
-	X[3] = BE32(((uint *)userKey)[3]);
+	GET_UINT32BE(X[0], userKey, 0);
+	GET_UINT32BE(X[1], userKey, 4);
+	GET_UINT32BE(X[2], userKey, 8);
+	GET_UINT32BE(X[3], userKey, 12);
 
 #define x(i) GETBYTE(X[i/4], 3-i%4)
 #define z(i) GETBYTE(Z[i/4], 3-i%4)

--- a/run/opencl/opencl_hmac_sha512.h
+++ b/run/opencl/opencl_hmac_sha512.h
@@ -54,14 +54,14 @@ inline void hmac_sha512(HMAC_KEY_TYPE void *_key, uint key_len,
 		SHA512_Update(&ctx, key, key_len);
 #endif
 		SHA512_Final(buf, &ctx);
-		pW[0] ^= 0x3636363636363636;
-		pW[1] ^= 0x3636363636363636;
-		pW[2] ^= 0x3636363636363636;
-		pW[3] ^= 0x3636363636363636;
-		pW[4] ^= 0x3636363636363636;
-		pW[5] ^= 0x3636363636363636;
-		pW[6] ^= 0x3636363636363636;
-		pW[7] ^= 0x3636363636363636;
+		pW[0] ^= 0x3636363636363636ULL;
+		pW[1] ^= 0x3636363636363636ULL;
+		pW[2] ^= 0x3636363636363636ULL;
+		pW[3] ^= 0x3636363636363636ULL;
+		pW[4] ^= 0x3636363636363636ULL;
+		pW[5] ^= 0x3636363636363636ULL;
+		pW[6] ^= 0x3636363636363636ULL;
+		pW[7] ^= 0x3636363636363636ULL;
 		memset_p(&buf[64], 0x36, 128 - 64);
 	} else
 #endif
@@ -69,7 +69,7 @@ inline void hmac_sha512(HMAC_KEY_TYPE void *_key, uint key_len,
 		memcpy_macro(buf, key, key_len);
 		memset_p(&buf[key_len], 0, 128 - key_len);
 		for (i = 0; i < 16; i++)
-			pW[i] ^= 0x3636363636363636;
+			pW[i] ^= 0x3636363636363636ULL;
 	}
 	SHA512_Init(&ctx);
 	SHA512_Update(&ctx, buf, 128);
@@ -88,7 +88,7 @@ inline void hmac_sha512(HMAC_KEY_TYPE void *_key, uint key_len,
 #endif
 	SHA512_Final(local_digest, &ctx);
 	for (i = 0; i < 16; i++)
-		pW[i] ^= (0x3636363636363636 ^ 0x5c5c5c5c5c5c5c5c);
+		pW[i] ^= (0x3636363636363636ULL ^ 0x5c5c5c5c5c5c5c5cULL);
 	SHA512_Init(&ctx);
 	SHA512_Update(&ctx, buf, 128);
 	SHA512_Update(&ctx, local_digest, 64);

--- a/run/opencl/opencl_md4_ctx.h
+++ b/run/opencl/opencl_md4_ctx.h
@@ -23,7 +23,7 @@ inline void _md4_process(MD4_CTX *ctx, const uchar data[64])
 {
 	uint W[16], A, B, C, D;
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)data & 0x03)) {
 		GET_UINT32_ALIGNED(W[ 0], data,  0);
 		GET_UINT32_ALIGNED(W[ 1], data,  4);
@@ -146,7 +146,7 @@ inline void MD4_Final(uchar output[20], MD4_CTX *ctx)
 	MD4_Update(ctx, md4_padding, padn);
 	MD4_Update(ctx, msglen, 8);
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)output & 0x03)) {
 		PUT_UINT32_ALIGNED(ctx->state[0], output,  0);
 		PUT_UINT32_ALIGNED(ctx->state[1], output,  4);

--- a/run/opencl/opencl_md5_ctx.h
+++ b/run/opencl/opencl_md5_ctx.h
@@ -23,7 +23,7 @@ inline void _md5_process(MD5_CTX *ctx, const uchar data[64])
 {
 	uint W[16], A, B, C, D;
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)data & 0x03)) {
 		GET_UINT32_ALIGNED(W[ 0], data,  0);
 		GET_UINT32_ALIGNED(W[ 1], data,  4);
@@ -146,7 +146,7 @@ inline void MD5_Final(uchar output[20], MD5_CTX *ctx)
 	MD5_Update(ctx, md5_padding, padn);
 	MD5_Update(ctx, msglen, 8);
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)output & 0x03)) {
 		PUT_UINT32_ALIGNED(ctx->state[0], output,  0);
 		PUT_UINT32_ALIGNED(ctx->state[1], output,  4);

--- a/run/opencl/opencl_misc.h
+++ b/run/opencl/opencl_misc.h
@@ -34,6 +34,10 @@ typedef uint64_t host_size_t;
 typedef uint32_t host_size_t;
 #endif
 
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
 /*
  * Some runtimes/drivers breaks on using inline, others breaks on lack of it,
  * yet others require use of static as well.
@@ -300,8 +304,11 @@ inline MAYBE_VECTOR_UINT VSWAP32(MAYBE_VECTOR_UINT x)
 	}
 
 /*
+ * Allow some strict aliasing violations, for nvidia only.
  * These require (b) to be aligned!
  */
+#if gpu_nvidia(DEVICE_INFO)
+#define ALLOW_ALIASING_VIOLATIONS	1
 #if __ENDIAN_LITTLE__
 #define GET_UINT32_ALIGNED(n, b, i)	(n) = ((uint*)(b))[(i) >> 2]
 #define PUT_UINT32_ALIGNED(n, b, i)	((uint*)(b))[(i) >> 2] = (n)
@@ -318,6 +325,7 @@ inline MAYBE_VECTOR_UINT VSWAP32(MAYBE_VECTOR_UINT x)
 #define PUT_UINT64_ALIGNED(n, b, i)	((ulong*)(b))[(i) >> 3] = SWAP64(n)
 #define GET_UINT64BE_ALIGNED(n, b, i)	(n) = ((ulong*)(b))[(i) >> 3]
 #define PUT_UINT64BE_ALIGNED(n, b, i)	((ulong*)(b))[(i) >> 3] = (n)
+#endif
 #endif
 
 /* Any device can do 8-bit reads BUT these macros are scalar only! */
@@ -393,239 +401,86 @@ inline int check_pkcs_pad(const uchar *data, int len, int blocksize)
 	} while (0)
 
 /*
- * Optimized functions. You need to pick the one that corresponds to the
- * source- and destination memory type(s).
- *
- * Note that for very small sizes, the overhead may make these functions
- * slower than naive code. On the other hand, due to inlining we will
- * hopefully have stuff optimized away more often than not!
+ * memcpy functions.  Until we require OpenCL 2.0, you need to pick the one
+ * that corresponds to the source- and destination memory type(s).
  */
 
 /* src and dst are private mem */
-inline void memcpy_pp(void *dst, const void *src, uint count)
+inline void memcpy_pp(void* restrict dst, const void* restrict src, uint count)
 {
-	union {
-		const uint *w;
-		const uchar *c;
-	} s;
-	union {
-		uint *w;
-		uchar *c;
-	} d;
+	const char *s = src;
+	char *d = dst;
 
-	s.c = src;
-	d.c = dst;
-
-	if (((size_t)dst & 0x03) == ((size_t)src & 0x03)) {
-		while (((size_t)s.c) & 0x03 && count--)
-			*d.c++ = *s.c++;
-
-		while (count >= 4) {
-			*d.w++ = *s.w++;
-			count -= 4;
-		}
-	}
-
-	while (count--) {
-		*d.c++ = *s.c++;
-	}
+	while (count--)
+		*d++ = *s++;
 }
 
 /* src is private mem, dst is global mem */
-inline void memcpy_pg(__global void *dst, const void *src, uint count)
+inline void memcpy_pg(__global void* restrict dst, const void* restrict src, uint count)
 {
-	union {
-		const uint *w;
-		const uchar *c;
-	} s;
-	union {
-		__global uint *w;
-		__global uchar *c;
-	} d;
+	const char *s = src;
+	__global char *d = dst;
 
-	s.c = src;
-	d.c = dst;
-
-	if (((size_t)dst & 0x03) == ((size_t)src & 0x03)) {
-		while (((size_t)s.c) & 0x03 && count--)
-			*d.c++ = *s.c++;
-
-		while (count >= 4) {
-			*d.w++ = *s.w++;
-			count -= 4;
-		}
-	}
-
-	while (count--) {
-		*d.c++ = *s.c++;
-	}
+	while (count--)
+		*d++ = *s++;
 }
 
 /* src is global mem, dst is private mem */
-inline void memcpy_gp(void *dst, __global const void *src, uint count)
+inline void memcpy_gp(void* restrict dst, __global const void* restrict src, uint count)
 {
-	union {
-		__global const uint *w;
-		__global const uchar *c;
-	} s;
-	union {
-		uint *w;
-		uchar *c;
-	} d;
+	__global const char *s = src;
+	char *d = dst;
 
-	s.c = src;
-	d.c = dst;
-
-	if (((size_t)dst & 0x03) == ((size_t)src & 0x03)) {
-		while (((size_t)s.c) & 0x03 && count--)
-			*d.c++ = *s.c++;
-
-		while (count >= 4) {
-			*d.w++ = *s.w++;
-			count -= 4;
-		}
-	}
-
-	while (count--) {
-		*d.c++ = *s.c++;
-	}
+	while (count--)
+		*d++ = *s++;
 }
 
 /* src is constant mem, dst is private mem */
-inline void memcpy_cp(void *dst, __constant void *src, uint count)
+inline void memcpy_cp(void* restrict dst, __constant void* restrict src, uint count)
 {
-	union {
-		__constant uint *w;
-		__constant uchar *c;
-	} s;
-	union {
-		uint *w;
-		uchar *c;
-	} d;
+	__constant char *s = src;
+	char *d = dst;
 
-	s.c = src;
-	d.c = dst;
-
-	if (((size_t)dst & 0x03) == ((size_t)src & 0x03)) {
-		while (((size_t)s.c) & 0x03 && count--)
-			*d.c++ = *s.c++;
-
-		while (count >= 4) {
-			*d.w++ = *s.w++;
-			count -= 4;
-		}
-	}
-
-	while (count--) {
-		*d.c++ = *s.c++;
-	}
+	while (count--)
+		*d++ = *s++;
 }
 
 /* src is MAYBE_CONSTANT mem, dst is private mem */
-inline void memcpy_mcp(void *dst, MAYBE_CONSTANT void *src, uint count)
+inline void memcpy_mcp(void* restrict dst, MAYBE_CONSTANT void* restrict src, uint count)
 {
-	union {
-		MAYBE_CONSTANT uint *w;
-		MAYBE_CONSTANT uchar *c;
-	} s;
-	union {
-		uint *w;
-		uchar *c;
-	} d;
+	MAYBE_CONSTANT char *s = src;
+	char *d = dst;
 
-	s.c = src;
-	d.c = dst;
-
-	if (((size_t)dst & 0x03) == ((size_t)src & 0x03)) {
-		while (((size_t)s.c) & 0x03 && count--)
-			*d.c++ = *s.c++;
-
-		while (count >= 4) {
-			*d.w++ = *s.w++;
-			count -= 4;
-		}
-	}
-
-	while (count--) {
-		*d.c++ = *s.c++;
-	}
+	while (count--)
+		*d++ = *s++;
 }
 
 /* dst is private mem */
 inline void memset_p(void *p, uint val, uint count)
 {
-	const uint val4 = val | (val << 8) | (val << 16) | (val << 24);
-	union {
-		uint *w;
-		uchar *c;
-	} d;
-
-	d.c = p;
-
-	while (((size_t)d.c) & 0x03 && count--)
-		*d.c++ = val;
-
-	while (count >= 4) {
-		*d.w++ = val4;
-		count -= 4;
-	}
+	char *d = p;
 
 	while (count--)
-		*d.c++ = val;
+		*d++ = val;
 }
 
 /* dst is global mem */
 inline void memset_g(__global void *p, uint val, uint count)
 {
-	const uint val4 = val | (val << 8) | (val << 16) | (val << 24);
-	union {
-		__global uint *w;
-		__global uchar *c;
-	} d;
-
-	d.c = p;
-
-	while (((size_t)d.c) & 0x03 && count--)
-		*d.c++ = val;
-
-	while (count >= 4) {
-		*d.w++ = val4;
-		count -= 4;
-	}
+	__global char *d = p;
 
 	while (count--)
-		*d.c++ = val;
+		*d++ = val;
 }
 
 /* s1 and s2 are private mem */
 inline int memcmp_pp(const void *s1, const void *s2, uint size)
 {
-	union {
-		const uint *w;
-		const uchar *c;
-	} a;
-	union {
-		const uint *w;
-		const uchar *c;
-	} b;
-
-	a.c = s1;
-	b.c = s2;
-
-	if (((size_t)s1 & 0x03) == ((size_t)s2 & 0x03)) {
-		while (((size_t)a.c) & 0x03 && size--)
-			if (*b.c++ != *a.c++)
-				return 1;
-
-		while (size >= 4) {
-			if (*b.w++ != *a.w++)
-				return 1;
-			size -= 4;
-		}
-	}
+	const uchar *a = s1;
+	const uchar *b = s2;
 
 	while (size--)
-		if (*b.c++ != *a.c++)
+		if (*a++ != *b++)
 			return 1;
 
 	return 0;
@@ -634,32 +489,11 @@ inline int memcmp_pp(const void *s1, const void *s2, uint size)
 /* s1 is private mem, s2 is global mem */
 inline int memcmp_pg(const void *s1, __global const void *s2, uint size)
 {
-	union {
-		const uint *w;
-		const uchar *c;
-	} a;
-	union {
-		__global const uint *w;
-		__global const uchar *c;
-	} b;
-
-	a.c = s1;
-	b.c = s2;
-
-	if (((size_t)s1 & 0x03) == ((size_t)s2 & 0x03)) {
-		while (((size_t)a.c) & 0x03 && size--)
-			if (*b.c++ != *a.c++)
-				return 1;
-
-		while (size >= 4) {
-			if (*b.w++ != *a.w++)
-				return 1;
-			size -= 4;
-		}
-	}
+	const uchar *a = s1;
+	__global const uchar *b = s2;
 
 	while (size--)
-		if (*b.c++ != *a.c++)
+		if (*a++ != *b++)
 			return 1;
 
 	return 0;
@@ -668,32 +502,24 @@ inline int memcmp_pg(const void *s1, __global const void *s2, uint size)
 /* s1 is private mem, s2 is constant mem */
 inline int memcmp_pc(const void *s1, __constant const void *s2, uint size)
 {
-	union {
-		const uint *w;
-		const uchar *c;
-	} a;
-	union {
-		__constant const uint *w;
-		__constant const uchar *c;
-	} b;
-
-	a.c = s1;
-	b.c = s2;
-
-	if (((size_t)s1 & 0x03) == ((size_t)s2 & 0x03)) {
-		while (((size_t)a.c) & 0x03 && size--)
-			if (*b.c++ != *a.c++)
-				return 1;
-
-		while (size >= 4) {
-			if (*b.w++ != *a.w++)
-				return 1;
-			size -= 4;
-		}
-	}
+	const uchar *a = s1;
+	__constant const uchar *b = s2;
 
 	while (size--)
-		if (*b.c++ != *a.c++)
+		if (*a++ != *b++)
+			return 1;
+
+	return 0;
+}
+
+/* s1 is global mem, s2 is constant mem */
+inline int memcmp_gc(__global const void *s1, __constant void *s2, uint size)
+{
+	__global const uchar *a = s1;
+	__constant uchar *b = s2;
+
+	while (size--)
+		if (*a++ != *b++)
 			return 1;
 
 	return 0;
@@ -702,32 +528,11 @@ inline int memcmp_pc(const void *s1, __constant const void *s2, uint size)
 /* s1 is private mem, s2 is MAYBE_CONSTANT mem */
 inline int memcmp_pmc(const void *s1, MAYBE_CONSTANT void *s2, uint size)
 {
-	union {
-		const uint *w;
-		const uchar *c;
-	} a;
-	union {
-		MAYBE_CONSTANT uint *w;
-		MAYBE_CONSTANT uchar *c;
-	} b;
-
-	a.c = s1;
-	b.c = s2;
-
-	if (((size_t)s1 & 0x03) == ((size_t)s2 & 0x03)) {
-		while (((size_t)a.c) & 0x03 && size--)
-			if (*b.c++ != *a.c++)
-				return 1;
-
-		while (size >= 4) {
-			if (*b.w++ != *a.w++)
-				return 1;
-			size -= 4;
-		}
-	}
+	const uchar *a = s1;
+	MAYBE_CONSTANT uchar *b = s2;
 
 	while (size--)
-		if (*b.c++ != *a.c++)
+		if (*a++ != *b++)
 			return 1;
 
 	return 0;
@@ -737,11 +542,11 @@ inline int memcmp_pmc(const void *s1, MAYBE_CONSTANT void *s2, uint size)
 inline int memmem_pc(const void *haystack, size_t haystack_len,
                      __constant const void *needle, size_t needle_len)
 {
-	char* haystack_ = (char*)haystack;
-	__constant const char* needle_ = (__constant const char*)needle;
+	const char *haystack_ = haystack;
+	__constant const char *needle_ = needle;
 	int hash = 0;
 	int hay_hash = 0;
-	char* last;
+	const char *last;
 	size_t i;
 
 	if (haystack_len < needle_len)
@@ -757,11 +562,9 @@ inline int memmem_pc(const void *haystack, size_t haystack_len,
 
 	haystack_ = (char*)haystack;
 	needle_ = (__constant char*)needle;
-	last = haystack_+(haystack_len - needle_len + 1);
-	for (; haystack_ < last; ++haystack_) {
-		if (hash == hay_hash &&
-		    *haystack_ == *needle_ &&
-		    !memcmp_pc (haystack_, needle_, needle_len))
+
+	for (last = haystack_ + (haystack_len - needle_len + 1); haystack_ < last; ++haystack_) {
+		if (hash == hay_hash && *haystack_ == *needle_ && !memcmp_pc(haystack_, needle_, needle_len))
 			return 1;
 
 		hay_hash -= *haystack_;

--- a/run/opencl/opencl_sha1_ctx.h
+++ b/run/opencl/opencl_sha1_ctx.h
@@ -68,7 +68,7 @@ inline void _sha1_process(SHA_CTX *ctx, const uchar data[64])
 #endif
 	uint temp, W[16], A, B, C, D, E, r[16];
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)data & 0x03)) {
 		GET_UINT32BE_ALIGNED(W[ 0], data,  0);
 		GET_UINT32BE_ALIGNED(W[ 1], data,  4);
@@ -180,7 +180,7 @@ inline void SHA1_Final(uchar output[20], SHA_CTX *ctx)
 	SHA1_Update(ctx, sha1_padding, padn);
 	SHA1_Update(ctx, msglen, 8);
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)output & 0x03)) {
 		PUT_UINT32BE_ALIGNED(ctx->state[0], output,  0);
 		PUT_UINT32BE_ALIGNED(ctx->state[1], output,  4);

--- a/run/opencl/opencl_sha2_ctx.h
+++ b/run/opencl/opencl_sha2_ctx.h
@@ -40,7 +40,7 @@ inline
 void _sha256_process(SHA256_CTX *ctx, const uchar data[64]) {
 	MAYBE_VOLATILE uint t, W[16], A, B, C, D, E, F, G, H;
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)data & 0x03)) {
 		GET_UINT32BE_ALIGNED(W[ 0], data,  0);
 		GET_UINT32BE_ALIGNED(W[ 1], data,  4);
@@ -158,7 +158,7 @@ void SHA256_Final(uchar output[32], SHA256_CTX *ctx) {
 	SHA256_Update(ctx, sha256_padding, padn);
 	SHA256_Update(ctx, msglen, 8);
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)output & 0x03)) {
 		PUT_UINT32BE_ALIGNED(ctx->state[0], output,  0);
 		PUT_UINT32BE_ALIGNED(ctx->state[1], output,  4);
@@ -209,7 +209,7 @@ inline
 void _sha512_process(SHA512_CTX *ctx, const uchar data[128]) {
 	ulong t, W[16], A, B, C, D, E, F, G, H;
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)data & 0x07)) {
 		GET_UINT64BE_ALIGNED(W[ 0], data,   0);
 		GET_UINT64BE_ALIGNED(W[ 1], data,   8);
@@ -328,7 +328,7 @@ void SHA512_Final(uchar output[64], SHA512_CTX *ctx) {
 	SHA512_Update(ctx, sha512_padding, padn);
 	SHA512_Update(ctx, msglen, 16);
 
-#if gpu_nvidia(DEVICE_INFO)
+#if ALLOW_ALIASING_VIOLATIONS
 	if (!((size_t)output & 0x07)) {
 		PUT_UINT64BE_ALIGNED(ctx->state[0], output,  0);
 		PUT_UINT64BE_ALIGNED(ctx->state[1], output,  8);

--- a/run/opencl/sspr_kernel.cl
+++ b/run/opencl/sspr_kernel.cl
@@ -283,7 +283,7 @@ __kernel void loop_sha512(__global sspr_hash *outbuffer,
 
 		for (j = 0; j < 8; j++)
 			W[j] = buf.W[j];
-		W[8] = 0x8000000000000000;
+		W[8] = 0x8000000000000000ULL;
 		W[15] = 64 << 3;
 		sha512_single_zeros(W, buf.W);
 	}

--- a/run/opencl/zip_kernel.cl
+++ b/run/opencl/zip_kernel.cl
@@ -34,8 +34,7 @@ __kernel void zip(__global const pbkdf2_password *inbuffer,
 	       salt->salt, salt->length, salt->iterations,
 	       outbuffer[idx].v, 2, 2 * salt->key_len);
 
-	if (*(__global ushort*)outbuffer[idx].v ==
-	    *(__constant ushort*)salt->passverify) {
+	if (!memcmp_gc(outbuffer[idx].v, salt->passverify, 2)) {
 
 		pbkdf2(inbuffer[idx].v, inbuffer[idx].length,
 		       salt->salt, salt->length, salt->iterations,

--- a/src/opencl_7z_fmt_plug.c
+++ b/src/opencl_7z_fmt_plug.c
@@ -97,7 +97,7 @@ static cl_kernel sevenzip_init, sevenzip_final, sevenzip_aes;
 
 static struct fmt_main *self;
 
-#define HASH_LOOPS	0x4000
+#define HASH_LOOPS	0x4000 // Must be multiple of 32
 #define LOOP_COUNT	((1 << currentsalt.iterations) / HASH_LOOPS)
 #define STEP		0
 #define SEED		16

--- a/src/opencl_axcrypt2_fmt_plug.c
+++ b/src/opencl_axcrypt2_fmt_plug.c
@@ -79,7 +79,7 @@ typedef struct {
 	salt_t pbkdf2;
 	uint32_t key_wrapping_rounds;
 	unsigned char salt[64];
-	unsigned char wrappedkey[144];
+	unsigned int wrappedkey[144/4];
 } axcrypt2_salt_t;
 
 typedef struct {
@@ -299,8 +299,8 @@ static void set_salt(void *salt)
 	host_salt->pbkdf2.length = cur_salt->deriv_salt_length;
 	host_salt->pbkdf2.rounds = cur_salt->deriv_iterations;
 
-        memcpy(host_salt->salt, cur_salt->salt, 64);
-        memcpy(host_salt->wrappedkey, cur_salt->wrappedkey, 144);
+	memcpy(host_salt->salt, cur_salt->salt, 64);
+	memcpy(host_salt->wrappedkey, cur_salt->wrappedkey, 144);
 
 	host_salt->key_wrapping_rounds = cur_salt->key_wrapping_rounds;
 


### PR DESCRIPTION
This is work in progress. So far, the byte wise OpenCL memcpy stuff seem to generally *bump* performance (if anything) using a fairly recent nvidia driver (CUDA 11.3 a.k.a 465.19.01) so I see no reason to re-add larger writes through pointers to unions. I assume recent drivers' optimizer recognizes the KISS memcpy and does the right thing anyway (and quite possibly better than the older offending code).

The nvidia-specific 32-byte writes in `opencl_*_ctx.h` are kept, but clearly marked as aliasing violations and now easily switchable from `opencl_misc.h`.

~As of right now, `mgetl.h` too is just byte wise copy (except for SIMD) but I will try re-adding the wider writes using pointers to unions.~