### PR TITLE
DEScrypt build salt "dots progress"

### DIFF
--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -698,8 +698,8 @@ static void reset(struct db_main *db)
 			salt_list[num_salts++] = (*(WORD *)salt->salt);
 		} while ((salt = salt->next));
 
-		if (num_salts > 1 && !(options.flags & FLG_TEST_CHK) && john_main_process)
-			fprintf(stderr, "Note: Building per-salt kernels. This takes e.g. 2 hours for 4096 salts.\n");
+		if (num_salts > 10 && !ocl_any_test_running && john_main_process)
+			fprintf(stderr, "Building %d per-salt kernels, one dot per three salts done: ", num_salts);
 
 #if _OPENMP && PARALLEL_BUILD
 #pragma omp parallel for
@@ -712,11 +712,12 @@ static void reset(struct db_main *db)
 #endif
 			{
 				opencl_process_event();
-
-				if (options.verbosity < VERB_LEGACY)
-					advance_cursor();
 			}
+			if (num_salts > 10 && (i % 3) == 2 && !ocl_any_test_running && john_main_process)
+				fprintf(stderr, ".");
 		}
+		if (num_salts > 10 && !ocl_any_test_running && john_main_process)
+			fprintf(stderr, " Done!\n");
 		set_kernel_args_kpc();
 	}
 	else {

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -712,8 +712,8 @@ static void reset(struct db_main *db)
 			salt_list[num_salts++] = (*(WORD *)salt->salt);
 		} while ((salt = salt->next));
 
-		if (num_salts > 1 && !(options.flags & FLG_TEST_CHK) && john_main_process)
-			fprintf(stderr, "Note: Building per-salt kernels. This takes e.g. 2 hours for 4096 salts.\n");
+		if (num_salts > 10 && !ocl_any_test_running && john_main_process)
+			fprintf(stderr, "Building %d per-salt kernels, one dot per three salts done: ", num_salts);
 
 #if _OPENMP && PARALLEL_BUILD
 #pragma omp parallel for
@@ -726,11 +726,12 @@ static void reset(struct db_main *db)
 #endif
 			{
 				opencl_process_event();
-
-				if (options.verbosity < VERB_LEGACY)
-					advance_cursor();
 			}
+			if (num_salts > 10 && (i % 3) == 2 && !ocl_any_test_running && john_main_process)
+				fprintf(stderr, ".");
 		}
+		if (num_salts > 10 && !ocl_any_test_running && john_main_process)
+			fprintf(stderr, " Done!\n");
 		set_kernel_args_kpc();
 	}
 	else {

--- a/src/opencl_common.h
+++ b/src/opencl_common.h
@@ -130,6 +130,8 @@ extern struct db_main *ocl_autotune_db;
 extern int autotune_real_db;
 extern int opencl_unavailable;
 
+#define ocl_any_test_running	(bench_or_test_running || ocl_autotune_running)
+
 extern cl_device_id devices[MAX_GPU_DEVICES + 1];
 extern cl_context context[MAX_GPU_DEVICES];
 extern cl_program program[MAX_GPU_DEVICES];


### PR DESCRIPTION
This replaces the "This takes e.g. 2 hours" message. We print one dot per three salts, so this wont overflow even an 80x25 terminal.

```
Device 1: Apple M1
Using default input encoding: UTF-8
Loaded 30 password hashes with 30 different salts (descrypt-opencl, traditional crypt(3) [DES OpenCL])
Building 30 per-salt kernels, one dot per three salts done: .......... Done!
Press 'q' or Ctrl-C to abort, almost any other key for status
```