### PR TITLE
Improved openssl2john and pem2john

### DIFF
--- a/run/openssl2john.py
+++ b/run/openssl2john.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # This utility helps in cracking files encrypted using "openssl enc" command.
+# It does not help in cracking encrypted private key files. Use pem2john.py instead.
 #
 # This software is Copyright (c) 2013, Dhiru Kholia <dhiru at openwall.com> and
 # it is hereby released to the general public under the following terms:
@@ -19,13 +20,15 @@ from binascii import hexlify
 # openssl aes-256-cbc -a -in secret.txt -out secret.txt.enc
 # openssl enc -aes-256-cbc -in secret.txt -out secret.txt.enc
 
-PY3 = sys.version_info[0] == 3
-
 
 def process(filename, plaintext=None, cipher=0, md=0, minascii=0):
 
     with open(filename, "rb") as f:
         data = f.read()
+
+        if b"PRIVATE KEY-----" in data:
+            sys.stderr.write("%s looks like a private key but this tool processes data encrypted using OpenSSL's enc command! Try pem2john.py instead!\n" % filename)
+            return
 
         if not data.startswith(b"Salted__"):
             try:
@@ -44,9 +47,7 @@ def process(filename, plaintext=None, cipher=0, md=0, minascii=0):
 
         rlen = len(data) - 16
         salt = data[8:16]
-        salt = hexlify(salt)
-        if PY3:
-            salt = salt.decode("ascii")
+        salt = hexlify(salt).decode("ascii")
 
         if rlen <= 16:
             last_chunk = data[-16:]
@@ -56,9 +57,7 @@ def process(filename, plaintext=None, cipher=0, md=0, minascii=0):
                 s = "2$%d" % minascii
             else:
                 s = "0"
-            last_chunk = hexlify(last_chunk)
-            if PY3:
-                last_chunk = last_chunk.decode("ascii")
+            last_chunk = hexlify(last_chunk).decode("ascii")
             sys.stdout.write("%s:$openssl$%s$%s$8$%s$%s$1$%s\n" %
                              (filename, cipher, md, salt, last_chunk, s))
         else:
@@ -71,12 +70,8 @@ def process(filename, plaintext=None, cipher=0, md=0, minascii=0):
                 s = "2$%d" % minascii
             else:
                 s = "0"
-            last_chunk = hexlify(last_chunk)
-            if PY3:
-                last_chunk = last_chunk.decode("ascii")
-            rdata = hexlify(rdata)
-            if PY3:
-                rdata = rdata.decode("ascii")
+            last_chunk = hexlify(last_chunk).decode("ascii")
+            rdata = hexlify(rdata).decode("ascii")
             sys.stdout.write("%s:$openssl$%s$%s$8$%s$%s$0$%s$%s$%s\n" %
                              (os.path.basename(filename), cipher, md, salt,
                               last_chunk,
@@ -100,5 +95,5 @@ if __name__ == '__main__':
     parser.add_option('-m', action="store", dest="md", default=0)
     options, remainder = parser.parse_args()
 
-    for j in range(0, len(remainder)):
-        process(remainder[j], options.plaintext, options.cipher, options.md, options.minascii)
+    for filename in remainder:
+        process(filename, options.plaintext, options.cipher, options.md, options.minascii)

--- a/run/pem2john.py
+++ b/run/pem2john.py
@@ -9,6 +9,8 @@
 #
 # pylint: disable=invalid-name,line-too-long,missing-docstring,pointless-string-statement
 
+# This script converts encrypted private key files in PKCS8 format to John input
+
 import sys
 from binascii import hexlify
 
@@ -18,8 +20,6 @@ try:
 except ImportError:
     sys.stderr.write("asn1crypto python package is missing, please install it using 'pip install --user asn1crypto' command.\n")
     sys.exit(1)
-
-PY3 = sys.version_info[0] == 3
 
 """
 
@@ -99,14 +99,9 @@ def unwrap_pkcs8_data(blob):
             sys.stderr.write("[%s] cipher <%s> is not supported currently!\n" % (sys.argv[0], cipher))
             return False
 
-        salth = hexlify(salt)
-        encrypted_datah = hexlify(encrypted_data)
-        ivh = hexlify(iv)
-
-        if PY3:
-            salth = salth.decode("ascii")
-            encrypted_datah = encrypted_datah.decode("ascii")
-            ivh = ivh.decode("ascii")
+        salth = hexlify(salt).decode("ascii")
+        encrypted_datah = hexlify(encrypted_data).decode("ascii")
+        ivh = hexlify(iv).decode("ascii")
 
         sys.stdout.write("$PEM$1$%d$%s$%s$%s$%d$%s\n" % (cid, salth, iterations, ivh, len(encrypted_data), encrypted_datah))
         return True
@@ -122,16 +117,16 @@ if __name__ == "__main__":
 
     for filename in sys.argv[1:]:
         blob = open(filename, "rb").read()
-        if b'-----BEGIN ENCRYPTED PRIVATE KEY-----' not in blob:
-            if b'PRIVATE KEY-----' in blob:
-                sys.stderr.write("[%s] try using ssh2john.py on this file instead!\n" % sys.argv[0])
-            else:
-                # try as DER payload
-                ret = unwrap_pkcs8_data(blob)
-                if not ret:
-                    sys.stderr.write("[%s] is this really a private key in PKCS #8 format?\n" % sys.argv[0])
-
-        else:
+        if b'-----BEGIN ENCRYPTED PRIVATE KEY-----' in blob:
             ret = unwrap_pkcs8(blob)
             if not ret:
-                sys.stderr.write("[%s] is this really a private key in PKCS #8 format?\n" % sys.argv[0])
+                sys.stderr.write("[%s] is this really a private key in PKCS #8 format?\n" % filename)
+        elif b'-----BEGIN PRIVATE KEY-----' in blob:
+            sys.stderr.write("[%s] is not encrypted!\n" % filename)
+        elif b'PRIVATE KEY-----' in blob:
+            sys.stderr.write("[%s] try using ssh2john.py on this file instead!\n" % filename)
+        else:
+            # try as DER instead of PEM
+            ret = unwrap_pkcs8_data(blob)
+            if not ret:
+                sys.stderr.write("[%s] is this really a private key in PKCS #8 format?\n" % filename)


### PR DESCRIPTION
I did a bit of cleanup in both scripts. More importantly:

- `openssl2john.py` detects private key files and recommends `pem2john.py`
- `pem2john.py` now detects unencrypted private key files

fixes #4833