### PR TITLE
Loader: Bug fix for --make-charset with --target-encoding

### DIFF
--- a/doc/ENCODINGS
+++ b/doc/ENCODINGS
@@ -75,6 +75,14 @@ For MASKS, such conversion is required: If no internal codepage was selected,
 or if the selected one can't hold all of the characters, you'll get an error
 describing the problem.
 
+If you want to create an incremental charset for a certain codepage, such as
+for use with the LM format, you need to use the --target-encoding option with
+--make-charset.  The fact that we default to storing all passwords to the pot
+file in UTF-8 means this will work fine regardless of what formats it contains.
+So for example, "--make-charset=custom.chr --target-encoding=cp850" will use
+every password in the pot file that can be encoded in CP850, and build the
+charset from that.
+
 Caveats:
 Beware of UTF-8 BOM's. They will cripple the first word in your wordlist or
 the first entry in your hashfile. Try to avoid using Windows tools that add

--- a/doc/NEWS
+++ b/doc/NEWS
@@ -193,6 +193,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   ClamAV unrar code (crippling the RAR v3 formats a little).  Simply deleting
   src/unrar*.[ch] will infer that option as well.  [magnum; 2021]
 
+- Support --target-encoding with --make-charset, for generating charsets for
+  formats like LM that need to be in a legacy codepage.  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -2201,6 +2201,21 @@ static void ldr_show_pot_line(struct db_main *db, char *line)
 		} while (*pos++);
 
 		if (db->options->flags & DB_PLAINTEXTS) {
+			if (options.flags & FLG_MAKECHR_CHK) {
+				if (options.target_enc > ASCII && options.target_enc < UTF_8) {
+					char *plain = ldr_conv(line);
+
+					/* Only load words that fit our selected codepage */
+					if (plain != line && strlen(plain) != strlen8((UTF8*)line))
+						return;
+					else
+						line = plain;
+				} else if (options.target_enc == UTF_8) {
+					/* Only load words that are valid UTF-8 */
+					if (!valid_utf8((UTF8*)line))
+						return;
+				}
+			}
 			list_add(db->plaintexts, line);
 			return;
 		}


### PR DESCRIPTION
It was silently ignored.  Correctly supporting it allows for eg. creating a codepage-specific charset for LM and similar formats.