### PR TITLE
OpenCL formats: Ensure we profile when autotuning

### DIFF
--- a/src/opencl_7z_fmt_plug.c
+++ b/src/opencl_7z_fmt_plug.c
@@ -323,10 +323,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		any_cracked = 0;
 	}
 
+	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
+
 	if (ocl_autotune_running || new_keys) {
 		int i;
-
-		global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 		// Copy data to gpu
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
@@ -353,9 +353,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], sevenzip_final, 1,
 			NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[3]),
 			"Run final loop kernel");
-	}
 
-	new_keys = 0;
+		new_keys = 0;
+	}
 
 	if (sevenzip_trust_padding || sevenzip_salt->type == 0x80) {
 		// Run AES kernel (only for truncated hashes)

--- a/src/opencl_bitcoin_fmt_plug.c
+++ b/src/opencl_bitcoin_fmt_plug.c
@@ -384,7 +384,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	in_size = sizeof(password_t) * global_work_size;
 	cracked_size = sizeof(*cracked) * global_work_size;
 
-	if (new_keys) {
+	if (ocl_autotune_running || new_keys) {
 		// Copy data to gpu
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
 			in_size, saved_key, 0, NULL, multi_profilingEvent[0]),

--- a/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
@@ -49,6 +49,7 @@ static cl_int cl_error;
 static cl_mem mem_in, mem_out, mem_salt, mem_state;
 static cl_kernel split_kernel, final_kernel;
 static struct fmt_main *self;
+static int new_keys;
 
 #define STEP			0
 #define SEED			1024
@@ -228,9 +229,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #endif
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
-		NULL, multi_profilingEvent[0]), "Copy data to gpu");
+	if (ocl_autotune_running || new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
+			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+			NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
@@ -283,6 +288,8 @@ static void set_key(char *key, int index)
 
 	memcpy(host_pass[index].v, key, saved_len);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
@@ -75,6 +75,7 @@ static cl_mem mem_in, mem_out, mem_salt, mem_state;
 static cl_kernel split_kernel;
 static cl_int cl_error;
 static struct fmt_main *self;
+static int new_keys;
 
 #define STEP                     0
 #define SEED                     256
@@ -259,9 +260,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #endif
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		global_work_size * sizeof(pass_t), host_pass, 0, NULL,
-		multi_profilingEvent[0]), "Copy data to gpu");
+	if (ocl_autotune_running || new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			global_work_size * sizeof(pass_t), host_pass, 0, NULL,
+			multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
@@ -306,6 +311,8 @@ static void set_key(char *key, int index)
 	// ^= the whole uint64 with the ipad/opad mask
 	strncpy((char*)host_pass[index].v, key, PLAINTEXT_LENGTH);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -728,15 +728,16 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = count;
 
 	if (keys_changed) {
-	// copy keys to the device
-	if (key_idx)
-		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_TRUE, 0, 4 * key_idx, saved_plain, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_keys.");
+		// copy keys to the device
+		if (key_idx)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_TRUE, 0, 4 * key_idx, saved_plain, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_keys.");
 
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_TRUE, 0, 4 * global_work_size, saved_idx, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_idx.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_TRUE, 0, 4 * global_work_size, saved_idx, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_idx.");
 
-	if (!mask_gpu_is_static)
-		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_TRUE, 0, 4 * global_work_size, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
-	keys_changed = 0;
+		if (!mask_gpu_is_static)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_TRUE, 0, 4 * global_work_size, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
+
+		keys_changed = 0;
 	}
 
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &global_work_size, lws, 0, NULL, NULL), "failed in clEnqueueNDRangeKernel");

--- a/src/opencl_sha256crypt_fmt_plug.c
+++ b/src/opencl_sha256crypt_fmt_plug.c
@@ -573,7 +573,7 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 		output_hashes = calculated_hash;
 	}
 
-	if (new_keys) {
+	if (ocl_autotune_running || new_keys) {
 		// sort passwords by length
 		if (bitmap_of_lens & (bitmap_of_lens - 1)) {
 			if (count > indices_size) {

--- a/src/opencl_sha512crypt_fmt_plug.c
+++ b/src/opencl_sha512crypt_fmt_plug.c
@@ -589,7 +589,7 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 		output_hashes = calculated_hash;
 	}
 
-	if (new_keys) {
+	if (ocl_autotune_running || new_keys) {
 		// sort passwords by length
 		if (bitmap_of_lens & (bitmap_of_lens - 1)) {
 			if (count > indices_size) {

--- a/src/opencl_sl3_fmt_plug.c
+++ b/src/opencl_sl3_fmt_plug.c
@@ -685,15 +685,15 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = count;
 
 	if (keys_changed) {
-	// copy keys to the device
-	if (key_idx)
-		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_TRUE, 0, 4 * key_idx, saved_plain, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_keys.");
+		// copy keys to the device
+		if (key_idx)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_TRUE, 0, 4 * key_idx, saved_plain, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_keys.");
 
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_TRUE, 0, 4 * global_work_size, saved_idx, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_idx.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_TRUE, 0, 4 * global_work_size, saved_idx, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_idx.");
 
-	if (!mask_gpu_is_static)
-		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_TRUE, 0, 4 * global_work_size, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
-	keys_changed = 0;
+		if (!mask_gpu_is_static)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_TRUE, 0, 4 * global_work_size, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
+		keys_changed = 0;
 	}
 
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &global_work_size, lws, 0, NULL, NULL), "failed in clEnqueueNDRangeKernel");


### PR DESCRIPTION
If using 'new_keys' optimization, ensure we call that code path while
autotuning or the event may end up uninitialized and skew tuning.

Also *adds* new_keys optimization to a few formats (there seem to be more).

Also just fixes indentation for a couple of formats that did the right
thing otherwise (they don't use shared autotune though, so not quite in
scope of #4932).

Closes #4932