### PR TITLE
Single mode: Bug fix for when to call clear_keys()

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -1232,11 +1232,12 @@ int crk_process_salt(struct db_salt *salt)
 	count_from_guesses = salt->keys->count_from_guesses;
 	index = 0;
 
-	crk_methods.clear_keys();
-
 	while (count--) {
 		strnzcpy(key, ptr, options.eff_maxlength + 1);
 		ptr += options.eff_maxlength;
+
+		if (index == 0)
+			crk_methods.clear_keys();
 
 		crk_methods.set_key(key, index++);
 		if (index >= crk_params->max_keys_per_crypt || !count ||
@@ -1269,7 +1270,6 @@ int crk_process_salt(struct db_salt *salt)
 			if (!salt->list)
 				return 0;
 			index = 0;
-			crk_methods.clear_keys();
 		}
 	}
 


### PR DESCRIPTION
I added a call in fb051f3b after seeing it was sometimes missed, but it led to many double calls and even a fatal [for a few SIMD formats] situation in the end of a single run because it would end up with a call to crypt_all() with the key buffer in limbo.

This fix should do the Right Thing in all situations.

@solardiz I think the diff just happens to include the "need to know" context to be easily reviewed. And I'm so sure this is correct I almost pushed it directly.