### PR TITLE
cracker.c: "pause file" fixes

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -323,11 +323,11 @@ ReloadAtDone = Y
 # but it may be delayed by the "Save" timer setting near top of this file.
 ReloadAtSave = Y
 
-# If this file exists, john will abort cleanly
-AbortFile = /var/run/john/abort
+# If this file exists, john will abort cleanly (uncomment to enable)
+#AbortFile = /var/run/john/abort
 
-# While this file exists, john will pause
-PauseFile = /var/run/john/pause
+# While this file exists, john will pause (uncomment to enable)
+#PauseFile = /var/run/john/pause
 
 # If set to true, the uid will be appended to user name on cracks
 #   With:     password123      (Administrator:500)


### PR DESCRIPTION
After sleeping, fixup the times before calling log_event(), so we don't get an out-of-whack timestamp for that entry.
Also, call status_print() again after waking up.

Closes #4746

There's nothing really wrong with this patch except we should consider [some alternatives](https://github.com/openwall/john/issues/4746#issuecomment-856762315) first: Should we really alter the "time", and if we do, should we really call for a second status output?