### PR TITLE
Dynamic format: Don't un-hex ciphertexts too early.

### DIFF
--- a/src/dynamic.h
+++ b/src/dynamic.h
@@ -362,7 +362,6 @@ int dynamic_IS_VALID(int i, int single_lookup_only);
 int dynamic_real_salt_length(struct fmt_main *pFmt);
 void dynamic_salt_md5(struct db_salt *p);
 void dynamic_DISPLAY_ALL_FORMATS();
-char *RemoveHEX(char *output, char *input);
 const char *dynamic_Find_Function_Name(DYNAMIC_primitive_funcp p);
 
 // Function used to 'link' a thin format into dynamic.  See PHPS_fmt.c for an example.
@@ -378,10 +377,6 @@ int dynamic_IS_PARSER_VALID(int which, int single_lookup_only);
 
 // when switching to the RDP format, there are a few things we need to correct in the format.
 void dynamic_switch_compiled_format_to_RDP(struct fmt_main *pFmt);
-
-// This one is called in the .pot writing.  We 'fixup' salts which contain ':' chars, or other
-// chars which cause problems (like the $ char).
-char *dynamic_FIX_SALT_TO_HEX(char *ciphertext);
 
 // Here are the 'parser' functions (i.e. user built stuff in john.conf)
 int  dynamic_LOAD_PARSER_FUNCTIONS(int which, struct fmt_main *pFmt);

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -362,7 +362,17 @@ private_subformat_data curdat;
  *********************************************************************************
  *********************************************************************************/
 
