### PR TITLE
sipdump2john: write hashes to stdout

### DIFF
--- a/run/sipdump2john.py
+++ b/run/sipdump2john.py
@@ -15,13 +15,13 @@ def process_file(filename):
             # in the uri field, in that case, adds an empty field
             if len(data) == 13:
                 data.insert(7, '')
-            sys.stderr.write("%s-%s:$sip$*%s\n" % (data[0], data[1], '*'.join(data)))
+            sys.stdout.write("%s-%s:$sip$*%s\n" % (data[0], data[1], '*'.join(data)))
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        sys.stderr.write("Usage: %s <sipdump dump files>\n" % sys.argv[0])
+        sys.stderr.write("Usage: %s <sipdump files>\n" % sys.argv[0])
         sys.exit(1)
 
-    for i in range(1, len(sys.argv)):
-        process_file(sys.argv[i])
+    for i in sys.argv[1:]:
+        process_file(i)


### PR DESCRIPTION
Today I had a training course on VoIP hacking, when the instructor told us to run `sipdump2john.py sipdump.txt &> hash.txt`. First I thought, why the heck shall we redirect stderr. Then I noticed that the hashes are indeed written to stderr. I guess this is not on purpose since all other tools output to stdout.

This PR fixes this. Two other changes are just cleanup.