### PR TITLE
configure.ac: avoid bashism in pkg-config check

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -347,7 +347,7 @@ AS_IF([test -z "$STRIP"], [AC_CHECK_TOOL([STRIP], [strip])])
 dnl Check if we have this at all
 PKG_PROG_PKG_CONFIG
 AC_MSG_CHECKING([if pkg-config will be used])
-if test "x$PKG_CONFIG" = x || test "x$enable_pkg_config" == xno ; then
+if test "x$PKG_CONFIG" = x || test "x$enable_pkg_config" = xno ; then
   JTR_MSG_RESULT_FAILIF_FORCED([xno], [x$enable_pkg_config], [pkg-config is NOT available])
   PKG_CONFIG=no
 else


### PR DESCRIPTION
== is a Bashism and configure scripts need to work
with a POSIX shell, so let's change to = (like in
the other condition).

Signed-off-by: Sam James <sam@gentoo.org>