### PR TITLE
Replace all calls to DES_set_key() with DES_set_key_unchecked

### DIFF
--- a/src/KRB4_fmt_plug.c
+++ b/src/KRB4_fmt_plug.c
@@ -232,7 +232,7 @@ static int cmp_all(void *binary, int count)
 {
 	DES_cblock tmp;
 
-	DES_set_key(&saved_key.key, &saved_key.sched);
+	DES_set_key_unchecked(&saved_key.key, &saved_key.sched);
 
 	DES_pcbc_encrypt(saved_salt->tgt, (unsigned char *)&tmp,
 	                 sizeof(tmp), &saved_key.sched,

--- a/src/KRB5_std_plug.c
+++ b/src/KRB5_std_plug.c
@@ -184,9 +184,9 @@ inline static void derive_key(const void *constant, int len, krb5_key *krb5key) 
     // set the des schedule
     bk = (DES_cblock*) krb5key->key;
     s = (DES_key_schedule *) krb5key->schedule;
-    DES_set_key(&bk[0], &s[0]);
-    DES_set_key(&bk[1], &s[1]);
-    DES_set_key(&bk[2], &s[2]);
+    DES_set_key_unchecked(&bk[0], &s[0]);
+    DES_set_key_unchecked(&bk[1], &s[1]);
+    DES_set_key_unchecked(&bk[2], &s[2]);
 
     if (DES3_BLOCK_SIZE * 8 < DES3_KEY_BITS || len != DES3_BLOCK_SIZE) {
         nblocks = (DES3_KEY_BITS + DES3_BLOCK_SIZE * 8 - 1) / (DES3_BLOCK_SIZE * 8);
@@ -243,9 +243,9 @@ void des3_decrypt(krb5_key *key, char *cipher, char *plain, int len) {
     k = (DES_cblock *) key->key;
     s = (DES_key_schedule *) key->schedule;
 
-    DES_set_key(&k[0], &s[0]);
-    DES_set_key(&k[1], &s[1]);
-    DES_set_key(&k[2], &s[2]);
+    DES_set_key_unchecked(&k[0], &s[0]);
+    DES_set_key_unchecked(&k[1], &s[1]);
+    DES_set_key_unchecked(&k[2], &s[2]);
 
     DES_ede3_cbc_encrypt((const unsigned char*) cipher, (unsigned char*) plain, len, &s[0], &s[1], &s[2], &ivec, 0);
 

--- a/src/NETLM_fmt_plug.c
+++ b/src/NETLM_fmt_plug.c
@@ -219,7 +219,7 @@ inline static void setup_des_key(unsigned char key_56[], DES_key_schedule *ks)
   key[6] = (key_56[5] << 2) | (key_56[6] >> 6);
   key[7] = (key_56[6] << 1);
 
-  DES_set_key(&key, ks);
+  DES_set_key_unchecked(&key, ks);
 }
 
 static int crypt_all(int *pcount, struct db_salt *salt)

--- a/src/NETSPLITLM_fmt_plug.c
+++ b/src/NETSPLITLM_fmt_plug.c
@@ -198,7 +198,7 @@ inline static void setup_des_key(unsigned char key_56[], DES_key_schedule *ks)
   key[6] = (key_56[5] << 2) | (key_56[6] >> 6);
   key[7] = (key_56[6] << 1);
 
-  DES_set_key(&key, ks);
+  DES_set_key_unchecked(&key, ks);
 }
 
 static int crypt_all(int *pcount, struct db_salt *salt)

--- a/src/dmg_fmt_plug.c
+++ b/src/dmg_fmt_plug.c
@@ -372,9 +372,9 @@ static int apple_des3_ede_unwrap_key1(const unsigned char *wrapped_key, const in
 	unsigned char IV[8] = { 0x4a, 0xdd, 0xa2, 0x2c, 0x79, 0xe8, 0x21, 0x05 };
 	int outlen, i;
 
-	DES_set_key((DES_cblock*)(decryptKey +  0), &ks1);
-	DES_set_key((DES_cblock*)(decryptKey +  8), &ks2);
-	DES_set_key((DES_cblock*)(decryptKey + 16), &ks3);
+	DES_set_key_unchecked((DES_cblock*)(decryptKey +  0), &ks1);
+	DES_set_key_unchecked((DES_cblock*)(decryptKey +  8), &ks2);
+	DES_set_key_unchecked((DES_cblock*)(decryptKey + 16), &ks3);
 	DES_ede3_cbc_encrypt(wrapped_key, TEMP1, wrapped_key_len, &ks1, &ks2, &ks3,
 	                     (DES_cblock*)IV, DES_DECRYPT);
 
@@ -475,9 +475,9 @@ static void hash_plugin_check_hash(int index)
 		derived_key = Derived_key[j];
 #endif
 
-		DES_set_key((DES_cblock*)(derived_key +  0), &ks1);
-		DES_set_key((DES_cblock*)(derived_key +  8), &ks2);
-		DES_set_key((DES_cblock*)(derived_key + 16), &ks3);
+		DES_set_key_unchecked((DES_cblock*)(derived_key +  0), &ks1);
+		DES_set_key_unchecked((DES_cblock*)(derived_key +  8), &ks2);
+		DES_set_key_unchecked((DES_cblock*)(derived_key + 16), &ks3);
 		memcpy(iv, cur_salt->iv, 8);
 		DES_ede3_cbc_encrypt(cur_salt->encrypted_keyblob, TEMP1,
 		                     cur_salt->encrypted_keyblob_size, &ks1, &ks2, &ks3,

--- a/src/dpapimk_fmt_plug.c
+++ b/src/dpapimk_fmt_plug.c
@@ -267,9 +267,9 @@ static int decrypt_v1(unsigned char *key, unsigned char *iv, unsigned char *pwdh
 	DES_key_schedule ks1, ks2, ks3;
 
 	memset(out, 0, sizeof(out));
-	DES_set_key((DES_cblock *) key, &ks1);
-	DES_set_key((DES_cblock *) (key + 8), &ks2);
-	DES_set_key((DES_cblock *) (key + 16), &ks3);
+	DES_set_key_unchecked((DES_cblock *) key, &ks1);
+	DES_set_key_unchecked((DES_cblock *) (key + 8), &ks2);
+	DES_set_key_unchecked((DES_cblock *) (key + 16), &ks3);
 	memcpy(ivec, iv, 8);
 	DES_ede3_cbc_encrypt(data, out, cur_salt->encrypted_len, &ks1, &ks2, &ks3, &ivec,  DES_DECRYPT);
 

--- a/src/gpg_common_plug.c
+++ b/src/gpg_common_plug.c
@@ -1260,9 +1260,9 @@ int gpg_common_check(unsigned char *keydata, int ks)
 					  memcpy(key2, keydata + 8, 8);
 					  memcpy(key3, keydata + 16, 8);
 					  memcpy(divec, ivec, 8);
-					  DES_set_key((DES_cblock *)key1, &ks1);
-					  DES_set_key((DES_cblock *)key2, &ks2);
-					  DES_set_key((DES_cblock *)key3, &ks3);
+					  DES_set_key_unchecked((DES_cblock *)key1, &ks1);
+					  DES_set_key_unchecked((DES_cblock *)key2, &ks2);
+					  DES_set_key_unchecked((DES_cblock *)key3, &ks3);
 					  DES_ede3_cfb64_encrypt(gpg_common_cur_salt->data, out, SALT_LENGTH, &ks1, &ks2, &ks3, &divec, &num, DES_DECRYPT);
 				    }
 				    break;
@@ -1357,9 +1357,9 @@ int gpg_common_check(unsigned char *keydata, int ks)
 					  memcpy(key2, keydata + 8, 8);
 					  memcpy(key3, keydata + 16, 8);
 					  memcpy(divec, ivec, 8);
-					  DES_set_key((DES_cblock *) key1, &ks1);
-					  DES_set_key((DES_cblock *) key2, &ks2);
-					  DES_set_key((DES_cblock *) key3, &ks3);
+					  DES_set_key_unchecked((DES_cblock *) key1, &ks1);
+					  DES_set_key_unchecked((DES_cblock *) key2, &ks2);
+					  DES_set_key_unchecked((DES_cblock *) key3, &ks3);
 					  if (gpg_common_cur_salt->symmetric_mode && gpg_common_cur_salt->usage == 9) {
 						  DES_ede3_cfb64_encrypt(gpg_common_cur_salt->data, out, block_size + 2, &ks1, &ks2, &ks3, &divec, &num, DES_DECRYPT);
 						  num = 0;

--- a/src/keychain_fmt_plug.c
+++ b/src/keychain_fmt_plug.c
@@ -107,9 +107,9 @@ static int kcdecrypt(unsigned char *key, unsigned char *iv, unsigned char *data)
 	memcpy(key1, key, 8);
 	memcpy(key2, key + 8, 8);
 	memcpy(key3, key + 16, 8);
-	DES_set_key((DES_cblock *) key1, &ks1);
-	DES_set_key((DES_cblock *) key2, &ks2);
-	DES_set_key((DES_cblock *) key3, &ks3);
+	DES_set_key_unchecked((DES_cblock *) key1, &ks1);
+	DES_set_key_unchecked((DES_cblock *) key2, &ks2);
+	DES_set_key_unchecked((DES_cblock *) key3, &ks3);
 	memcpy(ivec, iv, 8);
 	DES_ede3_cbc_encrypt(data, out, CTLEN, &ks1, &ks2, &ks3, &ivec,  DES_DECRYPT);
 

--- a/src/krb5_common_plug.c
+++ b/src/krb5_common_plug.c
@@ -258,7 +258,7 @@ void des_cbc_mac_shishi(char key[8], char iv[8], unsigned char *in, size_t inlen
 #endif
 
 	memcpy(dkey, key, 8);
-	DES_set_key((DES_cblock *)dkey, &dks);
+	DES_set_key_unchecked((DES_cblock *)dkey, &dks);
 	memcpy(ivec, iv, 8);
 	DES_cbc_encrypt(in, ct, inlen, &dks, &ivec, DES_ENCRYPT);
 	memcpy(out, ct + inlen - 8, 8);

--- a/src/mozilla_ng_fmt_plug.c
+++ b/src/mozilla_ng_fmt_plug.c
@@ -360,9 +360,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		SHA1_Final(key+20, &ctxo);
 
 		// k = k1||k2 // encrypt "password-check" string using this key
-		DES_set_key((DES_cblock *) key, &ks1);
-		DES_set_key((DES_cblock *) (key+8), &ks2);
-		DES_set_key((DES_cblock *) (key+16), &ks3);
+		DES_set_key_unchecked((DES_cblock *) key, &ks1);
+		DES_set_key_unchecked((DES_cblock *) (key+8), &ks2);
+		DES_set_key_unchecked((DES_cblock *) (key+16), &ks3);
 		memcpy(ivec, key + 32, 8);  // last 8 bytes!
 		// PKCS#5 padding (standard block padding)
 		DES_ede3_cbc_encrypt((unsigned char*)"password-check\x02\x02", (unsigned char*)crypt_out[index], 16, &ks1, &ks2, &ks3, &ivec, DES_ENCRYPT);

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -244,7 +244,7 @@ inline static void setup_des_key(uchar key_56[], DES_key_schedule *ks)
 	key[6] = (key_56[5] << 2) | (key_56[6] >> 6);
 	key[7] = (key_56[6] << 1);
 
-	DES_set_key(&key, ks);
+	DES_set_key_unchecked(&key, ks);
 }
 
 static int chap_valid_long(char *ciphertext)

--- a/src/o10glogon_fmt_plug.c
+++ b/src/o10glogon_fmt_plug.c
@@ -102,7 +102,7 @@ static void init(struct fmt_main *self)
 {
 	omp_autotune(self, OMP_SCALE);
 
-	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);
+	DES_set_key_unchecked((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);
 	cur_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*cur_key));
 	plain_key = mem_calloc(self->params.max_keys_per_crypt,
@@ -320,7 +320,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 		iv[0] = iv[1] = 0;
 		DES_ncbc_encrypt((unsigned char *)buf, buf1, l, &desschedule1, (DES_cblock *) iv, DES_ENCRYPT);
-		DES_set_key((DES_cblock *)iv, &desschedule2);
+		DES_set_key_unchecked((DES_cblock *)iv, &desschedule2);
 		iv[0] = iv[1] = 0;
 		DES_ncbc_encrypt((unsigned char *)buf, buf1, l, &desschedule2, (DES_cblock *) iv, DES_ENCRYPT);
 

--- a/src/o3logon_fmt_plug.c
+++ b/src/o3logon_fmt_plug.c
@@ -99,7 +99,7 @@ static void init(struct fmt_main *self)
 {
 	omp_autotune(self, OMP_SCALE);
 
-	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);
+	DES_set_key_unchecked((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule1);
 	cur_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*cur_key));
 	plain_key = mem_calloc(self->params.max_keys_per_crypt,
@@ -232,9 +232,9 @@ static int ORACLE_TNS_Decrypt_3DES_CBC (unsigned char* input, int input_len, con
 	DES_key_schedule ks1,ks2,ks3;
 	unsigned char iv[] = {0x80,0x20,0x40,0x04,0x08,0x02,0x10,0x01};
 
-	DES_set_key((DES_cblock*) &key[0], &ks1);
-	DES_set_key((DES_cblock*) &key[8], &ks2);
-	DES_set_key((DES_cblock*) &key[16], &ks3);
+	DES_set_key_unchecked((DES_cblock*) &key[0], &ks1);
+	DES_set_key_unchecked((DES_cblock*) &key[8], &ks2);
+	DES_set_key_unchecked((DES_cblock*) &key[16], &ks3);
 
 	DES_ede3_cbc_encrypt(input,decrypted,input_len,&ks1,&ks2,&ks3,(DES_cblock*) iv,DES_DECRYPT);
 
@@ -296,7 +296,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 		iv[0] = iv[1] = 0;
 		DES_ncbc_encrypt((unsigned char *)buf, buf1, l, &desschedule1, (DES_cblock *) iv, DES_ENCRYPT);
-		DES_set_key((DES_cblock *)iv, &desschedule2);
+		DES_set_key_unchecked((DES_cblock *)iv, &desschedule2);
 		iv[0] = iv[1] = 0;
 		DES_ncbc_encrypt((unsigned char *)buf, buf1, l, &desschedule2, (DES_cblock *) iv, DES_ENCRYPT);
 

--- a/src/oracle_fmt_plug.c
+++ b/src/oracle_fmt_plug.c
@@ -216,7 +216,7 @@ static void init(struct fmt_main *self)
 {
 	omp_autotune(self, OMP_SCALE);
 
-	DES_set_key((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule_static);
+	DES_set_key_unchecked((DES_cblock *)"\x01\x23\x45\x67\x89\xab\xcd\xef", &desschedule_static);
 	cur_key = mem_calloc(self->params.max_keys_per_crypt,
 	                       sizeof(*cur_key));
 	plain_key = mem_calloc(self->params.max_keys_per_crypt,
@@ -302,7 +302,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		crypt_key[idx][1] = 0;
 
 		DES_ncbc_encrypt(buf2, buf, l, &desschedule_static, (DES_cblock *) crypt_key[idx], DES_ENCRYPT);
-		DES_set_key((DES_cblock *)crypt_key[idx], &sched_local);
+		DES_set_key_unchecked((DES_cblock *)crypt_key[idx], &sched_local);
 		crypt_key[idx][0] = 0;
 		crypt_key[idx][1] = 0;
 		DES_ncbc_encrypt(buf2, buf, l, &sched_local, (DES_cblock *) crypt_key[idx], DES_ENCRYPT);

--- a/src/pem_common_plug.c
+++ b/src/pem_common_plug.c
@@ -180,9 +180,9 @@ int pem_decrypt(unsigned char *key, unsigned char *iv, unsigned char *data, stru
 		memcpy(key1, key, 8);
 		memcpy(key2, key + 8, 8);
 		memcpy(key3, key + 16, 8);
-		DES_set_key((DES_cblock *) key1, &ks1);
-		DES_set_key((DES_cblock *) key2, &ks2);
-		DES_set_key((DES_cblock *) key3, &ks3);
+		DES_set_key_unchecked((DES_cblock *) key1, &ks1);
+		DES_set_key_unchecked((DES_cblock *) key2, &ks2);
+		DES_set_key_unchecked((DES_cblock *) key3, &ks3);
 		memcpy(ivec, iv, 8);
 		DES_ede3_cbc_encrypt(data, out, cur_salt->ciphertext_length, &ks1, &ks2, &ks3, &ivec, DES_DECRYPT);
 	} else if (cur_salt->cid == 2) {  // AES-128

--- a/src/sap_pse_fmt_plug.c
+++ b/src/sap_pse_fmt_plug.c
@@ -147,9 +147,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			DES_key_schedule ks1, ks2, ks3;
 
 			// pin encryption
-			DES_set_key((DES_cblock *) key[i], &ks1);
-			DES_set_key((DES_cblock *) (key[i]+8), &ks2);
-			DES_set_key((DES_cblock *) (key[i]+16), &ks3);
+			DES_set_key_unchecked((DES_cblock *) key[i], &ks1);
+			DES_set_key_unchecked((DES_cblock *) (key[i]+8), &ks2);
+			DES_set_key_unchecked((DES_cblock *) (key[i]+16), &ks3);
 			memcpy(ivec, iv[i], 8);
 			memcpy(input, saved_key[index+i], saved_len[index+i]);
 			padbyte = 8 - (saved_len[index+i] % 8);

--- a/src/ssh_fmt_plug.c
+++ b/src/ssh_fmt_plug.c
@@ -322,9 +322,9 @@ static void common_crypt_code(char *password, unsigned char *out, int full_decry
 		memcpy(key1, key, 8);
 		memcpy(key2, key + 8, 8);
 		memcpy(key3, key + 16, 8);
-		DES_set_key((DES_cblock *) key1, &ks1);
-		DES_set_key((DES_cblock *) key2, &ks2);
-		DES_set_key((DES_cblock *) key3, &ks3);
+		DES_set_key_unchecked((DES_cblock *) key1, &ks1);
+		DES_set_key_unchecked((DES_cblock *) key2, &ks2);
+		DES_set_key_unchecked((DES_cblock *) key3, &ks3);
 		if (full_decrypt) {
 			DES_ede3_cbc_encrypt(cur_salt->ct, out, cur_salt->ctl, &ks1, &ks2, &ks3, &iv, DES_DECRYPT);
 		} else {


### PR DESCRIPTION
This works around a regression in OpenSSL 3 where they changed the default behavior.  Closes #4831

Depending on how the OpenSSL team reacts to https://github.com/openssl/openssl/issues/16859 we might want to merge this - or maybe we want to so regardless?