### PR TITLE
descrypt: Fix x86 assembly files to match DES_bs_crypt_25() prototype

### DIFF
--- a/src/x86-64.S
+++ b/src/x86-64.S
@@ -1162,6 +1162,7 @@ DO_ALIGN(6)
 .globl DES_bs_crypt_25
 DES_bs_crypt_25:
 	PROLOGUE
+	movl (ARG1),%r8d
 	cmpl $0,DES_bs_all_keys_changed(%rip)
 	jnz DES_bs_finalize_keys_25
 DES_bs_crypt_25_body:
@@ -1213,6 +1214,7 @@ DES_bs_crypt_25_swap:
 	movl $0x108,rounds_and_swapped
 	subl $1,iterations
 	jnz DES_bs_crypt_25_swap
+	xchgq %r8,%rax
 	EPILOGUE
 	ret
 DES_bs_crypt_25_next:

--- a/src/x86-mmx.S
+++ b/src/x86-mmx.S
@@ -1192,11 +1192,13 @@ DES_bs_crypt_25_swap:
 	movl $0x108,rounds_and_swapped
 	decl iterations
 	jnz DES_bs_crypt_25_swap
+	movl 12(%esp),%eax
 	popl %esi
 	popl %ebp
 #ifdef EMMS
 	emms
 #endif
+	movl (%eax),%eax
 	ret
 DES_bs_crypt_25_next:
 	subl $nvec(0x300-48),k_ptr

--- a/src/x86-sse.S
+++ b/src/x86-sse.S
@@ -1187,8 +1187,10 @@ DES_bs_crypt_25_swap:
 	movl $0x108,rounds_and_swapped
 	decl iterations
 	jnz DES_bs_crypt_25_swap
+	movl 12(%esp),%eax
 	popl %esi
 	popl %ebp
+	movl (%eax),%eax
 	ret
 DES_bs_crypt_25_next:
 	subl $nvec(0x300-48),k_ptr


### PR DESCRIPTION
This got broken last year in ec6d12bab17558701b1f0779b6a28c2b1fef7445, which changed the function prototype and its usage in C, but missed a corresponding change to the assembly files.

Fixes #4842