### PR TITLE
Add option --mask-internal-target=N

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -234,6 +234,10 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Added apop2john.py: script to extract and format POP3 APOP challenge/responses
   [Mark Silinio; 2021]
 
+- Added option --mask-internal-target=N for overriding format's idea of how
+  large portion of a mask should be generated on device-side (or completely
+  disabling internal mask).  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/bench.c
+++ b/src/bench.c
@@ -51,6 +51,7 @@
 #include "gpu_common.h"
 #include "opencl_common.h"
 #include "mask.h"
+#include "mask_ext.h"
 #include "aligned.h"
 
 #ifndef BENCH_BUILD
@@ -833,6 +834,13 @@ AGAIN:
 		if ((options.flags & FLG_LOOPTEST_CHK) && john_main_process)
 			printf("#%u ", loop_total);
 #endif
+#if defined(HAVE_OPENCL) || defined(HAVE_ZTEX)
+		int using_int_mask = (format->params.flags & FMT_MASK) && (options.flags & FLG_MASK_CHK) &&
+			options.req_int_cand_target != 0 && mask_int_cand_target;
+#else
+		int using_int_mask = 0;
+#endif
+
 		if (john_main_process)
 		printf("%s: %s%s%s%s [%s%s%s%s]... ",
 		    benchmark_time ? "Benchmarking" : "Testing",
@@ -844,8 +852,7 @@ AGAIN:
 #ifndef BENCH_BUILD
 #define ENC_SET (!options.default_enc && options.target_enc != ENC_RAW && options.target_enc != ISO_8859_1)
 
-		    (benchmark_time && format->params.flags & FMT_MASK &&
-		     (options.flags & FLG_MASK_CHK)) ? "/mask accel" : "",
+		    (benchmark_time && using_int_mask) ? "/mask accel" : "",
 		    ENC_SET ? ", " : "",
 		    ENC_SET ? cp_id2name(options.target_enc) : "");
 #else

--- a/src/formats.c
+++ b/src/formats.c
@@ -397,17 +397,14 @@ void fmt_init(struct fmt_main *format)
 			orig_max = format->params.max_keys_per_crypt;
 			orig_len = format->params.plaintext_length;
 		}
-#endif
-		if (john_main_process && !bench_or_test_running &&
-#ifndef BENCH_BUILD
+
+		if (john_main_process && !(options.flags & FLG_TEST_CHK) &&
 		    !options.listconf && options.target_enc != UTF_8 &&
-#endif
 		    format->params.flags & FMT_UTF8)
 			fprintf(stderr, "Warning: %s format should always be "
 			        "UTF-8. Use --target-encoding=utf8\n",
 				format->params.label);
 
-#ifndef BENCH_BUILD
 		if (john_main_process && !(options.flags & FLG_TEST_CHK) && !options.listconf) {
 			if (format->params.flags & FMT_NOT_EXACT) {
 				fprintf(stderr, "Note: This format may emit false positives, ");

--- a/src/opencl_DES_bs_b_plug.c
+++ b/src/opencl_DES_bs_b_plug.c
@@ -575,10 +575,14 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 	if (lws_tune_flag)
 		save_lws_config(CONFIG_FILE, gpu_id, local_work_size, 0);
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
 }
 
 static void reset(struct db_main *db)

--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -698,9 +698,9 @@ static void reset(struct db_main *db)
 			salt_list[num_salts++] = (*(WORD *)salt->salt);
 		} while ((salt = salt->next));
 
-		if (num_salts > 1 && john_main_process)
-			fprintf(stderr, "Note: Building per-salt kernels. "
-				"This takes e.g. 2 hours for 4096 salts.\n");
+		if (num_salts > 1 && !(options.flags & FLG_TEST_CHK) && john_main_process)
+			fprintf(stderr, "Note: Building per-salt kernels. This takes e.g. 2 hours for 4096 salts.\n");
+
 #if _OPENMP && PARALLEL_BUILD
 #pragma omp parallel for
 #endif

--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -637,10 +637,14 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 	if (lws_tune_flag)
 		save_lws_config(CONFIG_FILE, gpu_id, local_work_size, *forced_global_keys);
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
 }
 
 static void reset(struct db_main *db)

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -651,10 +651,14 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 	if (lws_tune_flag)
 		save_lws_config(CONFIG_FILE, gpu_id, local_work_size, *forced_global_keys);
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
 }
 
 static void reset(struct db_main *db)

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -712,9 +712,9 @@ static void reset(struct db_main *db)
 			salt_list[num_salts++] = (*(WORD *)salt->salt);
 		} while ((salt = salt->next));
 
-		if (num_salts > 1 && john_main_process)
-			fprintf(stderr, "Note: Building per-salt kernels. "
-				"This takes e.g. 2 hours for 4096 salts.\n");
+		if (num_salts > 1 && !(options.flags & FLG_TEST_CHK) && john_main_process)
+			fprintf(stderr, "Note: Building per-salt kernels. This takes e.g. 2 hours for 4096 salts.\n");
+
 #if _OPENMP && PARALLEL_BUILD
 #pragma omp parallel for
 #endif

