### PR TITLE
tezos-opencl key transfer optimization

### DIFF
--- a/src/opencl_tezos_fmt_plug.c
+++ b/src/opencl_tezos_fmt_plug.c
@@ -42,8 +42,7 @@ john_register_one(&fmt_opencl_tezos);
 #define BINARY_ALIGN            sizeof(uint32_t)
 #define SALT_SIZE               sizeof(struct custom_salt)
 #define SALT_ALIGN              sizeof(uint32_t)
-#define PLAINTEXT_LENGTH        110
-#define REAL_PLAINTEXT_LENGTH   48
+#define PLAINTEXT_LENGTH        48
 #define MIN_KEYS_PER_CRYPT      1
 #define MAX_KEYS_PER_CRYPT      1
 #define INIT_KERNEL_NAME        "pbkdf2_sha512_tezos_init"
@@ -332,8 +331,7 @@ static int cmp_exact(char *source, int index)
 
 static void set_key(char *key, int index)
 {
-	int saved_len = MIN(strlen(key), PLAINTEXT_LENGTH);
-
+	size_t saved_len = strnlen(key, PLAINTEXT_LENGTH);
 	memcpy(host_pass[index].v, key, saved_len);
 	host_pass[index].length = saved_len;
 	new_keys = 1;
@@ -357,7 +355,7 @@ struct fmt_main fmt_opencl_tezos = {
 		BENCHMARK_COMMENT,
 		BENCHMARK_LENGTH,
 		0,
-		REAL_PLAINTEXT_LENGTH,
+		PLAINTEXT_LENGTH,
 		BINARY_SIZE,
 		BINARY_ALIGN,
 		SALT_SIZE,

--- a/src/tezos_common.h
+++ b/src/tezos_common.h
@@ -18,7 +18,7 @@ struct custom_salt {
         uint32_t email_length;
         uint32_t mnemonic_length;
         uint32_t raw_address_length;
-        char mnemonic[512];
+        char mnemonic[132]; /* our OpenCL kernel supports up to 128, and on host we also add NUL */
         char email[256];
         char address[64];
         char raw_address[64];

--- a/src/tezos_common_plug.c
+++ b/src/tezos_common_plug.c
@@ -38,15 +38,15 @@ int tezos_valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if ((p = strtokm(NULL, "*")) == NULL) // mnemonic
 		goto err;
-	if (strlen(p) > 512)
+	if (strlen(p) > 128)
 		goto err;
 	if ((p = strtokm(NULL, "*")) == NULL) // email
 		goto err;
-	if (strlen(p) > 256)
+	if (strlen(p) >= 256)
 		goto err;
 	if ((p = strtokm(NULL, "*")) == NULL) // address
 		goto err;
-	if (strlen(p) > 64)
+	if (strlen(p) >= 64)
 		goto err;
 	if ((p = strtokm(NULL, "*")) == NULL) // raw address
 		goto err;


### PR DESCRIPTION
Only transfer keys when changed (not re-transfer when merely switching to next salt). Only transfer keys up to length 48, not 110. 48 was the maximum supported in the code anyway, but 110 was also used in some places including for transfer size.

Also, limit mnemonics to a maximum of 128 characters in valid() (was 512) and use that for the allocation size in the CPU format. The OpenCL format had it that way anyway (in the host code, and effectively at 112 in the device code - now increased), and could probably be made to crash due to the higher limit in valid().