### PR TITLE
DES OpenCL: Fix detection of NVIDIA later than Maxwell, and allow selecting kernel with environment variable

### DIFF
--- a/run/opencl/opencl_DES_hst_dev_shared.h
+++ b/run/opencl/opencl_DES_hst_dev_shared.h
@@ -1,6 +1,20 @@
 #ifndef _OPENCL_DES_HST_DEV_SHARED_H
 #define _OPENCL_DES_HST_DEV_SHARED_H
 
+/*
+ * There are three kernels. All run bit-sliced DES, but:
+ *
+ * bs_b is "basic" kernel, for any salt
+ * bs_h is "hardcoded salts" kernel
+ * bs_f is "fully unrolled" kernel
+ *
+ * To avoid run-time build of salts, set OVERRIDE_AUTO_CONFIG and neither of HARDCODE_SALT or FULL_UNROLL
+ *
+ * Note that a rebuild of the host-code is then needed, despite this file's location.
+ *
+ * A better option for run-time selection is setting environment variable JOHN_DES_KERNEL to
+ * "bs_b", "bs_h" or "bs_f". This works for LM as well although "bs_h" is not supported then.
+ */
 #define OVERRIDE_AUTO_CONFIG	0
 #define HARDCODE_SALT 		0
 #define FULL_UNROLL		0

--- a/run/opencl/opencl_DES_kernel_params.h
+++ b/run/opencl/opencl_DES_kernel_params.h
@@ -14,7 +14,7 @@ typedef unsigned WORD vtype;
  * macOS in general has problems building the "fast goto" version, and the
  * same goes for MESA and POCL.
  */
-#if nvidia_sm_5x(DEVICE_INFO) || __OS_X__ || __MESA__ || __POCL__ || \
+#if nvidia_sm_5plus(DEVICE_INFO) || __OS_X__ || __MESA__ || __POCL__ || \
 	(gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR >= 1573 && !defined(__Tahiti__)) || \
 	(gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR >= 1702)
 //#warning Using 'safe goto' kernel

--- a/run/opencl/opencl_device_info.h
+++ b/run/opencl/opencl_device_info.h
@@ -31,8 +31,8 @@
 #define DEV_NV_C32                  (1 << 16)   //65536
 #define DEV_NV_C35                  (1 << 17)   //131072
 #define DEV_NV_MAXWELL              (1 << 18)   //262144
-#define DEV_NV_PASCAL               (1 << 19)   //524288
-#define DEV_NV_VOLTA                (1 << 20)   //1M
+#define DEV_NV_MAXWELL_PLUS         (1 << 19)   //524288
+#define DEV_NV_PASCAL               (1 << 20)   //1M
 #define DEV_USE_LOCAL               (1 << 21)   //2M
 #define DEV_NO_BYTE_ADDRESSABLE     (1 << 22)   //4M
 #define PLATFORM_MESA               (1 << 23)   //8M
@@ -56,7 +56,7 @@
 #define nvidia_sm_3x(n)             (((n & DEV_NV_C30) || (n & DEV_NV_C32) || (n & DEV_NV_C35)) && gpu_nvidia(n))
 #define nvidia_sm_5x(n)             ((n & DEV_NV_MAXWELL) && gpu_nvidia(n))
 #define nvidia_sm_6x(n)             ((n & DEV_NV_PASCAL) && gpu_nvidia(n))
-#define nvidia_sm_7x(n)             ((n & DEV_NV_VOLTA) && gpu_nvidia(n))
+#define nvidia_sm_5plus(n)          ((n & DEV_NV_MAXWELL_PLUS) && gpu_nvidia(n))
 #define no_byte_addressable(n)      ((n & DEV_NO_BYTE_ADDRESSABLE))
 #define use_local(n)                ((n & DEV_USE_LOCAL))
 

--- a/run/opencl/opencl_lm_kernel_params.h
+++ b/run/opencl/opencl_lm_kernel_params.h
@@ -14,7 +14,7 @@ typedef unsigned WORD vtype;
  * OSX' Intel HD4000 driver [1.2(Sep25 2014 22:26:04)] fails building the
  * "fast goto" version.
  */
-#if nvidia_sm_5x(DEVICE_INFO) || gpu_intel(DEVICE_INFO) ||	  \
+#if nvidia_sm_5plus(DEVICE_INFO) || gpu_intel(DEVICE_INFO) ||	  \
 	(gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR >= 1573 && !defined(__Tahiti__)) || \
 	(gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR >= 1702)
 //#warning Using 'safe goto' kernel

--- a/run/opencl/sha256_kernel.cl
+++ b/run/opencl/sha256_kernel.cl
@@ -26,9 +26,7 @@
         #define UNROLL_LOOP    132104
     #elif (nvidia_sm_2x(DEVICE_INFO) || nvidia_sm_3x(DEVICE_INFO))
         #define UNROLL_LOOP    132098
-    #elif nvidia_sm_5x(DEVICE_INFO)
-        #define UNROLL_LOOP    132104
-    #elif nvidia_sm_6x(DEVICE_INFO)
+    #elif nvidia_sm_5plus(DEVICE_INFO)
         #define UNROLL_LOOP    132104
     #elif gpu_intel(DEVICE_INFO)
         #define UNROLL_LOOP    131586

--- a/run/opencl/sha512_gpl_kernel.cl
+++ b/run/opencl/sha512_gpl_kernel.cl
@@ -29,7 +29,7 @@
         #define UNROLL_LOOP    132098
     #elif nvidia_sm_5x(DEVICE_INFO)
         #define UNROLL_LOOP    33686536
