### PR TITLE
--catch-up option: Show progress relative to the targeted session

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -454,6 +454,9 @@ void status_print(void)
 	if (options.flags & FLG_STATUS_CHK)
 		percent_value = status.progress;
 	else
+	if (options.catchup && john_max_cands) {
+		percent_value = 100.0 * status.cands / john_max_cands;
+	} else
 	if (status_get_progress)
 		percent_value = status_get_progress();
 


### PR DESCRIPTION
I intentionally ignored this when I added the --catch-up option because I had the idea it would be messy in several ways, but I came to realize the code is trivial and bullet proof. The catch-up session will show ETA even if the mother session don't support progress at all!.

See #4761

```
$ ./john bigcrypt.in --format=descrypt --catch-up=test -mask -len=8 -prog=2
Using default input encoding: UTF-8
Loaded 2 password hashes with 2 different salts (descrypt, traditional crypt(3) [DES 256/256 AVX2])
Remaining 1 password hash
Will run 16 OpenMP threads
Using default mask: ?1?2?2?2?2?2?2?3
Press 'q' or Ctrl-C to abort, almost any other key for status
0g 0:00:00:02 21.68% (ETA: 18:30:02) 0g/s 52641Kp/s 52641Kc/s 52641KC/s vicuaeaa..Kopbaeaa
0g 0:00:00:04 43.43% (ETA: 18:30:02) 0g/s 52715Kp/s 52715Kc/s 52715KC/s pmt5aiaa..Uck4aiaa
0g 0:00:00:06 65.22% (ETA: 18:30:02) 0g/s 52772Kp/s 52772Kc/s 52772KC/s wjwkeoaa..Jv9geoaa
0g 0:00:00:08 86.41% (ETA: 18:30:02) 0g/s 52445Kp/s 52445Kc/s 52445KC/s 5vjeenaa..ow0ienaa
0g 0:00:00:09 DONE (2021-08-12 18:30) 0g/s 52206Kp/s 52206Kc/s 52206KC/s 9bk9znaa..egx8znaa
Done catching up with 'test'
Session completed. 
```