### PR TITLE
OpenCL: Improve handling of cached kernels

### DIFF
--- a/src/listconf.c
+++ b/src/listconf.c
@@ -143,7 +143,7 @@ static void listconf_list_build_info(void)
 	int gmp_major, gmp_minor, gmp_patchlevel;
 #endif
 	puts("Version: " JTR_GIT_VERSION);
-	puts("Build: " JOHN_BLD _MP_VERSION DEBUG_STRING ASAN_STRING UBSAN_STRING);
+	puts("Build: " JOHN_BLD _MP_VERSION OCL_STRING ZTEX_STRING DEBUG_STRING ASAN_STRING UBSAN_STRING);
 #ifdef SIMD_COEF_32
 	printf("SIMD: %s, interleaving: MD4:%d MD5:%d SHA1:%d SHA256:%d SHA512:%d\n",
 	       SIMD_TYPE,

--- a/src/listconf.h
+++ b/src/listconf.h
@@ -41,6 +41,18 @@
 #define UBSAN_STRING ""
 #endif
 
+#if HAVE_OPENCL
+#define OCL_STRING " OPENCL"
+#else
+#define OCL_STRING ""
+#endif
+
+#if HAVE_ZTEX
+#define ZTEX_STRING " ZTEX"
+#else
+#define ZTEX_STRING ""
+#endif
+
 #define _STR_VALUE(arg)			#arg
 #define STR_MACRO(n)			_STR_VALUE(n)
 

--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -226,7 +226,7 @@ static void modify_build_save_restore(WORD salt_val, int id_gpu, int save_binary
 		size_t program_size;
 		fclose(file);
 		program_size = opencl_read_source(kernel_bin_name, &kernel_source);
-		opencl_build_from_binary(id_gpu, program_ptr, kernel_source, program_size);
+		HANDLE_CLERROR(opencl_build_from_binary(id_gpu, program_ptr, kernel_source, program_size), "kernel build failed");
 
 		if (options.verbosity > VERB_DEFAULT)
 			fprintf(stderr, "Salt compiled from Binary:%d\n", salt_val);

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -233,7 +233,7 @@ static void modify_build_save_restore(WORD salt_val, int id_gpu, int save_binary
 		size_t program_size;
 		fclose(file);
 		program_size = opencl_read_source(kernel_bin_name, &kernel_source);
-		opencl_build_from_binary(id_gpu, program_ptr, kernel_source, program_size);
+		HANDLE_CLERROR(opencl_build_from_binary(id_gpu, program_ptr, kernel_source, program_size), "kernel build failed");
 
 		if (options.verbosity > VERB_DEFAULT)
 			fprintf(stderr, "Salt compiled from Binary:%d\n", salt_val);

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -51,7 +51,7 @@
 #include "recovery.h"
 #include "status.h"
 #include "john.h"
-#include "md5.h"
+#include "md4.h"
 #include "misc.h"
 #include "john_mpi.h"
 #include "timer.h"
@@ -2235,7 +2235,7 @@ void opencl_build_kernel_opt(const char *kernel_filename, int sequential_id,
 	MEM_FREE(kernel_source);
 }
 
-#define md5add(string) MD5_Update(&ctx, (string), strlen(string))
+#define md4add(string) MD4_Update(&ctx, (string), strlen(string))
 
 void opencl_build_kernel(const char *kernel_filename, int sequential_id, const char *opts,
                          int warn)
@@ -2246,7 +2246,7 @@ void opencl_build_kernel(const char *kernel_filename, int sequential_id, const c
 	unsigned char hash[16];
 	char hash_str[33];
 	int i, use_cache;
-	MD5_CTX ctx;
+	MD4_CTX ctx;
 	char *kernel_source = NULL;
 	const char *global_opts;
 
@@ -2267,17 +2267,17 @@ void opencl_build_kernel(const char *kernel_filename, int sequential_id, const c
 /*
  * Create a hash of kernel source and parameters, and use as cache name.
  */
-	MD5_Init(&ctx);
-	md5add(kernel_filename);
+	MD4_Init(&ctx);
+	md4add(kernel_filename);
 	opencl_read_source(kernel_filename, &kernel_source);
-	md5add(kernel_source);
-	md5add(global_opts);
+	md4add(kernel_source);
+	md4add(global_opts);
 	if (opts)
-		md5add(opts);
-	md5add(opencl_driver_ver(sequential_id));
-	md5add(dev_name);
-	MD5_Update(&ctx, (char*)&platform_id, sizeof(platform_id));
-	MD5_Final(hash, &ctx);
+		md4add(opts);
+	md4add(opencl_driver_ver(sequential_id));
+	md4add(dev_name);
+	MD4_Update(&ctx, (char*)&platform_id, sizeof(platform_id));
+	MD4_Final(hash, &ctx);
 
 	for (i = 0; i < 16; i++) {
 		hash_str[2 * i + 0] = itoa16[hash[i] >> 4];

--- a/src/opencl_common.h
+++ b/src/opencl_common.h
@@ -189,7 +189,7 @@ void opencl_init(const char *kernel_filename, int sequential_id, const char *opt
 /* used by opencl_DES_bs_*.c */
 void opencl_build(int sequential_id, const char *opts, int save, const char *file_name,
 		  cl_program *program, const char *kernel_source_file, const char *kernel_source);
-void opencl_build_from_binary(int sequential_id, cl_program *program, const char *kernel_source,
+cl_int opencl_build_from_binary(int sequential_id, cl_program *program, const char *kernel_source,
 			      size_t program_size);
 
 /* Build kernel (if not cached), and cache it */


### PR DESCRIPTION
If building from a cached binary fails, just build a new one instead of bailing out. This **does** affect DEScrypt's per-salt kernels as well.

See #3525

~I'm not 100% happy with the code (adding a struct and code in `john.c` just for this) but not sure how to make it safe & portable otherwise. At least it's simple code. I'm open for suggestions, as always.~