### PR TITLE
john.conf: add external "wordcase" mode

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -3974,8 +3974,8 @@ void next()
 }
 /* restore() not needed. john properly restores fast enough without it */
 
-# External hybrid CaSE mutation code
-[List.External:Case]
+# Shared base code for External hybrid CaSE and Wordcase mutation code
+[List.External_base:Case]
 
 int rotor[251]; /* max length input is 125 bytes [125*5+1]; */
 int rotors[125];
@@ -3985,12 +3985,7 @@ int rotor_cnt[125];
 int current_word_count;
 int max_mangle; /* controls how many bytes we run through our 'leet' code */
 int original_word; /* if set to 1 then we start with original word. If 0, then start with first mangled word */
-
-void init()
-{
-	max_mangle = 20; /* only mangle 20 characters max (2^20 is 1 million) */
-	original_word = 1; /* for case mangle, unless the data is 100% lower case, we really can not skip the original word */
-}
+int word_mode; /* if set to 1, only first character of each space-separated word is case-toggled, else every character */
 
 /* new word */
 void new()
@@ -4008,18 +4003,24 @@ void new()
 		rotor_cnt[wlen] = rotor_idx[wlen] = 0;
 		rotor_ptr[wlen] = rotor_off;
 		ch = word[wlen];
-		if (ch >= 'A' && ch <= 'Z') {
-			ch += 0x20;
-			word[wlen] = ch;
-			rotor[rotor_off++] = ch;
-			rotor[rotor_off++] = ch-0x20;
-		}
-		if (ch >= 'a' && ch <= 'z') {
-			rotor[rotor_off++] = ch;
-			rotor[rotor_off++] = ch-0x20;
-			rotor_cnt[wlen] = 2;
-			hybrid_total *= 2;
-			rotors[idx++] = wlen;
+		/* traditionally, this block was always executed, with Wordcase
+		   mode added we execute it either always when word_mode isn't
+		   used or at the beginning of a word or when the previous char
+		   was space */
+		if (word_mode == 0 || wlen == 0 || word[wlen-1] == 0x20) {
+			if (ch >= 'A' && ch <= 'Z') {
+				ch += 0x20;
+				word[wlen] = ch;
+				rotor[rotor_off++] = ch;
+				rotor[rotor_off++] = ch-0x20;
+			}
+			if (ch >= 'a' && ch <= 'z') {
+				rotor[rotor_off++] = ch;
+				rotor[rotor_off++] = ch-0x20;
+				rotor_cnt[wlen] = 2;
+				hybrid_total *= 2;
+				rotors[idx++] = wlen;
+			}
 		}
 		++wlen;
 	}
@@ -4055,6 +4056,30 @@ void next()
 	++current_word_count;
 }
 /* restore() not needed. john properly restores fast enough without it */
+
+# External hybrid CaSE mutation code
+[List.External:Case]
+.include [List.External_base:Case]
+
+void init()
+{
+	max_mangle = 20; /* only mangle 20 characters max (2^20 is 1 million) */
+	original_word = 1; /* for case mangle, unless the data is 100% lower case, we really can not skip the original word */
+	word_mode = 0;
+}
+
+
+# external mode toggling case in all word combinations, e.g:
+# foo bar -> foo bar, foo Bar, Foo bar, Foo Bar
+[List.External:Wordcase]
+.include [List.External_base:Case]
+
+void init()
+{
+	max_mangle = 20; /* only mangle 20 characters max (2^20 is 1 million) */
+	original_word = 1; /* for case mangle, unless the data is 100% lower case, we really can not skip the original word */
+	word_mode = 1;
+}
 
 # Alternate hybrid external 'leet' mode (HybridLeet)
 .include <hybrid.conf>

--- a/run/john.conf
+++ b/run/john.conf
@@ -3990,7 +3990,7 @@ int word_mode; /* if set to 1, only first character of each space-separated word
 /* new word */
 void new()
 {
-	int rotor_off, idx, wlen, ch;
+	int rotor_off, idx, wlen, ch, prevch;
 	idx = rotor_off = wlen = 0;
 	hybrid_total = 1;
 	while (word[wlen++]) ; --wlen;
@@ -3999,6 +3999,7 @@ void new()
 		return;
 	}
 	wlen = 0;
+	prevch = ' '; /* at word start, behave as if previous char was space for wordcase mode */
 	while (word[wlen] && idx < max_mangle) {
 		rotor_cnt[wlen] = rotor_idx[wlen] = 0;
 		rotor_ptr[wlen] = rotor_off;
@@ -4007,7 +4008,7 @@ void new()
 		   mode added we execute it either always when word_mode isn't
 		   used or at the beginning of a word or when the previous char
 		   was space */
-		if (word_mode == 0 || wlen == 0 || word[wlen-1] == 0x20) {
+		if (!word_mode || prevch == ' ') {
 			if (ch >= 'A' && ch <= 'Z') {
 				ch += 0x20;
 				word[wlen] = ch;
@@ -4023,6 +4024,7 @@ void new()
 			}
 		}
 		++wlen;
+		prevch = ch;
 	}
 	/* hybrid_total+666 is our indicator that this is the original word */
 	if (original_word)


### PR DESCRIPTION
expands an input phrase, e.g. "foo bar" into all possible combinations
with words separated by space capitalized or not:
foo bar
Foo bar
Foo Bar
foo Bar

the code is identical to 'case' external mode, with the addition of one
condition in the new() function.