### PR TITLE
Add knowledge of Apple M1 GPU's core count

### DIFF
--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -2562,6 +2562,9 @@ cl_uint get_processors_count(int sequential_id)
 	} else if (gpu_intel(device_info[sequential_id])) {
 		// It seems all current models are x 8
 		core_count *= ocl_device_list[sequential_id].cores_per_MP = 8;
+	} else if (!strcmp(dname, "Apple M1")) {
+		// Each GPU core is split into 16 Execution Units, which each contain eight Arithmetic Logic Units (ALUs)
+		core_count *= ocl_device_list[sequential_id].cores_per_MP = 16 * 8;
 	} else if (gpu_amd(device_info[sequential_id])) {
 		// 16 thread proc * 5 SP
 		core_count *= (ocl_device_list[sequential_id].cores_per_MP = (16 *


### PR DESCRIPTION
This changes our best-effort "speed index" for Apple M1 GPU's and, as a result of that, greatly increases speeds for most internal mask OpenCL formats (namely the ones that use said speed index to decide on a mask accleration target).

Info was taken from https://en.wikipedia.org/wiki/Apple_M1#GPU - @solardiz do you think it's correct to translate

*Each GPU core is split into 16 Execution Units, which each contain eight Arithmetic Logic Units (ALUs). In total, the M1 GPU contains up to 128 Execution units or 1024 ALUs,[11] which Apple says can execute up to 24,576 threads simultaneously and which have a maximum floating point (FP32) performance of 2.6 TFLOPs.[8][12]*

to

Stream processors = core_count * 16 *8 ?

Perhaps it should just be core_count * 16. Anyway with the former, speed for internal mask format was boosted significantly due to the fact that target mask multiplier is based on our "speed index":

Before
```
./john --list=opencl-devices
(...)
    Max clock (MHz):        1000
    Parallel compute cores: 8
    Speed index:            8000
(...)

Device 1: Apple M1
Benchmarking: LM-opencl [DES BS OpenCL/mask accel]... LWS=64 GWS=1048576
DONE
Raw:	140136K c/s real, 405260K c/s virtual

Benchmarking: NT-opencl [MD4 OpenCL/mask accel]... LWS=256 GWS=8192 (32 blocks) x26 DONE
Raw:	219455K c/s real, 279181K c/s virtual
```

After
```
./john --list=opencl-devices
(...)
    Max clock (MHz):        1000
    Parallel compute cores: 8
    Stream processors:      1024  (8 x 128)
    Speed index:            1024000
(...)

Device 1: Apple M1
Benchmarking: LM-opencl [DES BS OpenCL/mask accel]... LWS=32 GWS=16384
DONE
Raw:	283209K c/s real, 14868M c/s virtual

Benchmarking: NT-opencl [MD4 OpenCL/mask accel]... LWS=256 GWS=1048576 (4096 blocks) x3300 DONE
Raw:	2572M c/s real, 173015M c/s virtual
```