-char *RemoveHEX(char *output, char *input)
+#define KEEP_UNPRINTABLE 0
+#define KEEP_NULLS 1
+
+/*
+ * Decode HEX$deadcafe salt strings into bytes. If last parameter is KEEP_UNPRINTABLE and there's
+ * unprintable characters in the string, bail without decoding (still copy input to output).
+ * If last parameter is KEEP_NULLS, anything except embedded nulls will be decoded.
+ * Output buffer must at least as big as input buffer.  If hex is decoded, the resulting
+ * output will be shorter.
+ */
+static char *RemoveHEX(char *output, char *input, int only_null)
 {
 	char *cpi = input;
 	char *cpo = output;
@@ -380,12 +390,13 @@ char *RemoveHEX(char *output, char *input)
 	*cpo++ = *cpi;
 	cpi += 5;
 	while (*cpi) {
-		if (*cpi == '0' && cpi[1] == '0') {
-			strcpy(output, input);
-			return output;
-		}
 		if (atoi16[ARCH_INDEX(*cpi)] != 0x7f && atoi16[ARCH_INDEX(cpi[1])] != 0x7f) {
-			*cpo++ = atoi16[ARCH_INDEX(*cpi)]*16 + atoi16[ARCH_INDEX(cpi[1])];
+			unsigned char c = atoi16[ARCH_INDEX(*cpi)]*16 + atoi16[ARCH_INDEX(cpi[1])];
+			if ((only_null && c == 0) || (!only_null && (c < ' ' || c > 0x7e))) {
+				strcpy(output, input);
+				return output;
+			}
+			*cpo++ = c;
 			cpi += 2;
 		} else if (*cpi == '$') {
 			while (*cpi && strncmp(cpi, "$HEX$", 5)) {
@@ -402,6 +413,56 @@ char *RemoveHEX(char *output, char *input)
 	}
 	*cpo = 0;
 	return output;
+}
+
+/*
+ * Add $HEX$ encoding for salts where needed.  For canonicalized pot storage, we encode
+ * anything containing unprintables or field separators, but never anything else.
+ */
+static char *AddHEX(char *ciphertext) {
+	char *cp;
+
+	if (strncmp(ciphertext, "$dynamic_", 9) && strncmp(ciphertext, "@dynamic=", 9))
+		return ciphertext;  // not a dynamic format, so we can not 'fix' it.
+
+	if (!(cp = strchr(&ciphertext[1], ciphertext[0])) || !(cp = strchr(&cp[1], '$')))
+		return ciphertext;  // not a salted format.
+
+	if (!strncmp(cp, "$HEX$", 5))
+		return ciphertext;  // already HEX$
+
+	unsigned char *s = (unsigned char*)cp++;
+	int need_hex = 0;
+	if (*cp && (cp[strlen(cp) - 1] == ' ' || cp[strlen(cp) - 1] == '\t'))
+		need_hex = 1;
+	else
+	while (*++s) {
+		if (*s < ' ' || *s > 0x7e || *s == ':' || *s == '$') {
+			need_hex = 1;
+			break;
+		}
+	}
+
+	/* New length is length of ciphertext, the HEX$ and 2 bytes per char of salt string plus ending null. */
+	if (need_hex) {
+		static char *out;
+		static size_t out_size;
+		size_t size_needed = strlen(ciphertext) + 4 + strlen(cp) + 1;
+
+		if (size_needed > out_size) {
+			out_size = (size_needed + 1024) / 1024 * 1024;
+			out = mem_realloc(out, out_size);
+		}
+
+		char *cpx = out;
+		cpx += sprintf(out, "%.*sHEX$", (int)(cp - ciphertext), ciphertext);
+		while (*cp)
+			cpx += sprintf(cpx, "%02x", (unsigned char)(*cp++));
+
+		return out;
+	}
+
+	return ciphertext;
 }
 
 /*********************************************************************************
@@ -432,7 +493,7 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 	// of leaving it in there. The ONLY problem we still have is NULL bytes.
 	if (strstr(ciphertext, "$HEX$")) {
 		if (strnlen(ciphertext, sizeof(fixed_ciphertext) + 1) < sizeof(fixed_ciphertext))
-			ciphertext = RemoveHEX(fixed_ciphertext, ciphertext);
+			ciphertext = RemoveHEX(fixed_ciphertext, ciphertext, KEEP_NULLS);
 	}
 
 	cp = &ciphertext[strlen(pPriv->dynamic_WHICH_TYPE_SIG)];
@@ -1029,44 +1090,12 @@ static char *prepare(char *split_fields[10], struct fmt_main *pFmt)
 	/* the ONE exception to this, is if there is a NULL byte in the $HEX$ string, then we MUST leave that $HEX$ string */
 	/* alone, and let the later calls in dynamic.c handle them. */
 	if (strstr(cpBuilding, "$HEX$")) {
-		char *cp, *cpo;
-		int bGood=1;
 		static char ct[512];
 
-		strcpy(ct, cpBuilding);
-		cp = strstr(ct, "$HEX$");
-		cpo = cp;
-		*cpo++ = *cp;
-		cp += 5;
-		while (*cp && bGood) {
-			if (*cp == '0' && cp[1] == '0') {
-				bGood = 0;
-				break;
-			}
-			if (atoi16[ARCH_INDEX(*cp)] != 0x7f && atoi16[ARCH_INDEX(cp[1])] != 0x7f) {
-				*cpo++ = atoi16[ARCH_INDEX(*cp)]*16 + atoi16[ARCH_INDEX(cp[1])];
-				*cpo = 0;
-				cp += 2;
-			} else if (*cp == '$') {
-				while (*cp && strncmp(cp, "$HEX$", 5)) {
-					*cpo++ = *cp++;
-				}
-				*cpo = 0;
-				if (!strncmp(cp, "$HEX$", 5)) {
-					*cpo++ = *cp;
-					cp += 5;
-				}
-			} else {
-				return split_fields[1];
-			}
-		}
-		if (bGood)
-			cpBuilding = ct;
-		// if we came into $HEX$ removal, then cpBuilding will always be shorter
+		cpBuilding = RemoveHEX(ct, cpBuilding, KEEP_NULLS);
 	}
 
 	// at this point max length is still < 512.  491 + strlen($dynamic_xxxxx$) is 506
-
 	if (pPriv->nUserName && !strstr(cpBuilding, "$$U")) {
 		if (split_fields[0] && split_fields[0][0] && strcmp(split_fields[0], "?")) {
 			char *userName=split_fields[0], *cp;
@@ -1133,8 +1162,9 @@ static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
 	if (!strncmp(ciphertext, "$dynamic", 8) ||
 	    !strncmp(ciphertext, "@dynamic=", 9)) {
 		if (strstr(ciphertext, "$HEX$"))
-			return RemoveHEX(out, ciphertext);
-		return ciphertext;
+			return AddHEX(RemoveHEX(out, ciphertext, KEEP_UNPRINTABLE));
+
+		return AddHEX(ciphertext);
 	}
 	if (!strncmp(ciphertext, "md5_gen(", 8)) {
 		ciphertext += 8;
@@ -1143,11 +1173,12 @@ static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
 	}
 	if (strstr(ciphertext, "$HEX$")) {
 		char *cp = out + sprintf(out, "%s", pPriv->dynamic_WHICH_TYPE_SIG);
-		RemoveHEX(cp, ciphertext);
+		RemoveHEX(cp, ciphertext, KEEP_UNPRINTABLE);
 	} else
 		snprintf(out, sizeof(out), "%s%s", pPriv->dynamic_WHICH_TYPE_SIG, ciphertext);
 
-	return out;
+	/* Add missing $HEX$ encoding (contains unprintables or field separators). */
+	return AddHEX(out);
 }
 
 // This split unifies case.
@@ -1159,12 +1190,12 @@ static char *split_UC(char *ciphertext, int index, struct fmt_main *pFmt)
 
 	if (!strncmp(ciphertext, "$dynamic", 8)) {
 		if (strstr(ciphertext, "$HEX$"))
-			RemoveHEX(out, ciphertext);
+			RemoveHEX(out, ciphertext, KEEP_UNPRINTABLE);
 		else
 			strcpy(out, ciphertext);
 	} else if (!strncmp(ciphertext, "@dynamic=", 9)) {
 		if (strstr(ciphertext, "$HEX$"))
-			RemoveHEX(out, ciphertext);
+			RemoveHEX(out, ciphertext, KEEP_UNPRINTABLE);
 		else
 			strcpy(out, ciphertext);
 		search_char = '@';
@@ -1176,7 +1207,7 @@ static char *split_UC(char *ciphertext, int index, struct fmt_main *pFmt)
 		}
 		if (strstr(ciphertext, "$HEX$")) {
 			char *cp = out + sprintf(out, "%s", pPriv->dynamic_WHICH_TYPE_SIG);
-			RemoveHEX(cp, ciphertext);
+			RemoveHEX(cp, ciphertext, KEEP_UNPRINTABLE);
 		} else
 			sprintf(out, "%s%s", pPriv->dynamic_WHICH_TYPE_SIG, ciphertext);
 	}
@@ -1186,8 +1217,9 @@ static char *split_UC(char *ciphertext, int index, struct fmt_main *pFmt)
 			*ciphertext += 0x20; // ASCII specific, but I really do not care.
 		++ciphertext;
 	}
-//	printf("%s\n", out);
-	return out;
+
+	/* Add missing $HEX$ encoding (contains unprintables or field separators). */
+	return AddHEX(out);
 }
 
 /*********************************************************************************
@@ -2324,7 +2356,7 @@ static unsigned int salt_external_to_internal_convert(unsigned char *extern_salt
  *********************************************************************************/
 static void *get_salt(char *ciphertext)
 {
-	char Salt[SALT_SIZE+1], saltIntBuf[SALT_SIZE+1];
+	char Salt[SALT_SIZE + 1], saltIntBuf[SALT_SIZE + 1], unhex_salt[1024];
 	int off, possible_neg_one=0;
 	unsigned char *saltp;
 	unsigned int the_real_len;
@@ -2332,6 +2364,10 @@ static void *get_salt(char *ciphertext)
 		unsigned char salt_p[sizeof(unsigned char*)];
 		ARCH_WORD p[1];
 	} union_x;
