### PR TITLE
Made pwsafe2john.py compatible with python3

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -202,6 +202,12 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Cracker: Re-transfer salt every 30 seconds even if only one salt is loaded.
   This minimizes impact if a device-side salt gets thrashed.  [magnum; 2021]
 
+- pwsafe2john.py: Fixed parsing bug of iteration count, that led to
+  uncrackable hashes in the past.  [NecroMortis; 2021]
+
+- Python3 compatibility improvements in various *2john.py scripts
+  [exploide; 2019-2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/run/pwsafe2john.py
+++ b/run/pwsafe2john.py
@@ -9,15 +9,14 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted.
 #
-# Password Safe file format is documented at,
+# Ported to Python 3 by Jannik Vieten <me at exploide.net>
 #
-# + http://keybox.rubyforge.org/password-safe-db-format.html
+# Password Safe file format is documented at
+# https://github.com/pwsafe/pwsafe/blob/master/docs/formatV3.txt
 #
-# + https://github.com/pwsafe/pwsafe/blob/master/docs/formatV3.txt
-#
-# Output Format: filename:$passwordsaf$*version*salt*iterations*hash */
+# Output Format: filename:$pwsafe$*version*salt*iterations*hash
 
-magic = "PWS3"
+magic = b"PWS3"
 
 import sys
 import struct
@@ -31,7 +30,7 @@ def process_file(filename):
 
     data = f.read(4)
     if data != magic:
-        sys.stderr.write("%s : PWS3 magic string missing, is this a Password Safe file?\n", filename)
+        sys.stderr.write("%s : PWS3 magic string missing, is this a Password Safe file?\n" % filename)
         return
 
     buf = f.read(32)
@@ -43,13 +42,13 @@ def process_file(filename):
 
     sys.stdout.write("%s:$pwsafe$*3*" %
                      os.path.basename(filename).rstrip(".psafe3"))
-    sys.stdout.write(hexlify(buf))
+    sys.stdout.write(hexlify(buf).decode('ascii'))
     sys.stdout.write("*%s*" % iterations)
     hsh = f.read(32)
     if len(hsh) != 32:
         sys.stderr.write("Error: hash read failed.\n")
         return
-    sys.stdout.write(hexlify(hsh))
+    sys.stdout.write(hexlify(hsh).decode('ascii'))
     sys.stdout.write("\n")
 
     f.close()
@@ -57,8 +56,8 @@ def process_file(filename):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        sys.stdout.write("Usage: pwsafe2john [.psafe3 files]\n")
-        sys.exit(-1)
+        sys.stdout.write("Usage: %s [.psafe3 files]\n" % sys.argv[0])
+        sys.exit(1)
 
-    for i in range(1, len(sys.argv)):
-        process_file(sys.argv[i])
+    for f in sys.argv[1:]:
+        process_file(f)


### PR DESCRIPTION
This is the follow up PR to #4756.

It makes `pwsafe2john.py` compatible with python3 and does a bit of cleanup.

Furthermore, news entries for the recently patched pwsafe parsing bug and the python3 improvements are added.

Note that this does not change the behavior how john treats hashes produces by older `pwsafe2john.py` yet.