### PR TITLE
mgetl.h: Avoid strict aliasing violations.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -374,7 +374,7 @@ listconf.o:	listconf.c autoconfig.h os.h os-autoconf.h jumbo.h arch.h simd-intri
 
 LM_fmt.o:	LM_fmt.c arch.h misc.h jumbo.h autoconfig.h memory.h DES_bs.h common.h loader.h params.h list.h formats.h os.h os-autoconf.h
 
-loader.o:	loader.c autoconfig.h jumbo.h arch.h os.h os-autoconf.h misc.h params.h path.h memory.h list.h signals.h formats.h dyna_salt.h loader.h options.h getopt.h common.h config.h unicode.h dynamic.h simd-intrinsics.h pseudo_intrinsics.h aligned.h simd-intrinsics-load-flags.h fake_salts.h john.h cracker.h logger.h base64_convert.h showformats.h
+loader.o:	loader.c mgetl.h autoconfig.h jumbo.h arch.h os.h os-autoconf.h misc.h params.h path.h memory.h list.h signals.h formats.h dyna_salt.h loader.h options.h getopt.h common.h config.h unicode.h dynamic.h simd-intrinsics.h pseudo_intrinsics.h aligned.h simd-intrinsics-load-flags.h fake_salts.h john.h cracker.h logger.h base64_convert.h showformats.h
 
 logger.o:	logger.c os.h os-autoconf.h autoconfig.h jumbo.h arch.h misc.h params.h path.h memory.h status.h options.h list.h loader.h formats.h getopt.h common.h config.h recovery.h unicode.h dynamic.h simd-intrinsics.h pseudo_intrinsics.h aligned.h simd-intrinsics-load-flags.h john_mpi.h cracker.h signals.h
 
@@ -523,7 +523,7 @@ whirlpool.o:	whirlpool.c sph_whirlpool.h sph_types.h autoconfig.h arch.h os.h os
 
 win32_memmap.o:	win32_memmap.c os.h os-autoconf.h autoconfig.h jumbo.h arch.h win32_memmap.h misc.h memory.h
 
-wordlist.o:	wordlist.c autoconfig.h os.h os-autoconf.h jumbo.h arch.h mem_map.h win32_memmap.h mmap-windows.c memory.h misc.h params.h common.h path.h signals.h loader.h list.h formats.h logger.h status.h recovery.h options.h getopt.h rpp.h config.h rules.h external.h compiler.h cracker.h john.h unicode.h regex.h mask.h pseudo_intrinsics.h aligned.h
+wordlist.o:	wordlist.c mgetl.h autoconfig.h os.h os-autoconf.h jumbo.h arch.h mem_map.h win32_memmap.h mmap-windows.c memory.h misc.h params.h common.h path.h signals.h loader.h list.h formats.h logger.h status.h recovery.h options.h getopt.h rpp.h config.h rules.h external.h compiler.h cracker.h john.h unicode.h regex.h mask.h pseudo_intrinsics.h aligned.h
 
 wpapcap2john.o:	wpapcap2john.c wpapcap2john.h arch.h johnswap.h common.h memory.h jumbo.h os.h os-autoconf.h autoconfig.h
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -1895,7 +1895,15 @@ static void ldr_fill_user_words(struct db_main *db)
 	int last_count = 0;
 	FILE *file;
 	const char *name = path_expand(options.seed_per_user);
-	char line[LINE_BUFFER_SIZE];
+	union {
+		char buffer[LINE_BUFFER_SIZE];
+#if MGETL_HAS_SIMD
+		vtype dummy;
+#else
+		ARCH_WORD dummy;
+#endif
+	} aligned;
+	char *line = aligned.buffer;
 	size_t file_len;
 	int tot_num = 0;
 	int seeds_sorted = MAYBE | SORTED;

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -129,7 +129,16 @@ static MAYBE_INLINE int skip_lines(unsigned long n, char *line)
 
 static void restore_line_number(void)
 {
-	char line[LINE_BUFFER_SIZE];
+	union {
+		char buffer[LINE_BUFFER_SIZE];
+#if MGETL_HAS_SIMD
+		vtype dummy;
+#else
+		ARCH_WORD dummy;
+#endif
+	} aligned;
+	char *line = aligned.buffer;
+
 	if (skip_lines((unsigned long)rec_pos, line)) {
 		if (ferror(word_file))
 			pexit("fgets");
@@ -163,7 +172,16 @@ static int restore_state(FILE *file)
 	} else
 	if (!nWordFileLines) {
 		if (mem_map) {
-			char line[LINE_BUFFER_SIZE];
+			union {
+				char buffer[LINE_BUFFER_SIZE];
+#if MGETL_HAS_SIMD
+				vtype dummy;
+#else
+				ARCH_WORD dummy;
+#endif
+			} aligned;
+			char *line = aligned.buffer;
+
 			skip_lines(rec_line, line);
 			rec_pos = 0;
 		} else if (rec_line && !rec_pos) {
@@ -436,7 +454,11 @@ void do_wordlist_crack(struct db_main *db, const char *name, int rules)
 {
 	union {
 		char buffer[2][LINE_BUFFER_SIZE + CACHE_BANK_SHIFT];
+#if MGETL_HAS_SIMD
+		vtype dummy;
+#else
 		ARCH_WORD dummy;
+#endif
 	} aligned;
 	char *line = aligned.buffer[0];
 	char *last = aligned.buffer[1];


### PR DESCRIPTION
I reverted to KISS code: Keep the SIMD stuff (only used with intel so `MAY_ALIAS`), but use byte-wise copy for all other situations (100% aliasing compliant code for wider copy too hard to achieve and not worth the negligible boost). Also increase the alignment of line in wordlist.c from `ARCH_WORD` to `vtype` when applicable, allowing us to use vstore instead of vstoreu.

Closes #4733