### PR TITLE
blockchain2john: Fix for python2 vs. python3

### DIFF
--- a/run/blockchain2john.py
+++ b/run/blockchain2john.py
@@ -8,6 +8,8 @@ import argparse
 import json
 import traceback
 
+PY3 = sys.version_info[0] == 3
+
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(
@@ -54,7 +56,10 @@ if __name__ == '__main__':
                 # handle blockchain version 1 wallet format files which contain
                 # only a base64 encoded string
                 try:
-                    ddata = base64.decodestring(data)
+                    if PY3:
+                        ddata = base64.decodebytes(data)
+                    else:
+                        ddata = base64.decodestring(data)
                     print("%s:$blockchain$%s$%s" % (
                         os.path.basename(filename), len(ddata),
                         binascii.hexlify(ddata).decode("ascii")))


### PR DESCRIPTION
This avoids a deprecation warning under python3 while still working under python2.

See #4872