### PR TITLE
PBKDF2-HMAC-SHA1-opencl: Fix big-endian build

### DIFF
--- a/src/opencl_pbkdf2_hmac_sha1_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha1_fmt_plug.c
@@ -227,6 +227,7 @@ static void *get_binary(char *ciphertext)
 #if !ARCH_LITTLE_ENDIAN
 	char *p = strrchr(ciphertext, '$') + 1;
 	int len = strlen(p) / 2;
+	int i;
 	for (i = 0; i < len / sizeof(uint32_t); ++i) {
 		((uint32_t*)out)[i] = JOHNSWAP(((uint32_t*)out)[i]);
 	}


### PR DESCRIPTION
We are receiving following error message for building for s390x:
```
error: 'i' undeclared (first use in this function)
   226 |         for (i = 0; i < len / sizeof(uint32_t); ++i) {
                          ^

```
Firstly - before the enablement for s390x - the syntax issue should have been fixed.
Therefore I have created the declaration of an integar of I inside of the for loop.