### PR TITLE
Allow hashcat's '+N' rule (increment character) in more situations

### DIFF
--- a/doc/RULES
+++ b/doc/RULES
@@ -296,7 +296,7 @@ first, the second, or to both words:
 
 1	first word only
 2	second word only
-+	the concatenation of both (should only be used after a "1" or "2")
++	the concatenation of both (can only be used after a "1" or "2")
 
 If you use some of the above commands in a rule, it will only process
 word pairs (e.g., full names from the GECOS field) and reject single

--- a/doc/RULES-hashcat
+++ b/doc/RULES-hashcat
@@ -27,7 +27,7 @@ one simply creates include sections, like this:
 
 [List.Rules:HC_deadone]
 !! hashcat logic ON
-.include '/code/hashcat//rules/d3ad0ne.rule'
+.include '/code/hashcat/rules/d3ad0ne.rule'
 !! hashcat logic OFF
 
 ... etc.
@@ -102,4 +102,5 @@ Notes:
 4. R and L are keyboard shift R and L if not in hashcat mode.  But in hashcat
    mode, these are bitshift character at location N.  If R or N are followed by
    0 to 9 in non hashcat mode, then they are treated as the hashcat rules.
-5. +N does not work in single mode, unless hashcat logic is used.
+5. +N does not work after single mode word pair command 1 or 2 was used, unless
+   in hashcat mode.

--- a/src/rules.c
+++ b/src/rules.c
@@ -1475,13 +1475,14 @@ char *rules_apply(char *word_in, char *rule, int split, char *last)
 			break;
 
 		case '+':
-			if (hc_logic || split < 0) {
+			if (hc_logic || !which) {
 				/* HC rule: increment character */
 				unsigned char x;
 				POSITION(x)
 				if (x < length)
 					++in[x];
-			} else {
+				break;
+			}
 			switch (which) {
 			case 1:
 				strcat(in, buffer[2][STAGE]);
@@ -1503,7 +1504,6 @@ char *rules_apply(char *word_in, char *rule, int split, char *last)
 			}
 			length = strlen(in);
 			which = 0;
-			}
 			break;
 
 /* Rules added in Jumbo */


### PR DESCRIPTION
We already allowed the '+N' rule without explicitly being in "hashcat mode" as long as we weren't processing word pairs.

This change allows '+N' at any time where it wouldn't be valid as the original '+' concatenate word pair command:  If neither of commands "1" or "2" was used before it, the '+' is parsed as the hashcat command.