### PR TITLE
Change a confusing error message when requesting an empty format class

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -88,6 +88,27 @@ char fmt_class_list[] = "all, enabled, disabled"
 #endif
 	", cpu";
 
+int fmt_is_class(char *name)
+{
+	return (name && (!strcasecmp(name, "all") || !strcasecmp(name, "enabled") || !strcasecmp(name, "disabled") ||
+#if _OPENMP
+	                 !strcasecmp(name , "omp") ||
+#endif
+#if HAVE_OPENCL || HAVE_ZTEX
+	                 !strcasecmp(name , "mask") ||
+#endif
+#if HAVE_ZTEX
+	                 !strcasecmp(name , "ztex") ||
+#endif
+#if HAVE_OPENCL
+	                 !strcasecmp(name , "opencl") || !strcasecmp(name , "vector") ||
+#endif
+#ifndef DYNAMIC_DISABLED
+	                 !strcasecmp(name , "dynamic") ||
+#endif
+	                 !strcasecmp(name , "cpu")));
+}
+
 /*
  * Does req_format match format?
  *

--- a/src/formats.h
+++ b/src/formats.h
@@ -455,6 +455,11 @@ extern struct fmt_main *fmt_list;
 extern void fmt_register(struct fmt_main *format);
 
 /*
+ * Returns true if name is a format class such as "opencl" or "dynamic"
+ */
+extern int fmt_is_class(char *name);
+
+/*
  * Match req_format to format, supporting wildcards/groups/classes etc.
  */
 extern int fmt_match(const char *req_format, struct fmt_main *format, int override_disable);

--- a/src/john.c
+++ b/src/john.c
@@ -273,8 +273,12 @@ static void john_register_all(void)
 		error_msg("Could not parse format list '%s'\n", options.format_list);
 
 	if (!fmt_list) {
-		if (john_main_process)
-		fprintf(stderr, "Unknown ciphertext format name requested\n");
+		if (john_main_process) {
+			if (!options.format_list && fmt_is_class(options.format))
+				fprintf(stderr, "Error: No format matched '%s'\n", options.format);
+			else
+				fprintf(stderr, "Unknown ciphertext format name requested\n");
+		}
 		error();
 	}
 }


### PR DESCRIPTION
Before:
./john -list=format -form=vector
Unknown ciphertext format name requested

After:
./john -list=format -form=vector
Error: No format matched 'vector'

See https://github.com/openwall/john/pull/4903#issuecomment-987842123