### PR TITLE
sipdump2john.py handle ```sip:*``` uri. Fixes #3829

### DIFF
--- a/run/sipdump2john.py
+++ b/run/sipdump2john.py
@@ -4,11 +4,13 @@
 into a format suitable for use with JtR."""
 
 import sys
+import re
 
 
 def process_file(filename):
     with open(filename, "r") as f:
         for line in f.readlines():
+            line = re.sub(r'sip\:\*', r'sip:0.0.0.0', line)
             line = line.rstrip().replace('"', '*').replace(':', '*')
             data = line.split('*')
             # Handle the case when the port number is not explicit


### PR DESCRIPTION
see https://github.com/openwall/john/issues/3829