### PR TITLE
cryptoSafe-opencl format: Atomic functions need volatile pointer

### DIFF
--- a/run/opencl/cryptosafe_kernel.cl
+++ b/run/opencl/cryptosafe_kernel.cl
@@ -39,7 +39,7 @@ void cryptoSafe(__global const uchar *pwbuf,
                 __global const uint *index,
                 __constant salt_t *salt,
                 __global uint *result,
-                __global uint *crack_count_ret,
+                volatile __global uint *crack_count_ret,
                 __global uint *int_key_loc,
 #if USE_CONST_CACHE
                 __constant


### PR DESCRIPTION
Bug found while reworking zip-opencl format.  I suppose any driver that doesn't complain about this also doesn't really need it, but this is needed to comply with the specifications.