### PR TITLE
Add a format class for vector capable OpenCL formats

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -238,6 +238,10 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   large portion of a mask should be generated on device-side (or completely
   disabling internal mask).  [magnum; 2021]
 
+- Add a format class "vector" for matching vector capable OpenCL formats.  This
+  doesn't include bitslice formats.  It matches formats that will run SIMD
+  using the default GPU, or per the  --device option.  [magnum; 2021]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/formats.h
+++ b/src/formats.h
@@ -127,6 +127,9 @@ struct db_salt;
 /* Format's length before calling init() */
 extern int fmt_raw_len;
 
+/* We're currently in "format matching" code path */
+extern int fmt_matching;
+
 /*
  * A password to test the methods for correct operation.
  */

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -931,15 +931,15 @@ void opencl_load_environment(void)
 	}
 }
 
-/* Get the device preferred vector width */
+/*
+ * Get the device preferred vector width.  The --force-scalar option, or
+ * john.conf ForceScalar boolean, is taken care of in john.c and converted
+ * to "options.v_width = 1".
+ */
 unsigned int opencl_get_vector_width(int sequential_id, int size)
 {
-	/* --force-scalar option, or john.conf ForceScalar boolean */
-	if (options.flags & FLG_SCALAR)
-		options.v_width = 1;
-
 	/* --force-vector-width=N */
-	if (options.v_width) {
+	if (options.v_width && !fmt_matching) {
 		ocl_v_width = options.v_width;
 	} else {
 		cl_uint v_width = 0;


### PR DESCRIPTION
This matches formats that will run vectorized using the default GPU, or per the --device option.  See #4820.