### PR TITLE
Bug fix for --rules-skip-nop

### DIFF
--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -120,6 +120,12 @@ So --rules::'$\;$[0-9]' is just one rule, while --rules=:'$\;$[0-9];Az"tst"'
 is two rules, and --rules=:'$;$[0-9]' would 'try' to generate 2 rules, BUT
 the first will be invalid since it is just the $ character.
 
+--rules-skip-nop
+
+Option for --rules that makes it skip any no-op rules.  This is intended for
+when you already ran some attack on some slow format without rules and now
+want to run it with rules.
+
 --rules-stack=(SECTION[,..]|:rule[;..])
 
 Stacked rules. Adds a second pass of rules, applied after normal processing.

--- a/src/rules.c
+++ b/src/rules.c
@@ -654,7 +654,7 @@ char *rules_reject(char *rule, int split, char *last, struct db_main *db)
 		return NULL;
 	}
 
-	if (!*rule && options.flags & FLG_RULE_SKIP_NOP)
+	if ((options.flags & FLG_RULE_SKIP_NOP) && !rule[strspn(rule, ": \t")])
 		return NULL;
 
 	while (RULE)
@@ -662,8 +662,6 @@ char *rules_reject(char *rule, int split, char *last, struct db_main *db)
 	case ':':
 	case ' ':
 	case '\t':
-		if (options.flags & FLG_RULE_SKIP_NOP)
-			return NULL;
 		break;
 
 	case '-':


### PR DESCRIPTION
It would also skip any rules *containing* no-ops (including spaces or tabs), which was never intended.