-    #elif nvidia_sm_6x(DEVICE_INFO)
+    #elif nvidia_sm_6x(DEVICE_INFO) || nvidia_sm_5plus(DEVICE_INFO)
         #define UNROLL_LOOP    132104
     #elif gpu_intel(DEVICE_INFO)
         #define UNROLL_LOOP    262658

--- a/src/opencl_DES_fmt_plug.c
+++ b/src/opencl_DES_fmt_plug.c
@@ -14,6 +14,7 @@ john_register_one(&fmt_opencl_DES);
 #else
 
 #include <string.h>
+#include <stdlib.h>
 
 #include "arch.h"
 #include "common.h"
@@ -21,6 +22,7 @@ john_register_one(&fmt_opencl_DES);
 #include "config.h"
 #include "opencl_DES_bs.h"
 #include "../run/opencl/opencl_DES_hst_dev_shared.h"
+#include "logger.h"
 
 #define FORMAT_NAME			"traditional crypt(3)"
 
@@ -83,16 +85,31 @@ static unsigned char DES_atoi64[0x100] = {
 
 static void init(struct fmt_main *pFmt)
 {
+	char *force_kernel = getenv("JOHN_DES_KERNEL");
+
 	opencl_prepare_dev(gpu_id);
 
-	if ((USE_BASIC_KERNEL&& !OVERRIDE_AUTO_CONFIG) ||
-		(OVERRIDE_AUTO_CONFIG && !HARDCODE_SALT && !FULL_UNROLL))
+	if (force_kernel && !strcmp(force_kernel, "bs_b")) {
+		fprintf(stderr, "Using basic kernel (bs_b)\n");
 		opencl_DES_bs_b_register_functions(pFmt);
-	else if ((USE_FULL_UNROLL && !OVERRIDE_AUTO_CONFIG) ||
-		(OVERRIDE_AUTO_CONFIG && HARDCODE_SALT && FULL_UNROLL))
+	} else if (force_kernel && !strcmp(force_kernel, "bs_f")) {
+		fprintf(stderr, "Using fully unrolled, salt-specific kernels (bs_f)\n");
 		opencl_DES_bs_f_register_functions(pFmt);
-	else
+	} else if (force_kernel && !strcmp(force_kernel, "bs_h")) {
+		fprintf(stderr, "Using salt-specific kernels (bs_h)\n");
 		opencl_DES_bs_h_register_functions(pFmt);
+	} else if ((USE_BASIC_KERNEL && !OVERRIDE_AUTO_CONFIG) ||
+	    (OVERRIDE_AUTO_CONFIG && !HARDCODE_SALT && !FULL_UNROLL)) {
+		log_event("- Using basic kernel (bs_b)");
+		opencl_DES_bs_b_register_functions(pFmt);
+	} else if ((USE_FULL_UNROLL && !OVERRIDE_AUTO_CONFIG) ||
+	           (OVERRIDE_AUTO_CONFIG && HARDCODE_SALT && FULL_UNROLL)) {
+		log_event("- Using fully unrolled and salt-specific kernels (bs_f)");
+		opencl_DES_bs_f_register_functions(pFmt);
+	} else {
+		log_event("- Using salt-specific kernels (bs_h)");
+		opencl_DES_bs_h_register_functions(pFmt);
+	}
 
 	// Check if specific LWS/GWS was requested
 	opencl_get_user_preferences(FORMAT_LABEL);

--- a/src/opencl_DES_fmt_plug.c
+++ b/src/opencl_DES_fmt_plug.c
@@ -45,7 +45,7 @@ static struct fmt_tests tests[] = {
 #define BINARY_SIZE			(2 * sizeof(WORD))
 #define SALT_SIZE			sizeof(WORD)
 
-#define USE_FULL_UNROLL 		(amd_gcn(device_info[gpu_id]) || nvidia_sm_5x(device_info[gpu_id]))
+#define USE_FULL_UNROLL 		(amd_gcn(device_info[gpu_id]) || nvidia_sm_5plus(device_info[gpu_id]))
 #define USE_BASIC_KERNEL		(cpu(device_info[gpu_id]) || platform_apple(platform_id))
 
 void (*opencl_DES_bs_init_global_variables)(void);

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -2153,8 +2153,8 @@ static void load_device_info(int sequential_id)
 		device_info[sequential_id] +=
 		    (major == 3 && minor == 5 ? DEV_NV_C35 : 0);
 		device_info[sequential_id] += (major == 5 ? DEV_NV_MAXWELL : 0);
+		device_info[sequential_id] += (major >= 5 ? DEV_NV_MAXWELL_PLUS : 0);
 		device_info[sequential_id] += (major == 6 ? DEV_NV_PASCAL : 0);
-		device_info[sequential_id] += (major == 7 ? DEV_NV_VOLTA : 0);
 	}
 }
 


### PR DESCRIPTION
See #4897 

This speeds up DEScrypt-OpenCL on Pascal and newer GPUs with 65-70%, since we only checked for "Maxwell" until now and ended up using the suboptimal `bs_h` kernel for the newer ones.

The second commit lets user force a kernel, using environment variable `JOHN_DES_KERNEL` which can be `bs_b` (basic), `bs_f` (fully unrolled) and (only for DEScrypt) `bs_h` (less aggresively unrolled).

For DEScrypt, `bs_b` can be used to avoid run-time build of kernels. It currently bugs out on some devices but that's a separate issue.