### PR TITLE
configure: respect $STRINGS, fix bashisms

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -7781,7 +7781,7 @@ $as_echo "no" >&6; }
 fi
 
 
-if test "x$PERL" == x ; then
+if test "x$PERL" = x ; then
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "No perl executable found
@@ -8200,13 +8200,13 @@ fi
 $as_echo_n "checking if pkg-config will be used... " >&6; }
 if test "x$PKG_CONFIG" = x || test "x$enable_pkg_config" = xno ; then
 
-  if test "xno" == xyes; then
+  if test "xno" = xyes; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
   else
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-    if test "x$enable_pkg_config" == xyes; then
+    if test "x$enable_pkg_config" = xyes; then
       { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "pkg-config is NOT available
@@ -8223,7 +8223,7 @@ fi
 if ( test -e ../run/john.pot ) ; then
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if potcheck.pl succeeds" >&5
 $as_echo_n "checking if potcheck.pl succeeds... " >&6; }
-if test "x$PERL" == x ; then
+if test "x$PERL" = x ; then
    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no Perl (unable to check)" >&5
 $as_echo "no Perl (unable to check)" >&6; }
 else
@@ -13093,12 +13093,12 @@ fi
 fi
 
 
-  if test "x$using_rexgen" == "xyes" ; then
+  if test "x$using_rexgen" = "xyes" ; then
 
 $as_echo "#define HAVE_LIBREXGEN 1" >>confdefs.h
 
   else
-    if test "x$enable_rexgen" == "xyes" ; then
+    if test "x$enable_rexgen" = "xyes" ; then
       { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "rexgen not installed, or unusable version

--- a/src/configure
+++ b/src/configure
@@ -671,6 +671,7 @@ EGREP
 PKG_CONFIG_LIBDIR
 PKG_CONFIG_PATH
 PKG_CONFIG
+STRINGS
 STRIP
 PERL
 FIND
@@ -7980,6 +7981,100 @@ else
 fi
 
 fi
+if test -z "$STRINGS"; then :
+  if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}strings", so it can be a program name with args.
+set dummy ${ac_tool_prefix}strings; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_STRINGS+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$STRINGS"; then
+  ac_cv_prog_STRINGS="$STRINGS" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_STRINGS="${ac_tool_prefix}strings"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+STRINGS=$ac_cv_prog_STRINGS
+if test -n "$STRINGS"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $STRINGS" >&5
+$as_echo "$STRINGS" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test -z "$ac_cv_prog_STRINGS"; then
+  ac_ct_STRINGS=$STRINGS
+  # Extract the first word of "strings", so it can be a program name with args.
+set dummy strings; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_STRINGS+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$ac_ct_STRINGS"; then
+  ac_cv_prog_ac_ct_STRINGS="$ac_ct_STRINGS" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_ac_ct_STRINGS="strings"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+ac_ct_STRINGS=$ac_cv_prog_ac_ct_STRINGS
+if test -n "$ac_ct_STRINGS"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_STRINGS" >&5
+$as_echo "$ac_ct_STRINGS" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_ct_STRINGS" = x; then
+    STRINGS=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    STRINGS=$ac_ct_STRINGS
+  fi
+else
+  STRINGS="$ac_cv_prog_STRINGS"
+fi
+
+fi
 
 
 
@@ -10848,7 +10943,7 @@ EXTRA_AS_FLAGS=
 $as_echo_n "checking for extra ASFLAGS... " >&6; }
 CC="$CC_BACKUP"
 CFLAGS="$CFLAGS -O0"
-if echo "int long_ident;" > conftest.c && ${CC} -c conftest.c && strings - conftest.${OBJEXT} | ${GREP} _long_ident > conftest.out; then :
+if echo "int long_ident;" > conftest.c && ${CC} -c conftest.c && ${STRINGS} - conftest.${OBJEXT} | ${GREP} _long_ident > conftest.out; then :
 
    for i in -DUNDERSCORES; do
       jtr_list_add_dupe=0

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -339,7 +339,7 @@ AC_CACHE_SAVE
 AC_PATH_PROG([SORT], [sort])
 AC_PATH_PROG([FIND], [find])
 AC_PATH_PROG([PERL], [perl])
