### PR TITLE
Add new --catch-up=NAME option

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -208,6 +208,10 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Python3 compatibility improvements in various *2john.py scripts
   [exploide; 2019-2021]
 
+- Add new option --catch-up=NAME, for running a new session only until it
+  reaches the candidates tried count of a different, existing and paused
+  session, then exit.  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -193,6 +193,15 @@ Unix-like system, you can get a detached running session to update its
 session file by sending a SIGHUP to the appropriate "john" process;
 then use this option to read in and display the status.
 
+--catch-up=NAME			catch up with paused session
+
+Limit the session to running only until it reaches the candidates tried
+count of a different, existing and paused session NAME.  This can be
+used for adding more hashes to an existing job:  After the new session
+finishes, just concatenate the new hashes to the older session's hash
+file and resume the old session.  This will end up more or less as if
+both sets of hashes were in the original session to start with.
+
 --make-charset=FILE		make a charset, overwriting FILE
 
 Generates a charset file based on character frequencies from

--- a/run/john.bash_completion
+++ b/run/john.bash_completion
@@ -418,7 +418,7 @@ _john()
 			COMPREPLY[${#COMPREPLY[@]}]="${prev}"
 			return 0
 			;;
-		--restore=*|--status=*)
+		--restore=*|--status=*|--catch-up=*)
 			cur=${cur#*[=:]}
 			# .rec files are stored in the current directory (or a
 			# subdirectory if the session name contains a slash)

--- a/src/john.c
+++ b/src/john.c
@@ -184,7 +184,7 @@ int *john_child_pids = NULL;
 #endif
 char *john_terminal_locale = "C";
 
-unsigned long long john_max_cands;
+uint64_t john_max_cands;
 
 static int children_ok = 1;
 
@@ -1881,6 +1881,12 @@ static void john_done(void)
 				        "Warning: incremental mask started at length %d"
 				        " - try the CPU format for shorter lengths.\n",
 				        mask_iter_warn);
+		}
+		if (event_abort && options.catchup && john_max_cands && status.cands >= john_max_cands) {
+			event_abort = 0;
+			log_event("Done catching up with '%s'", options.catchup);
+			if (john_main_process)
+				fprintf(stderr, "Done catching up with '%s'\n", options.catchup);
 		}
 		if (event_abort) {
 			char *abort_msg = (aborted_by_timer) ?

--- a/src/john.h
+++ b/src/john.h
@@ -41,7 +41,7 @@ extern int *john_child_pids;
 extern char *john_terminal_locale;
 
 /* Current target for options.max_cands */
-extern unsigned long long john_max_cands;
+extern uint64_t john_max_cands;
 
 /* Print loaded/remaining counts */
 extern char *john_loaded_counts(struct db_main *db, char *prelude);

--- a/src/options.c
+++ b/src/options.c
@@ -137,6 +137,7 @@ static struct opt_entry opt_list[] = {
 	{"stdout", FLG_STDOUT, FLG_STDOUT, FLG_CRACKING_SUP, FLG_SINGLE_CHK | FLG_BATCH_CHK, "%u", &options.length},
 	{"restore", FLG_RESTORE_SET, FLG_RESTORE_CHK, 0, ~FLG_RESTORE_SET & ~GETOPT_FLAGS, OPT_FMT_STR_ALLOC, &options.session},
 	{"session", FLG_SESSION, FLG_SESSION, FLG_CRACKING_SUP, OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &options.session},
+	{"catch-up", FLG_ONCE, 0, 0, OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &options.catchup},
 	{"status", FLG_STATUS_SET, FLG_STATUS_CHK, 0, ~FLG_STATUS_SET & ~GETOPT_FLAGS, OPT_FMT_STR_ALLOC, &options.session},
 	{"make-charset", FLG_MAKECHR_SET, FLG_MAKECHR_CHK, 0, FLG_CRACKING_CHK | FLG_SESSION | OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &options.charset},
 	{"show", FLG_SHOW_SET, FLG_SHOW_CHK, 0, FLG_CRACKING_SUP | FLG_MAKECHR_CHK, OPT_FMT_STR_ALLOC, &show_uncracked_str},
@@ -329,6 +330,7 @@ JOHN_USAGE_FORK \
 "--verbosity=N              Change verbosity (1-%u or %u for debug, default %u)\n" \
 "--no-log                   Disables creation and writing to john.log file\n"  \
 "--bare-always-valid=Y      Treat bare hashes as valid (Y/N)\n" \
+"--catch-up=NAME            Catch up with existing (paused) session NAME\n" \
 "--config=FILE              Use FILE instead of john.conf or john.ini\n" \
 "--encoding=NAME            Input encoding (eg. UTF-8, ISO-8859-1). See also\n" \
 "                           doc/ENCODINGS.\n" \
@@ -607,6 +609,9 @@ void opt_init(char *name, int argc, char **argv)
 #endif
 		return;
 	}
+
+	if (options.catchup && options.max_cands)
+		error_msg("Can't combine --max-candidates and --catch-up options\n");
 
 	if (options.flags & FLG_STATUS_CHK) {
 #if OS_FORK

--- a/src/options.h
+++ b/src/options.h
@@ -387,7 +387,10 @@ struct options_main {
  */
 	int max_run_time;
 
-/* Graceful exit after this many candidates tried. */
+/*
+ * Graceful exit after this many candidates tried. If the number is
+ * negative, we reset the count on any successful crack.
+ */
 	long long max_cands;
 
 /* Emit a status line every N seconds */
@@ -450,6 +453,8 @@ struct options_main {
 	int log_stderr;
 /* Emit a status line for every password cracked */
 	int crack_status;
+/* --catch-up=oldsession */
+	char *catchup;
 };
 
 extern struct options_main options;

--- a/src/recovery.h
+++ b/src/recovery.h
@@ -113,4 +113,9 @@ extern void rec_restore_args(int lock);
  */
 extern void rec_restore_mode(int (*restore_mode)(FILE *file));
 
+/*
+ * Reads status.cands from other session's file and returns it.
+ */
+extern uint64_t rec_read_cands(char *session);
+
 #endif


### PR DESCRIPTION
This limits a session to running only until it reaches the candidates tried count of a different, existing and paused session NAME.  This can be used for "adding" more hashes to an existing job:  After the new session finishes, just concatenate the new hashes to the older session's hash file and resume the old session.  This will end up more or less as if both sets of hashes were in the original session to start with.

Obviously it's intended for salted hashes and mainly for things like incremental mode. It should be very usable for some situations we've had in contests in the past: If the original session had 100 salts and ran for several hours, we can "add" a new hash to it in minutes without missing a beat.

I've done this in the past using `--max-run-time` which is very imprecise. I then did it with `--max-candidates` which is much better but requires you to parse the old session file's `status.cands`. Setting config option `StatusShowCandidates` to true helps, but in case of fork/MPI you need to add up the numbers (but the sum you used will just be divided according to node count so if nodes' progress varied it will end up less precise again).

This option simply reads `status.cands` *per node* so will end up exactly where the old session ended or very slightly ahead. Other than that parsing, we mostly just piggy-back the existing `--max-candidates` code.