### PR TITLE
Bugfix for 'vector' format class

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -44,7 +44,6 @@ int fmt_raw_len;
 
 int self_test_running;
 int benchmark_running;
-int fmt_matching;
 
 #ifndef BENCH_BUILD
 static int orig_min, orig_max, orig_len;
@@ -200,12 +199,10 @@ int fmt_match(const char *req_format, struct fmt_main *format, int override_disa
 		int vectorized;
 		const char *orig_algo = format->params.algorithm_name;
 
-		fmt_matching = 1;
 		fmt_init(format);
 		vectorized = (ocl_v_width > 1);
 		fmt_done(format);
 		format->params.algorithm_name = orig_algo;
-		fmt_matching = 0;
 
 		return enabled && vectorized;
 	}

--- a/src/formats.h
+++ b/src/formats.h
@@ -127,9 +127,6 @@ struct db_salt;
 /* Format's length before calling init() */
 extern int fmt_raw_len;
 
-/* We're currently in "format matching" code path */
-extern int fmt_matching;
-
 /*
  * A password to test the methods for correct operation.
  */

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -939,7 +939,7 @@ void opencl_load_environment(void)
 unsigned int opencl_get_vector_width(int sequential_id, int size)
 {
 	/* --force-vector-width=N */
-	if (options.v_width && !fmt_matching) {
+	if (options.v_width) {
 		ocl_v_width = options.v_width;
 	} else {
 		cl_uint v_width = 0;


### PR DESCRIPTION
This lists formats that will run vectorized on current GPU:
--list=formats --format=vector

This lists formats that *can* run vectorized:
--list=formats --format=vector --force-vector=2