### PR TITLE
Mask mode: Bug fix for hybrid mask mode with non-ASCII

### DIFF
--- a/src/unicode.c
+++ b/src/unicode.c
@@ -675,12 +675,11 @@ char *utf8_to_enc_r(UTF8 *src, char *dst, int dstlen)
 /*
  * Thread-safe conversion from codepage to UTF-8.
  */
-char *cp_to_utf8_r(char *src, char *dst, int dstlen)
+char *cp_to_utf8_r(const char *src, char *dst, int dstlen)
 {
 	UTF16 tmp16[LINE_BUFFER_SIZE + 1];
 
-	cp_to_utf16(tmp16, LINE_BUFFER_SIZE, (unsigned char*)src,
-	             strlen(src));
+	cp_to_utf16(tmp16, LINE_BUFFER_SIZE, (unsigned char*)src, strlen(src));
 	return (char*)utf16_to_utf8_r((UTF8*)dst, dstlen, tmp16);
 }
 
@@ -708,12 +707,11 @@ inline static UTF8 *utf16_to_cp_r(UTF8 *dst, int dst_len, const UTF16 *source)
 /*
  * Thread-safe conversion from UTF-8 to codepage
  */
-char *utf8_to_cp_r(char *src, char *dst, int dstlen)
+char *utf8_to_cp_r(const char *src, char *dst, int dstlen)
 {
 	UTF16 tmp16[LINE_BUFFER_SIZE + 1];
 
-	utf8_to_utf16(tmp16, LINE_BUFFER_SIZE, (UTF8*)src,
-	              strlen(src));
+	utf8_to_utf16(tmp16, LINE_BUFFER_SIZE, (UTF8*)src, strlen(src));
 	utf16_to_cp_r((UTF8*)dst, dstlen, tmp16);
 	return (char*)dst;
 }

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -181,8 +181,8 @@ extern int enc_to_utf32(UTF32 *dst, unsigned int maxdstlen, const UTF8 *src,
  * we can opt to convert to/from.
  */
 extern char *utf16_to_cp(const UTF16* source);
-extern char *utf8_to_cp_r(char *src, char *dst, int dstlen);
-extern char *cp_to_utf8_r(char *src, char *dst, int dstlen);
+extern char *utf8_to_cp_r(const char *src, char *dst, int dstlen);
+extern char *cp_to_utf8_r(const char *src, char *dst, int dstlen);
 
 /*
  * Return length (in characters) of a UTF-32 string


### PR DESCRIPTION
In hybrid mask using an internal codepage and with no rules in play, and where the base word and the hybrid mask both contained non-ASCII, we would end up with an incorrectly encoded base word resulting in garbage.