### PR TITLE
cracker.c: Refresh salt every 30 seconds if only one salt loaded

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -199,6 +199,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Incremental: Allow supplying a charset file name as "mode", with no config
   entry required.  [magnum; 2021]
 
+- Cracker: Re-transfer salt every 30 seconds even if only one salt is loaded.
+  This minimizes impact if a device-side salt gets thrashed.  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/cracker.c
+++ b/src/cracker.c
@@ -112,6 +112,11 @@ int crk_max_keys_per_crypt(void)
 
 static void crk_dummy_set_salt(void *salt)
 {
+	/* Refresh salt every 30 seconds in case it was thrashed */
+	if (event_refresh_salt > 30) {
+		crk_db->format->methods.set_salt(salt);
+		event_refresh_salt = 0;
+	}
 }
 
 static void crk_dummy_fix_state(void)

--- a/src/signals.c
+++ b/src/signals.c
@@ -61,7 +61,7 @@ volatile int event_pending = 0, event_reload = 0;
 volatile int event_abort = 0, event_save = 0, event_status = 0, event_delayed_status = 0;
 volatile int event_ticksafety = 0;
 volatile int event_mpiprobe = 0, event_poll_files = 0;
-volatile int event_fix_state = 0;
+volatile int event_fix_state = 0, event_refresh_salt = 0;
 
 volatile int timer_abort = 0, timer_status = 0;
 static int timer_save_interval;
@@ -394,6 +394,7 @@ static void sig_handle_timer(int signum)
 #endif /* OS_TIMER */
 
 	event_fix_state = 1;
+	event_refresh_salt++;
 
 #endif /* !BENCH_BUILD */
 

--- a/src/signals.h
+++ b/src/signals.h
@@ -37,7 +37,8 @@ extern volatile int event_save;		/* Save the crash recovery file */
 extern volatile int event_status;	/* Status display requested */
 extern volatile int event_delayed_status;	/* Status display requested after current batch */
 extern volatile int event_ticksafety;	/* System time in ticks may overflow */
-extern volatile int event_fix_state;    /* For cracker */
+extern volatile int event_fix_state;	/* For cracker */
+extern volatile int event_refresh_salt;	/* For defensive salt refresh every nth seconds */
 #ifdef HAVE_MPI
 extern volatile int event_mpiprobe;	/* MPI probe for messages requested */
 #endif


### PR DESCRIPTION
This is a defensive measure, minimizing impact in case a format gets its device-side salt thrashed.  We transfer it again every 30 seconds.

See #4456