### PR TITLE
[pfx2john] patch the main loop over cli arguments

### DIFF
--- a/run/pfx2john.py
+++ b/run/pfx2john.py
@@ -91,4 +91,4 @@ if __name__ == "__main__":
         sys.stderr.write("Usage: %s <.pfx file(s)>\n" % sys.argv[0])
 
     for i in range(1, len(sys.argv)):
-        parse_pkcs12(sys.argv[1])
+        parse_pkcs12(sys.argv[i])


### PR DESCRIPTION
This seems to be a logical flaw.  While the script, in its current form,
works as expected in cases where exactly one `.pfx` filename is given as
an argument, it doesn't when more than one argument is specified.

It would then perform `len(argv)` times the conversion of the file given
by `argv[1]`, rather than iterating over all the elements of `argv[]`.

Still, I'm somehow wondering if I'm missing something obvious, since the
code has been like that for about two years without someone complaining.
If that's the case, excuse me please, and feel free to simply close this
PR.

Thank you for sharing this valuable project, by the way.

_Cheers !_