### PR TITLE
Tezos formats: Accept only ed25519_public_key_hash address type

### DIFF
--- a/src/opencl_tezos_fmt_plug.c
+++ b/src/opencl_tezos_fmt_plug.c
@@ -308,7 +308,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		for (index = 0; index < count; index++) {
 			unsigned char buffer[20];
 			blake2b((uint8_t *)buffer, host_pk[index].pk, NULL, 20, 32, 0);
-			if (memmem(cur_salt->raw_address, cur_salt->raw_address_length, buffer, 8)) {
+			if (!memcmp(cur_salt->raw_address + 2, buffer, 20)) {
 				cracked[index] = 1;
 #ifdef _OPENMP
 #pragma omp atomic

--- a/src/tezos_common.h
+++ b/src/tezos_common.h
@@ -20,8 +20,8 @@ struct custom_salt {
         uint32_t raw_address_length;
         char mnemonic[132]; /* our OpenCL kernel supports up to 128, and on host we also add NUL */
         char email[256];
-        char address[64];
-        char raw_address[64];
+        char address[62];
+        char raw_address[22];
 };
 
 extern struct fmt_tests tezos_tests[];

--- a/src/tezos_common_plug.c
+++ b/src/tezos_common_plug.c
@@ -46,11 +46,18 @@ int tezos_valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if ((p = strtokm(NULL, "*")) == NULL) // address
 		goto err;
-	if (strlen(p) >= 64)
+	if (strlen(p) >= 62)
 		goto err;
 	if ((p = strtokm(NULL, "*")) == NULL) // raw address
 		goto err;
-	if (hexlenl(p, &extra) > 64 * 2 || extra)
+/*
+ * https://gitlab.com/tezos/tezos/blob/master/src/lib_crypto/base58.ml says:
+ * (* 20 *)
+ * let ed25519_public_key_hash = "\006\161\159" (* tz1(36) *)
+ * Since ed25519_public_key_hash is the only thing we support in code, it would
+ * be wrong to accept other address types here (we'd have false negatives).
+ */
+	if (hexlenl(p, &extra) != 22 * 2 || extra || strncmp(p, "a19f", 4))
 		goto err;
 
 	MEM_FREE(keeptr);

--- a/src/tezos_fmt_plug.c
+++ b/src/tezos_fmt_plug.c
@@ -176,7 +176,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 			blake2b((uint8_t *)buffer, (unsigned char*)pk, NULL, 20, 32, 0); // pk is pkh (pubkey hash)
 
-			if (memmem(cur_salt->raw_address, cur_salt->raw_address_length, (void*)buffer, 8)) {
+			if (!memcmp(cur_salt->raw_address + 2, buffer, 20)) {
 				cracked[index+i] = 1;
 #ifdef _OPENMP
 #pragma omp atomic


### PR DESCRIPTION
https://gitlab.com/tezos/tezos/blob/master/src/lib_crypto/base58.ml says:

```
(* 20 *)
let ed25519_public_key_hash = "\006\161\159" (* tz1(36) *)
```

Since ed25519_public_key_hash is the only thing we support in code, it would be wrong to accept other address types here (we'd have false negatives).