### PR TITLE
Tezos-opencl: Tweaks for running under macOS

### DIFF
--- a/run/opencl/ed25519-donna/curve25519-donna-32bit.h
+++ b/run/opencl/ed25519-donna/curve25519-donna-32bit.h
@@ -322,7 +322,7 @@ curve25519_square(bignum25519 out, const bignum25519 in) {
 }
 
 static void
-curve25519_mul_const(bignum25519 out, const bignum25519 a, __constant bignum25519 b) {
+curve25519_mul_const(bignum25519 out, const bignum25519 a, __constant uint32_t *b) {
 	bignum25519 bpvt;
 	memcpy_cp(bpvt, b, sizeof(bpvt));
 	curve25519_mul(out, a, bpvt);
@@ -534,7 +534,7 @@ curve25519_contract(unsigned char out[32], const bignum25519 in) {
 
 /* out = (flag) ? in : out */
 static void
-curve25519_move_conditional_bytes(uint8_t out[96], __constant uint8_t in[96], uint32_t flag) {
+curve25519_move_conditional_bytes(uint8_t out[96], __constant uint8_t *in, uint32_t flag) {
 	const uint32_t nb = flag - 1, b = ~nb;
 	__constant uint32_t *inl = (__constant uint32_t *)in;
 	uint32_t *outl = (uint32_t *)out;

--- a/run/opencl/ed25519-donna/ed25519-donna-impl-base.h
+++ b/run/opencl/ed25519-donna/ed25519-donna-impl-base.h
@@ -93,7 +93,7 @@ ge25519_windowb_equal(uint32_t b, uint32_t c) {
 }
 
 static void
-ge25519_scalarmult_base_choose_niels(ge25519_niels *t, __constant uint8_t table[256][96], uint32_t pos, signed char b) {
+ge25519_scalarmult_base_choose_niels(ge25519_niels *t, uint32_t pos, signed char b) {
 	bignum25519 neg;
 	uint32_t sign = (uint32_t)((unsigned char)b >> 7);
 	uint32_t mask = ~(sign - 1);
@@ -106,7 +106,7 @@ ge25519_scalarmult_base_choose_niels(ge25519_niels *t, __constant uint8_t table[
 	packed[32] = 1;
 
 	for (i = 0; i < 8; i++)
-		curve25519_move_conditional_bytes(packed, table[(pos * 8) + i], ge25519_windowb_equal(u, i + 1));
+		curve25519_move_conditional_bytes(packed, ge25519_niels_base_multiples[(pos * 8) + i], ge25519_windowb_equal(u, i + 1));
 
 	/* expand in to t */
 	curve25519_expand(t->ysubx, packed +  0);
@@ -121,32 +121,32 @@ ge25519_scalarmult_base_choose_niels(ge25519_niels *t, __constant uint8_t table[
 
 /* computes [s]basepoint */
 static void
-ge25519_scalarmult_base_niels(ge25519 *r, __constant uint8_t basepoint_table[256][96], const bignum256modm s) {
+ge25519_scalarmult_base_niels(ge25519 *r, const bignum256modm s) {
 	signed char b[64];
 	uint32_t i;
 	ge25519_niels t;
 
 	contract256_window4_modm(b, s);
 
-	ge25519_scalarmult_base_choose_niels(&t, basepoint_table, 0, b[1]);
+	ge25519_scalarmult_base_choose_niels(&t, 0, b[1]);
 	curve25519_sub_reduce(r->x, t.xaddy, t.ysubx);
 	curve25519_add_reduce(r->y, t.xaddy, t.ysubx);
 	memset_p(r->z, 0, sizeof(bignum25519));
 	curve25519_copy(r->t, t.t2d);
 	r->z[0] = 2;
 	for (i = 3; i < 64; i += 2) {
-		ge25519_scalarmult_base_choose_niels(&t, basepoint_table, i / 2, b[i]);
+		ge25519_scalarmult_base_choose_niels(&t, i / 2, b[i]);
 		ge25519_nielsadd2(r, &t);
 	}
 	ge25519_double_partial(r, r);
 	ge25519_double_partial(r, r);
 	ge25519_double_partial(r, r);
 	ge25519_double(r, r);
-	ge25519_scalarmult_base_choose_niels(&t, basepoint_table, 0, b[0]);
+	ge25519_scalarmult_base_choose_niels(&t, 0, b[0]);
 	curve25519_mul_const(t.t2d, t.t2d, ge25519_ecd);
 	ge25519_nielsadd2(r, &t);
 	for(i = 2; i < 64; i += 2) {
-		ge25519_scalarmult_base_choose_niels(&t, basepoint_table, i / 2, b[i]);
+		ge25519_scalarmult_base_choose_niels(&t, i / 2, b[i]);
 		ge25519_nielsadd2(r, &t);
 	}
 }

--- a/run/opencl/ed25519-donna/ed25519-donna.c
+++ b/run/opencl/ed25519-donna/ed25519-donna.c
@@ -29,6 +29,6 @@ ed25519_publickey(const ed25519_secret_key sk, ed25519_public_key pk) {
 	/* A = aB */
 	ed25519_extsk(extsk, sk);
 	expand256_modm(a, extsk, 32);
-	ge25519_scalarmult_base_niels(&A, ge25519_niels_base_multiples, a);
+	ge25519_scalarmult_base_niels(&A, a);
 	ge25519_pack(pk, &A);
 }

--- a/run/opencl/ed25519-donna/ed25519-hash.h
+++ b/run/opencl/ed25519-donna/ed25519-hash.h
@@ -1,24 +1,5 @@
 #include "../opencl_sha2_ctx.h"
 
-typedef SHA512_CTX ed25519_hash_context;
-
-#if 0
-static void
-ed25519_hash_init(ed25519_hash_context *ctx) {
-	SHA512_Init(ctx);
-}
-
-static void
-ed25519_hash_update(ed25519_hash_context *ctx, const uint8_t *in, size_t inlen) {
-	SHA512_Update(ctx, in, inlen);
-}
-
-static void
-ed25519_hash_final(ed25519_hash_context *ctx, uint8_t *hash) {
-	SHA512_Final(hash, ctx);
-}
-#endif
-
 static void
 ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {
 	SHA512_CTX ctx;

--- a/run/opencl/ed25519-donna/ed25519-hash.h
+++ b/run/opencl/ed25519-donna/ed25519-hash.h
@@ -2,6 +2,7 @@
 
 typedef SHA512_CTX ed25519_hash_context;
 
+#if 0
 static void
 ed25519_hash_init(ed25519_hash_context *ctx) {
 	SHA512_Init(ctx);
@@ -16,6 +17,7 @@ static void
 ed25519_hash_final(ed25519_hash_context *ctx, uint8_t *hash) {
 	SHA512_Final(hash, ctx);
 }
+#endif
 
 static void
 ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {

--- a/run/opencl/tezos_kernel.cl
+++ b/run/opencl/tezos_kernel.cl
@@ -164,7 +164,7 @@ __kernel void pbkdf2_sha512_tezos_init(__global const pass_t *inbuffer,
 	memcpy_macro(salt.bytes + saltlen, "\x0\x0\x0\x1\x80", 5);
 	saltlen += 5;  // we include the x80 byte in our saltlen, but the .cl kernel knows to reduce saltlen by 1
 	if (saltlen % 8)
-		for (int i = saltlen; i < saltlen + (8 - saltlen % 8); i++)  // zeroize buffer correctly
+		for (uint i = saltlen; i < saltlen + (8 - saltlen % 8); i++)  // zeroize buffer correctly
 			salt.bytes[i] = 0;
 
 	state[idx].rounds = rounds - 1;
@@ -174,7 +174,7 @@ __kernel void pbkdf2_sha512_tezos_init(__global const pass_t *inbuffer,
 		passlen = sizeof(pass.bytes);  // safety, although we better fail reliably
 	memcpy_macro(pass.bytes, gsalt->mnemonic, passlen);  // actual password
 	if (passlen % 8)
-		for (int i = passlen; i < passlen + (8 - passlen % 8); i++)  // zeroize buffer correctly
+		for (uint i = passlen; i < passlen + (8 - passlen % 8); i++)  // zeroize buffer correctly
 			pass.bytes[i] = 0;
 
 	_tezos_preproc_(pass.data, passlen, ipad_state, 0x3636363636363636UL);


### PR DESCRIPTION
I believe this is not some weird Apple issue but actually needed for OpenCL compliance: You aren't allowed to have an array as a function argument unless (I think) it's in private memory. Several platforms allow it though.

I found no way to replace `__constant uint8_t table[256][96]` (I thought `__constant uint8_t **table` would do it, but it didn't) so I simply dropped the passing-around of that array, it's at global scope anyway. Not sure if there's a nicer way to do it?

With this, my macbook builds it without warnings and passes self-test using the CPU device. The "Intel(R) UHD Graphics 630" device fails self-test and the "AMD Radeon Pro Vega 20 Compute Engine" seem to build forever (I haven't had the patience to let it complete, I suspect it never will - it's over 10 minutes)