### PR TITLE
Fix regressions from recent change of benchmark_running logic

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -1279,6 +1279,7 @@ struct db_main *ldr_init_test_db(struct fmt_main *format, struct db_main *real)
 
 	testdb = mem_alloc(sizeof(struct db_main));
 
+	self_test_running++;
 	fmt_init(format);
 	dyna_salt_init(format);
 	ldr_init_database(testdb, &options.loader);
@@ -1288,7 +1289,6 @@ struct db_main *ldr_init_test_db(struct fmt_main *format, struct db_main *real)
 	ldr_init_password_hash(testdb);
 
 	ldr_loading_testdb = 1;
-	self_test_running++;
 	while (current->ciphertext) {
 		char *ex_len_line = NULL;
 		char _line[LINE_BUFFER_SIZE], *line = _line;

--- a/src/opencl_diskcryptor_aes_fmt_plug.c
+++ b/src/opencl_diskcryptor_aes_fmt_plug.c
@@ -175,7 +175,7 @@ static void init(struct fmt_main *_self)
 	self = _self;
 	opencl_prepare_dev(gpu_id);
 
-	if (!warned++ && !bench_or_test_running && !options.listconf) {
+	if (!warned++ && !(options.flags & FLG_TEST_CHK) && !options.listconf) {
 		fprintf(stderr, "[ATTENTION] This format (%s) can only crack AES XTS DiskCryptor hashes.\n", FORMAT_LABEL);
 	}
 }

--- a/src/opencl_diskcryptor_fmt_plug.c
+++ b/src/opencl_diskcryptor_fmt_plug.c
@@ -163,8 +163,6 @@ static void create_clobj(size_t kpc, struct fmt_main *self)
 	CLKERNELARG(split_kernel, 1, mem_out, "Error while setting mem_out");
 }
 
-extern int bench_running;
-
 static void init(struct fmt_main *_self)
 {
 	static int warned = 0;
@@ -174,7 +172,7 @@ static void init(struct fmt_main *_self)
 
 	Twofish_initialise();
 
-	if (!warned++ && !bench_or_test_running && !options.listconf) {
+	if (!warned++ && !(options.flags & FLG_TEST_CHK) && !options.listconf) {
 		fprintf(stderr, "[ATTENTION] This format (%s) does not support cascaded cipher modes yet.\n", FORMAT_LABEL);
 	}
 }


### PR DESCRIPTION
After 60f2babb we would get spurious bogus warnings from formats' init() during self-test, such as "Warning: cryptoSafe format should always be UTF-8. Use --target-encoding=utf8".