+
+	// We may have kept unprintables (except NULLs) so far, now remove them
+	if (strstr(ciphertext, "$HEX$"))
+		ciphertext = RemoveHEX(unhex_salt, ciphertext, KEEP_NULLS);
 
 	if ( (curdat.pSetup->flags&MGF_SALTED) == 0) {
 		memset(union_x.salt_p, 0, sizeof(union_x.salt_p));

--- a/src/dynamic_utils.c
+++ b/src/dynamic_utils.c
@@ -161,39 +161,4 @@ char *dynamic_Demangle(char *Line, int *Len)
 	return tmp;
 }
 
-// This one is called in the .pot writing.  We 'fixup' salts which contain ':' chars, or other
-// chars which cause problems (like the $ char).
-char *dynamic_FIX_SALT_TO_HEX(char *ciphertext) {
-	char *cp;
-	if (strncmp(ciphertext, "$dynamic_", 9))
-		return ciphertext;  // not a dynamic format, so we can not 'fix' it.
-	// ok, see if this is salted:
-	cp = strchr(&ciphertext[10+16], '$');
-	if (!cp)
-		return ciphertext;  // not a salted format.
-
-	// We will HAVE to get this much more functional.  But for now, we simply convert
-	// anything where we find a ':' or '$' or one of the line feed chars, in the salt,
-	// into a HEX string.  Otherwise the .pot file output can easily be 'broken'.
-	// it would be nice to also handle 'null' bytes (since some salts CAN have them), however
-	// since we are a C program, we already have problems with them. With recent changes
-	// in john, john CAN find them, but I do not think it can properly store them to pot
-	// file, unless the $HEX$ part is maintained (it may be maintained, I have to test that).
-	// Since the loader also strips trailing ' ' or '\t' characters,
-	// we need to convert to hex if the last character is either ' ' or '\t'.
-	++cp;
-	if ( strchr(cp, ':') || strchr(cp, '$') || strchr(cp, '\n') || strchr(cp, '\r') ||
-	     cp[strlen(cp) - 1] == ' ' || cp[strlen(cp) - 1] == '\t' ) {
-		// ok, we are going to convert to a 'HEX'  The length is length of ciphertext, the null, the HEX$ and 2 bytes per char of salt string.
-		char *cpx, *cpNew = mem_alloc_tiny(strlen(ciphertext) + 1 + 4 + strlen(cp), MEM_ALIGN_NONE);
-		cpx = cpNew;
-		// put the hash, including first '$' into the output string, AND the starting HEX$
-		cpx += sprintf(cpNew, "%*.*sHEX$", (int)(cp-ciphertext), (int)(cp-ciphertext), ciphertext);
-		while (*cp)
-			cpx += sprintf(cpx, "%02x", (unsigned char)(*cp++));
-		return cpNew;
-	}
-	return ciphertext;
-}
-
 #endif /* DYNAMIC_DISABLED */