--- a/src/opencl_lm_b_plug.c
+++ b/src/opencl_lm_b_plug.c
@@ -930,10 +930,14 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 		}
 	}
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
 }
 
 /* Use only for smaller bitmaps < 16MB */

--- a/src/opencl_mysqlsha1_fmt_plug.c
+++ b/src/opencl_mysqlsha1_fmt_plug.c
@@ -978,10 +978,16 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 	clear_keys();
 
 	self->params.max_keys_per_crypt = global_work_size;
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
+
 #undef calc_ms
 }
 

--- a/src/opencl_rawmd4_fmt_plug.c
+++ b/src/opencl_rawmd4_fmt_plug.c
@@ -577,10 +577,15 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 
 	self->params.max_keys_per_crypt = global_work_size;
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
+
 #undef calc_ms
 }
 

--- a/src/opencl_rawmd5_fmt_plug.c
+++ b/src/opencl_rawmd5_fmt_plug.c
@@ -602,10 +602,15 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 
 	self->params.max_keys_per_crypt = global_work_size;
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
+
 #undef calc_ms
 }
 

--- a/src/opencl_rawsha1_fmt_plug.c
+++ b/src/opencl_rawsha1_fmt_plug.c
@@ -932,10 +932,15 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 
 	self->params.max_keys_per_crypt = global_work_size;
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
+
 #undef calc_ms
 }
 

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -954,10 +954,15 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 
 	self->params.max_keys_per_crypt = global_work_size;
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
+
 #undef calc_ms
 }
 

--- a/src/opencl_sl3_fmt_plug.c
+++ b/src/opencl_sl3_fmt_plug.c
@@ -904,10 +904,15 @@ static void auto_tune(struct db_main *db, long double kernel_run_ms)
 
 	self->params.max_keys_per_crypt = global_work_size;
 
-	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) ||
-	    ocl_always_show_ws)
-		fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
-		        global_work_size, benchmark_running ? " " : "\n");
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT) || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
+
 #undef calc_ms
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -191,6 +191,7 @@ static struct opt_entry opt_list[] = {
 	{"gws", FLG_ONCE, 0, 0, USUAL_REQ_CLR | FLG_STDOUT | OPT_REQ_PARAM, Zu, &options.gws},
 #endif
 #if defined(HAVE_OPENCL) || defined(HAVE_ZTEX)
+	{"mask-internal-target", FLG_ONCE, 0, 0, USUAL_REQ_CLR | FLG_STDOUT | OPT_REQ_PARAM, "%d", &options.req_int_cand_target},
 	{"devices", FLG_ONCE, 0, 0, USUAL_REQ_CLR | FLG_STDOUT | OPT_REQ_PARAM, OPT_FMT_ADD_LIST_MULTI, &options.acc_devices},
 #endif
 	{"skip-self-tests", FLG_NOTESTS, FLG_NOTESTS, 0, USUAL_REQ_CLR | FLG_STDOUT},
@@ -368,6 +369,7 @@ FUZZ_USAGE \
 #define JOHN_USAGE_GPU \
 "\nOpenCL options:\n" \
 "--devices=N[,..]           Set OpenCL device(s) (see --list=opencl-devices)\n" \
+"--mask-internal-target=N   Request a specific internal mask target\n" \
 "--force-scalar             Force scalar mode\n" \
 "--force-vector-width=N     Force vector width N\n" \
 "--lws=N                    Force local worksize N\n" \
@@ -376,7 +378,8 @@ FUZZ_USAGE \
 "                           or set ZTEX device(s) by its(their) serial number(s)\n"
 #elif defined(HAVE_ZTEX)
 #define JOHN_USAGE_ZTEX \
-"--devices=N[,..]           Set ZTEX device(s) by its(their) serial number(s)\n"
+"--devices=N[,..]           Set ZTEX device(s) by its(their) serial number(s)\n" \
+"--mask-internal-target=N   Request a specific internal mask target\n"
 #endif
 
 static void opt_banner(char *name)
@@ -440,6 +443,8 @@ void opt_init(char *name, int argc, char **argv)
 	list_init(&options.loader.shells);
 #if defined(HAVE_OPENCL) || defined(HAVE_ZTEX)
 	list_init(&options.acc_devices);
+
+	options.req_int_cand_target = -1;
 #endif
 
 	options.length = -1;

--- a/src/options.h
+++ b/src/options.h
@@ -457,6 +457,10 @@ struct options_main {
 	int crack_status;
 /* --catch-up=oldsession */
 	char *catchup;
+#if defined(HAVE_OPENCL) || defined(HAVE_ZTEX)
+/* --mask-internal-target=N */
+	int req_int_cand_target;
+#endif
 };
 
 extern struct options_main options;


### PR DESCRIPTION
This overrides format's algorithm for selecting the target multiplier.

Closes #4876