### PR TITLE
Incremental mode: Correct log message for --max-length

### DIFF
--- a/src/inc.c
+++ b/src/inc.c
@@ -527,7 +527,8 @@ void do_incremental_crack(struct db_main *db, const char *mode)
 	if ((max_length = cfg_get_int(SECTION_INC, mode, "MaxLen")) < 0)
 		max_length = MIN(CHARSET_LENGTH, options.eff_maxlength);
 	else if (max_length > our_fmt_len) {
-		log_event("! MaxLen = %d is too large for this hash type", max_length);
+		log_event("! MaxLen = %d is too large%s, reduced", max_length,
+		    options.force_maxlength ? "" : " for this hash type");
 		if (john_main_process && !options.force_maxlength)
 			fprintf(stderr, "Warning: MaxLen = %d is too large "
 			    "for the current hash type, reduced to %d\n",


### PR DESCRIPTION
This removes erroneous claim "for this hash type" when the actual limit was possibly `--max-length`.

Similar change might also be needed for Markov and PRINCE, and for uses of `--min-length`, but those look trickier to me, so I don't bother. Someone else might.