--- a/src/formats.c
+++ b/src/formats.c
@@ -1939,7 +1939,7 @@ static void test_fmt_split_unifies_case_4(struct fmt_main *format, char *ciphert
 						good = 1;
 					if (!good) {
 						// white list.
-						if (!strncmp(ret, "@dynamic=", 9) ||
+						if (!strncmp(ret, "@dynamic=", 9) || strstr(ret, "$HEX$") ||
 						    (ret[0]=='$'&&ret[1]=='2'&&ret[3]=='$'&& (ret[2]=='a'||ret[2]=='b'||ret[2]=='x'||ret[2]=='y') ) )
 						{
 						} else

--- a/src/loader.c
+++ b/src/loader.c
@@ -1558,12 +1558,6 @@ static void ldr_show_left(struct db_main *db, struct db_password *pw)
 	char *pw_source = db->format->methods.source(pw->source, pw->binary);
 	char *login = (db->options->flags & DB_LOGIN) ? pw->login : "?";
 
-#ifndef DYNAMIC_DISABLED
-	/* Note for salted dynamic, we 'may' need to fix up the salts to
-	 * make them properly usable. */
-	if (!strncmp(pw_source, "$dynamic_", 9))
-		pw_source = dynamic_FIX_SALT_TO_HEX(pw_source);
-#endif
 	if (options.show_uid_in_cracks && pw->uid && *pw->uid) {
 		uid_sep[0] = db->options->field_sep_char;
 		uid_out = pw->uid;

--- a/src/logger.c
+++ b/src/logger.c
@@ -562,10 +562,6 @@ void log_guess(char *login, char *uid, char *ciphertext, char *rep_plain,
 	in_logger = 1;
 
 	if (pot.fd >= 0 && ciphertext ) {
-#ifndef DYNAMIC_DISABLED
-		if (!strncmp(ciphertext, "$dynamic_", 9))
-			ciphertext = dynamic_FIX_SALT_TO_HEX(ciphertext);
-#endif
 		if (options.secure) {
 			secret = components(store_plain, len);
 			count1 = (int)sprintf(pot.ptr,


### PR DESCRIPTION
We don't want unprintable ciphertexts in the pot file.

NULLs within a salt were already handled so I just extended that to include anything that's not printable ASCII.

I believe I also fixed a bug in the NULL handling (would be double-hex-encoded in the end) but I didn't bother verifying that. What I did verify was that the problems seen went away and I really don't expect any regression but the dynamic formats' code is a real mess.