### PR TITLE
Incremental: Allow supplying a charset file as "mode"

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -196,6 +196,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Support --target-encoding with --make-charset, for generating charsets for
   formats like LM that need to be in a legacy codepage.  [magnum; 2021]
 
+- Incremental: Allow supplying a charset file name as "mode", with no config
+  entry required.  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -147,6 +147,9 @@ rulesets that are made to work together.
 Enables the "incremental" mode, using the specified configuration file
 definition (section [Incremental:MODE]).  If MODE is omitted, the
 default is "ASCII" for most hash types and "LM_ASCII" for LM hashes.
+If no definition is found for MODE but it ends with ".chr", it will be
+taken as a charset file name, eg. for temporary use.
+
 
 --external=MODE			external mode or word filter
 

--- a/run/john.conf
+++ b/run/john.conf
@@ -1239,7 +1239,9 @@ b1 ]
 
 # Incremental modes
 
-# This is for one-off uses (make your own custom.chr)
+# This is for one-off uses (make your own custom.chr).
+# A charset can now also be named directly from command-line, so no config
+# entry needed: --incremental=whatever.chr
 [Incremental:Custom]
 File = $JOHN/custom.chr
 MinLen = 0

--- a/src/inc.c
+++ b/src/inc.c
@@ -498,11 +498,18 @@ void do_incremental_crack(struct db_main *db, const char *mode)
 
 	if (!(charset = cfg_get_param(SECTION_INC, mode, "File"))) {
 		if (cfg_get_section(SECTION_INC, mode) == NULL) {
-			log_event("! Unknown incremental mode: %s", mode);
-			if (john_main_process)
-				fprintf(stderr, "Unknown incremental mode: %s\n",
-				    mode);
-			error();
+			if (strlen(mode) > 4 && !strcmp(mode + strlen(mode) - 4, ".chr")) {
+				log_event("! Using charset file supplied as option: %s", mode);
+				if (john_main_process)
+					fprintf(stderr, "Using charset file supplied as option: %s\n", mode);
+				charset = mode;
+			} else {
+				log_event("! Unknown incremental mode: %s", mode);
+				if (john_main_process)
+					fprintf(stderr, "Unknown incremental mode: %s\n",
+					        mode);
+				error();
+			}
 		}
 		else {
 			log_event("! No charset defined");


### PR DESCRIPTION
This lets you use eg. --inc=temp.chr without any entry in john.conf