-if test "x$PERL" == x ; then
+if test "x$PERL" = x ; then
   AC_MSG_FAILURE([No perl executable found])
 fi
 AS_IF([test -z "$AS"], [AS="$CC"])
@@ -370,7 +370,7 @@ dnl to succeeed.
 dnl
 if ( test -e ../run/john.pot ) ; then
 AC_MSG_CHECKING([if potcheck.pl succeeds])
-if test "x$PERL" == x ; then
+if test "x$PERL" = x ; then
    AC_MSG_RESULT([no Perl (unable to check)])
 else
    $PERL ../run/potcheck.pl -validate < ../run/john.pot
@@ -677,10 +677,10 @@ if test "x$enable_rexgen" != xno ; then
         AC_MSG_RESULT([TOO old. Rexgen not usable!]))]
     )]
   )
-  if test "x$using_rexgen" == "xyes" ; then
+  if test "x$using_rexgen" = "xyes" ; then
     AC_DEFINE(HAVE_LIBREXGEN,1,[Define to 1 if you have the `rexgen' library (-lrexgen).])
   else
-    if test "x$enable_rexgen" == "xyes" ; then
+    if test "x$enable_rexgen" = "xyes" ; then
       AC_MSG_FAILURE([rexgen not installed, or unusable version])
     fi
   fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -346,6 +346,7 @@ AS_IF([test -z "$AS"], [AS="$CC"])
 AS_IF([test -z "$LD"], [LD="$CC"])
 AS_IF([test -z "$AR"], [AC_CHECK_TOOL([AR], [ar])])
 AS_IF([test -z "$STRIP"], [AC_CHECK_TOOL([STRIP], [strip])])
+AS_IF([test -z "$STRINGS"], [AC_CHECK_TOOL([STRINGS], [strings])])
 
 dnl Check if we have this at all
 PKG_PROG_PKG_CONFIG

--- a/src/m4/jtr_asm_magic.m4
+++ b/src/m4/jtr_asm_magic.m4
@@ -19,7 +19,7 @@ EXTRA_AS_FLAGS=
 AC_MSG_CHECKING([for extra ASFLAGS])
 CC="$CC_BACKUP"
 CFLAGS="$CFLAGS -O0"
-AS_IF([echo "int long_ident;" > conftest.c && ${CC} -c conftest.c && strings - conftest.${OBJEXT} | ${GREP} _long_ident > conftest.out],
+AS_IF([echo "int long_ident;" > conftest.c && ${CC} -c conftest.c && ${STRINGS} - conftest.${OBJEXT} | ${GREP} _long_ident > conftest.out],
       [JTR_LIST_ADD(EXTRA_AS_FLAGS, [-DUNDERSCORES])])
 
 AC_LINK_IFELSE([AC_LANG_SOURCE(

--- a/src/m4/jtr_utility_macros.m4
+++ b/src/m4/jtr_utility_macros.m4
@@ -189,11 +189,11 @@ dnl will be xno, xyes, xauto, etc.  forced_fail_msg is a message that
 dnl will be output, and the script will abort, IF forced is xyes which
 dnl means the user used --enable-foobar
 AC_DEFUN([JTR_MSG_RESULT_FAILIF_FORCED], [
-  if test "$1" == xyes; then
+  if test "$1" = xyes; then
     AC_MSG_RESULT([yes])
   else
     AC_MSG_RESULT([no])
-    if test "$2" == xyes; then
+    if test "$2" = xyes; then
       AC_MSG_FAILURE([$3])
     fi
   fi


### PR DESCRIPTION
- Respect $STRINGS from the user's environment (like we do for $AR, $CC, etc) but fall back to 'strings' like before
- Don't use Bashisms in configure (similar to #4822).