### PR TITLE
configure: Bail out if 'perl' is not found

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -7780,6 +7780,12 @@ $as_echo "no" >&6; }
 fi
 
 
+if test "x$PERL" == x ; then
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "No perl executable found
+See \`config.log' for more details" "$LINENO" 5; }
+fi
 if test -z "$AS"; then :
   AS="$CC"
 fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -339,6 +339,9 @@ AC_CACHE_SAVE
 AC_PATH_PROG([SORT], [sort])
 AC_PATH_PROG([FIND], [find])
 AC_PATH_PROG([PERL], [perl])
+if test "x$PERL" == x ; then
+  AC_MSG_FAILURE([No perl executable found])
+fi
 AS_IF([test -z "$AS"], [AS="$CC"])
 AS_IF([test -z "$LD"], [LD="$CC"])
 AS_IF([test -z "$AR"], [AC_CHECK_TOOL([AR], [ar])])


### PR DESCRIPTION
We shouldn't really rely on it, but we currently do for preparing some dynamic format magic.  All other uses are (to my knowledge) optional, such as adding Makefile dependencies using plugin_deps.pl, which is nice but not need.  OTOH nearly all systems have perl, and some of our *2john tools are written in perl as well.

Closes #4856