### PR TITLE
Bcrypt opencl fixes

### DIFF
--- a/src/opencl_DES_bs_b_plug.c
+++ b/src/opencl_DES_bs_b_plug.c
@@ -485,8 +485,8 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 		}
 		else {
 			warp_size = 1;
-			if (!(cpu(device_info[gpu_id]) || gpu_intel(device_info[gpu_id])))
-			fprintf(stderr, "Possible auto_tune fail!!.\n");
+			//if (!(cpu(device_info[gpu_id]) || gpu_intel(device_info[gpu_id])))
+				//fprintf(stderr, "Possible auto_tune fail!!.\n");
 		}
 
 		if (lws_tune_flag)

--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -542,8 +542,8 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 		}
 		else {
 			warp_size = 1;
-			if (!(cpu(device_info[gpu_id]) || gpu_intel(device_info[gpu_id])))
-			fprintf(stderr, "Possible auto_tune fail!!.\n");
+			//if (!(cpu(device_info[gpu_id]) || gpu_intel(device_info[gpu_id])))
+				//fprintf(stderr, "Possible auto_tune fail!!.\n");
 		}
 
 		if (lws_tune_flag)

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -556,8 +556,8 @@ static void auto_tune_all(long double kernel_run_ms, struct fmt_main *format, WO
 		}
 		else {
 			warp_size = 1;
-			if (!(cpu(device_info[gpu_id]) || gpu_intel(device_info[gpu_id])))
-			fprintf(stderr, "Possible auto_tune fail!!.\n");
+			//if (!(cpu(device_info[gpu_id]) || gpu_intel(device_info[gpu_id])))
+				//fprintf(stderr, "Possible auto_tune fail!!.\n");
 		}
 
 		if (lws_tune_flag)

--- a/src/opencl_bf_fmt_plug.c
+++ b/src/opencl_bf_fmt_plug.c
@@ -22,6 +22,7 @@ john_register_one(&fmt_opencl_bf);
 #include "common.h"
 #include "formats.h"
 #include "config.h"
+#include "loader.h"
 #include "BF_common.h"
 
 #define FORMAT_LABEL			"bcrypt-opencl"
@@ -57,6 +58,14 @@ static void done(void) {
 
 static void init(struct fmt_main *self) {
 	saved_key = mem_calloc(BF_N, sizeof(*saved_key));
+	keys_mode = 'a';
+	sign_extension_bug = 0;
+
+	opencl_prepare_dev(gpu_id);
+}
+
+static void reset(struct db_main *db)
+{
 	global_work_size = 0;
 
 	//Prepare OpenCL environment.
@@ -67,9 +76,8 @@ static void init(struct fmt_main *self) {
 
 	// BF_select_device(platform,device);
 	//platform_id = get_platform_id(gpu_id);
-        BF_select_device(self);
-	keys_mode = 'a';
-	sign_extension_bug = 0;
+	BF_select_device(db->format);
+
 	//fprintf(stderr, "****Please see 'opencl_bf_std.h' for device specific optimizations****\n");
 }
 
@@ -183,7 +191,7 @@ struct fmt_main fmt_opencl_bf = {
 	}, {
 		init,
 		done,
-		fmt_default_reset,
+		reset,
 		fmt_default_prepare,
 		BF_common_valid,
 		BF_common_split,

--- a/src/opencl_lm_b_plug.c
+++ b/src/opencl_lm_b_plug.c
@@ -859,7 +859,7 @@ static void auto_tune_all(char *bitmap_params, unsigned int num_loaded_hashes, l
 		}
 		else {
 			warp_size = 1;
-			fprintf(stderr, "Possible auto_tune fail!!.\n");
+			//fprintf(stderr, "Possible auto_tune fail!!.\n");
 		}
 		if (lws_tune_flag)
 			local_work_size = warp_size;


### PR DESCRIPTION
Move OpenCL setup from init() to reset(). This was the last of formats not "complying" with our current standard way of doing things.
    
Mutes spurious weird messages (and delays) from eg. `--list=NAME`.
Now outputs "Device:" and LWS/GWS at the right time.
    
Closes #4914
