### PR TITLE
tezos-opencl: Compute pkh with BLAKE2b on device, drop OpenMP

### DIFF
--- a/run/opencl/blake2_mjosref/LICENSE
+++ b/run/opencl/blake2_mjosref/LICENSE
@@ -1,0 +1,116 @@
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later
+claims of infringement build upon, modify, incorporate in other works, reuse
+and redistribute as freely as possible in any form whatsoever and for any
+purposes, including without limitation commercial purposes. These owners may
+contribute to the Commons to promote the ideal of a free culture and the
+further production of creative, cultural and scientific works, or to gain
+reputation or greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with a
+Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not limited
+to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display, communicate,
+  and translate a Work;
+
+  ii. moral rights retained by the original author(s) and/or performer(s);
+
+  iii. publicity and privacy rights pertaining to a person's image or likeness
+  depicted in a Work;
+
+  iv. rights protecting against unfair competition in regards to a Work,
+  subject to the limitations in paragraph 4(a), below;
+
+  v. rights protecting the extraction, dissemination, use and reuse of data in
+  a Work;
+
+  vi. database rights (such as those arising under Directive 96/9/EC of the
+  European Parliament and of the Council of 11 March 1996 on the legal
+  protection of databases, and under any national implementation thereof,
+  including any amended or successor version of such directive); and
+
+  vii. other similar, equivalent or corresponding rights throughout the world
+  based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number of
+copies, and (iv) for any purpose whatsoever, including without limitation
+commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+the Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such Waiver
+shall not be subject to revocation, rescission, cancellation, termination, or
+any other legal or equitable action to disrupt the quiet enjoyment of the Work
+by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account
+Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+is so judged Affirmer hereby grants to each affected person a royalty-free,
+non transferable, non sublicensable, non exclusive, irrevocable and
+unconditional license to exercise Affirmer's Copyright and Related Rights in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions), (iii)
+in any current or future medium and for any number of copies, and (iv) for any
+purpose whatsoever, including without limitation commercial, advertising or
+promotional purposes (the "License"). The License shall be deemed effective as
+of the date CC0 was applied by Affirmer to the Work. Should any part of the
+License for any reason be judged legally invalid or ineffective under
+applicable law, such partial invalidity or ineffectiveness shall not
+invalidate the remainder of the License, and in such case Affirmer hereby
+affirms that he or she will not (i) exercise any of his or her remaining
+Copyright and Related Rights in the Work or (ii) assert any associated claims
+and causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+  a. No trademark or patent rights held by Affirmer are waived, abandoned,
+  surrendered, licensed or otherwise affected by this document.
+
+  b. Affirmer offers the Work as-is and makes no representations or warranties
+  of any kind concerning the Work, express, implied, statutory or otherwise,
+  including without limitation warranties of title, merchantability, fitness
+  for a particular purpose, non infringement, or the absence of latent or
+  other defects, accuracy, or the present or absence of errors, whether or not
+  discoverable, all to the greatest extent permissible under applicable law.
+
+  c. Affirmer disclaims responsibility for clearing rights of other persons
+  that may apply to the Work or any use thereof, including without limitation
+  any person's Copyright and Related Rights in the Work. Further, Affirmer
+  disclaims responsibility for obtaining any necessary consents, permissions
+  or other rights required for any use of the Work.
+
+  d. Affirmer understands and acknowledges that Creative Commons is not a
+  party to this document and has no duty or obligation with respect to this
+  CC0 or use of the Work.
+
+For more information, please see
+<http://creativecommons.org/publicdomain/zero/1.0/>

--- a/run/opencl/blake2_mjosref/README.md
+++ b/run/opencl/blake2_mjosref/README.md
@@ -1,0 +1,10 @@
+# blake2_mjosref
+
+29-Jan-15  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+This is just an another -- somewhat smaller -- implementation of BLAKE2,
+written while working on the RFC text. Some stuff regarding parameter
+handling has been simplified. The API is little different from the 
+original Reference implementation (after consultation with BLAKE2 authors).
+
+See [blake2.net](https://blake2.net) for more information.

--- a/run/opencl/blake2_mjosref/README.md
+++ b/run/opencl/blake2_mjosref/README.md
@@ -8,3 +8,10 @@ handling has been simplified. The API is little different from the
 original Reference implementation (after consultation with BLAKE2 authors).
 
 See [blake2.net](https://blake2.net) for more information.
+
+# OpenCL
+
+This is a trivial port from C to OpenCL by Solar Designer.
+
+The filenames of original blake2_mjosref have been preserved to allow for easy
+"diff -ur" against the original.

--- a/run/opencl/blake2_mjosref/blake2b.c
+++ b/run/opencl/blake2_mjosref/blake2b.c
@@ -1,0 +1,181 @@
+// blake2b.c
+// A simple BLAKE2b Reference Implementation.
+
+#include "blake2b.h"
+
+// Cyclic right rotation.
+
+#ifndef ROTR64
+#define ROTR64(x, y)  (((x) >> (y)) ^ ((x) << (64 - (y))))
+#endif
+
+// Little-endian byte access.
+
+#define B2B_GET64(p)                            \
+    (((uint64_t) ((uint8_t *) (p))[0]) ^        \
+    (((uint64_t) ((uint8_t *) (p))[1]) << 8) ^  \
+    (((uint64_t) ((uint8_t *) (p))[2]) << 16) ^ \
+    (((uint64_t) ((uint8_t *) (p))[3]) << 24) ^ \
+    (((uint64_t) ((uint8_t *) (p))[4]) << 32) ^ \
+    (((uint64_t) ((uint8_t *) (p))[5]) << 40) ^ \
+    (((uint64_t) ((uint8_t *) (p))[6]) << 48) ^ \
+    (((uint64_t) ((uint8_t *) (p))[7]) << 56))
+
+// G Mixing function.
+
+#define B2B_G(a, b, c, d, x, y) {   \
+    v[a] = v[a] + v[b] + x;         \
+    v[d] = ROTR64(v[d] ^ v[a], 32); \
+    v[c] = v[c] + v[d];             \
+    v[b] = ROTR64(v[b] ^ v[c], 24); \
+    v[a] = v[a] + v[b] + y;         \
+    v[d] = ROTR64(v[d] ^ v[a], 16); \
+    v[c] = v[c] + v[d];             \
+    v[b] = ROTR64(v[b] ^ v[c], 63); }
+
+// Initialization Vector.
+
+static const uint64_t blake2b_iv[8] = {
+    0x6A09E667F3BCC908, 0xBB67AE8584CAA73B,
+    0x3C6EF372FE94F82B, 0xA54FF53A5F1D36F1,
+    0x510E527FADE682D1, 0x9B05688C2B3E6C1F,
+    0x1F83D9ABFB41BD6B, 0x5BE0CD19137E2179
+};
+
+// Compression function. "last" flag indicates last block.
+
+static void blake2b_compress(blake2b_ctx *ctx, int last)
+{
+    const uint8_t sigma[12][16] = {
+        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+        { 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 },
+        { 11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4 },
+        { 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8 },
+        { 9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13 },
+        { 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9 },
+        { 12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11 },
+        { 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10 },
+        { 6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5 },
+        { 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0 },
+        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+        { 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 }
+    };
+    int i;
+    uint64_t v[16], m[16];
+
+    for (i = 0; i < 8; i++) {           // init work variables
+        v[i] = ctx->h[i];
+        v[i + 8] = blake2b_iv[i];
+    }
+
+    v[12] ^= ctx->t[0];                 // low 64 bits of offset
+    v[13] ^= ctx->t[1];                 // high 64 bits
+    if (last)                           // last block flag set ?
+        v[14] = ~v[14];
+
+    for (i = 0; i < 16; i++)            // get little-endian words
+        m[i] = B2B_GET64(&ctx->b[8 * i]);
+
+    for (i = 0; i < 12; i++) {          // twelve rounds
+        B2B_G( 0, 4,  8, 12, m[sigma[i][ 0]], m[sigma[i][ 1]]);
+        B2B_G( 1, 5,  9, 13, m[sigma[i][ 2]], m[sigma[i][ 3]]);
+        B2B_G( 2, 6, 10, 14, m[sigma[i][ 4]], m[sigma[i][ 5]]);
+        B2B_G( 3, 7, 11, 15, m[sigma[i][ 6]], m[sigma[i][ 7]]);
+        B2B_G( 0, 5, 10, 15, m[sigma[i][ 8]], m[sigma[i][ 9]]);
+        B2B_G( 1, 6, 11, 12, m[sigma[i][10]], m[sigma[i][11]]);
+        B2B_G( 2, 7,  8, 13, m[sigma[i][12]], m[sigma[i][13]]);
+        B2B_G( 3, 4,  9, 14, m[sigma[i][14]], m[sigma[i][15]]);
+    }
+
+    for( i = 0; i < 8; ++i )
+        ctx->h[i] ^= v[i] ^ v[i + 8];
+}
+
+// Initialize the hashing context "ctx" with optional key "key".
+//      1 <= outlen <= 64 gives the digest size in bytes.
+//      Secret key (also <= 64 bytes) is optional (keylen = 0).
+
+int blake2b_init(blake2b_ctx *ctx, size_t outlen,
+    const void *key, size_t keylen)        // (keylen=0: no key)
+{
+    size_t i;
+
+    if (outlen == 0 || outlen > 64 || keylen > 64)
+        return -1;                      // illegal parameters
+
+    for (i = 0; i < 8; i++)             // state, "param block"
+        ctx->h[i] = blake2b_iv[i];
+    ctx->h[0] ^= 0x01010000 ^ (keylen << 8) ^ outlen;
+
+    ctx->t[0] = 0;                      // input count low word
+    ctx->t[1] = 0;                      // input count high word
+    ctx->c = 0;                         // pointer within buffer
+    ctx->outlen = outlen;
+
+    for (i = keylen; i < 128; i++)      // zero input block
+        ctx->b[i] = 0;
+    if (keylen > 0) {
+        blake2b_update(ctx, key, keylen);
+        ctx->c = 128;                   // at the end
+    }
+
+    return 0;
+}
+
+// Add "inlen" bytes from "in" into the hash.
+
+void blake2b_update(blake2b_ctx *ctx,
+    const void *in, size_t inlen)       // data bytes
+{
+    size_t i;
+
+    for (i = 0; i < inlen; i++) {
+        if (ctx->c == 128) {            // buffer full ?
+            ctx->t[0] += ctx->c;        // add counters
+            if (ctx->t[0] < ctx->c)     // carry overflow ?
+                ctx->t[1]++;            // high word
+            blake2b_compress(ctx, 0);   // compress (not last)
+            ctx->c = 0;                 // counter to zero
+        }
+        ctx->b[ctx->c++] = ((const uint8_t *) in)[i];
+    }
+}
+
+// Generate the message digest (size given in init).
+//      Result placed in "out".
+
+void blake2b_final(blake2b_ctx *ctx, void *out)
+{
+    size_t i;
+
+    ctx->t[0] += ctx->c;                // mark last block offset
+    if (ctx->t[0] < ctx->c)             // carry overflow
+        ctx->t[1]++;                    // high word
+
+    while (ctx->c < 128)                // fill up with zeros
+        ctx->b[ctx->c++] = 0;
+    blake2b_compress(ctx, 1);           // final block flag = 1
+
+    // little endian convert and store
+    for (i = 0; i < ctx->outlen; i++) {
+        ((uint8_t *) out)[i] =
+            (ctx->h[i >> 3] >> (8 * (i & 7))) & 0xFF;
+    }
+}
+
+// Convenience function for all-in-one computation.
+
+int blake2b(void *out, size_t outlen,
+    const void *key, size_t keylen,
+    const void *in, size_t inlen)
+{
+    blake2b_ctx ctx;
+
+    if (blake2b_init(&ctx, outlen, key, keylen))
+        return -1;
+    blake2b_update(&ctx, in, inlen);
+    blake2b_final(&ctx, out);
+
+    return 0;
+}
+

--- a/run/opencl/blake2_mjosref/blake2b.c
+++ b/run/opencl/blake2_mjosref/blake2b.c
@@ -5,7 +5,7 @@
 
 // Cyclic right rotation.
 
-#ifndef ROTR64
+#if 0 // was "#ifndef ROTR64", but we currently prefer to fail
 #define ROTR64(x, y)  (((x) >> (y)) ^ ((x) << (64 - (y))))
 #endif
 
@@ -35,7 +35,7 @@
 
 // Initialization Vector.
 
-static const uint64_t blake2b_iv[8] = {
+static __constant uint64_t blake2b_iv[8] = {
     0x6A09E667F3BCC908, 0xBB67AE8584CAA73B,
     0x3C6EF372FE94F82B, 0xA54FF53A5F1D36F1,
     0x510E527FADE682D1, 0x9B05688C2B3E6C1F,

--- a/run/opencl/blake2_mjosref/blake2b.h
+++ b/run/opencl/blake2_mjosref/blake2b.h
@@ -1,0 +1,39 @@
+// blake2b.h
+// BLAKE2b Hashing Context and API Prototypes
+
+#ifndef BLAKE2B_H
+#define BLAKE2B_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+// state context
+typedef struct {
+    uint8_t b[128];                     // input buffer
+    uint64_t h[8];                      // chained state
+    uint64_t t[2];                      // total number of bytes
+    size_t c;                           // pointer for b[]
+    size_t outlen;                      // digest size
+} blake2b_ctx;
+
+// Initialize the hashing context "ctx" with optional key "key".
+//      1 <= outlen <= 64 gives the digest size in bytes.
+//      Secret key (also <= 64 bytes) is optional (keylen = 0).
+int blake2b_init(blake2b_ctx *ctx, size_t outlen,
+    const void *key, size_t keylen);    // secret key
+
+// Add "inlen" bytes from "in" into the hash.
+void blake2b_update(blake2b_ctx *ctx,   // context
+    const void *in, size_t inlen);      // data to be hashed
+
+// Generate the message digest (size given in init).
+//      Result placed in "out".
+void blake2b_final(blake2b_ctx *ctx, void *out);
+
+// All-in-one convenience function.
+int blake2b(void *out, size_t outlen,   // return buffer for digest
+    const void *key, size_t keylen,     // optional secret key
+    const void *in, size_t inlen);      // data to be hashed
+
+#endif
+

--- a/run/opencl/blake2_mjosref/blake2b.h
+++ b/run/opencl/blake2_mjosref/blake2b.h
@@ -4,9 +4,6 @@
 #ifndef BLAKE2B_H
 #define BLAKE2B_H
 
-#include <stdint.h>
-#include <stddef.h>
-
 // state context
 typedef struct {
     uint8_t b[128];                     // input buffer

--- a/run/opencl/ed25519-donna/curve25519-donna-32bit.h
+++ b/run/opencl/ed25519-donna/curve25519-donna-32bit.h
@@ -324,7 +324,7 @@ curve25519_square(bignum25519 out, const bignum25519 in) {
 static void
 curve25519_mul_const(bignum25519 out, const bignum25519 a, __constant uint32_t *b) {
 	bignum25519 bpvt;
-	memcpy_cp(bpvt, b, sizeof(bpvt));
+	memcpy_macro(bpvt, b, sizeof(bpvt) / sizeof(bpvt[0]));
 	curve25519_mul(out, a, bpvt);
 }
 

--- a/run/opencl/ed25519-donna/ed25519-hash.h
+++ b/run/opencl/ed25519-donna/ed25519-hash.h
@@ -1,3 +1,4 @@
+#if 0
 #include "../opencl_sha2_ctx.h"
 
 static void
@@ -8,3 +9,44 @@ ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {
 	SHA512_Update(&ctx, in, inlen);
 	SHA512_Final(hash, &ctx);
 }
+#else
+#include "../opencl_sha2.h"
+
+static void
+ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {
+	ulong W[16];
+	ulong A, B, C, D, E, F, G, H, t;
+
+	A = SHA2_INIT_A;
+	B = SHA2_INIT_B;
+	C = SHA2_INIT_C;
+	D = SHA2_INIT_D;
+	E = SHA2_INIT_E;
+	F = SHA2_INIT_F;
+	G = SHA2_INIT_G;
+	H = SHA2_INIT_H;
+
+	/* Assume inlen is 32 */
+	GET_UINT64BE(W[0], in, 0);
+	GET_UINT64BE(W[1], in, 8);
+	GET_UINT64BE(W[2], in, 16);
+	GET_UINT64BE(W[3], in, 24);
+	W[4] = 0x8000000000000000UL;
+	W[5] = 0;
+	W[6] = 0;
+	W[7] = 0;
+	W[8] = 0;
+	W[15] = 32 << 3;
+
+	SHA512_ZEROS(A, B, C, D, E, F, G, H, W);
+
+	PUT_UINT64BE(A + SHA2_INIT_A, hash, 0);
+	PUT_UINT64BE(B + SHA2_INIT_B, hash, 8);
+	PUT_UINT64BE(C + SHA2_INIT_C, hash, 16);
+	PUT_UINT64BE(D + SHA2_INIT_D, hash, 24);
+	PUT_UINT64BE(E + SHA2_INIT_E, hash, 32);
+	PUT_UINT64BE(F + SHA2_INIT_F, hash, 40);
+	PUT_UINT64BE(G + SHA2_INIT_G, hash, 48);
+	PUT_UINT64BE(H + SHA2_INIT_H, hash, 56);
+}
+#endif

--- a/run/opencl/opencl_sha2.h
+++ b/run/opencl/opencl_sha2.h
@@ -259,7 +259,6 @@ __constant uint k[] = {
 	ROUND_A(B,C,D,E,F,G,H,A,k[15],W[15]); \
 	SHA256_16to63(A,B,C,D,E,F,G,H,W)
 
-#define Z (0)
 //W[9]-W[14] are zeros
 #define SHA256_ZEROS(A,B,C,D,E,F,G,H,W)	  \
 	ROUND_A(A,B,C,D,E,F,G,H,k[0],W[0]); \
@@ -278,21 +277,21 @@ __constant uint k[] = {
 	ROUND_Z(D,E,F,G,H,A,B,C,k[13]); \
 	ROUND_Z(C,D,E,F,G,H,A,B,k[14]); \
 	ROUND_A(B,C,D,E,F,G,H,A,k[15],W[15]); \
-	ROUND_I(A,B,C,D,E,F,G,H,k[16],W[0],  Z,W[1],W[0],Z) \
-	ROUND_J(H,A,B,C,D,E,F,G,k[17],W[1],  W[15],W[2],W[1],Z) \
-	ROUND_J(G,H,A,B,C,D,E,F,k[18],W[2],  W[0],W[3],W[2],Z) \
-	ROUND_J(F,G,H,A,B,C,D,E,k[19],W[3],  W[1],W[4],W[3],Z) \
-	ROUND_J(E,F,G,H,A,B,C,D,k[20],W[4],  W[2],W[5],W[4],Z) \
-	ROUND_J(D,E,F,G,H,A,B,C,k[21],W[5],  W[3],W[6],W[5],Z) \
+	ROUND_I(A,B,C,D,E,F,G,H,k[16],W[0],  0,W[1],W[0],0) \
+	ROUND_J(H,A,B,C,D,E,F,G,k[17],W[1],  W[15],W[2],W[1],0) \
+	ROUND_J(G,H,A,B,C,D,E,F,k[18],W[2],  W[0],W[3],W[2],0) \
+	ROUND_J(F,G,H,A,B,C,D,E,k[19],W[3],  W[1],W[4],W[3],0) \
+	ROUND_J(E,F,G,H,A,B,C,D,k[20],W[4],  W[2],W[5],W[4],0) \
+	ROUND_J(D,E,F,G,H,A,B,C,k[21],W[5],  W[3],W[6],W[5],0) \
 	ROUND_B(C,D,E,F,G,H,A,B,k[22],W[6],  W[4],W[7],W[6],W[15]) \
 	ROUND_B(B,C,D,E,F,G,H,A,k[23],W[7],  W[5],W[8],W[7],W[0]) \
-	ROUND_K(A,B,C,D,E,F,G,H,k[24],W[8],  W[6],Z,W[8],W[1]) \
-	ROUND_L(H,A,B,C,D,E,F,G,k[25],W[9],  W[7],Z,Z,W[2]) \
-	ROUND_L(G,H,A,B,C,D,E,F,k[26],W[10],  W[8],Z,Z,W[3]) \
-	ROUND_L(F,G,H,A,B,C,D,E,k[27],W[11],  W[9],Z,Z,W[4]) \
-	ROUND_L(E,F,G,H,A,B,C,D,k[28],W[12],  W[10],Z,Z,W[5]) \
-	ROUND_L(D,E,F,G,H,A,B,C,k[29],W[13],  W[11],Z,Z,W[6]) \
-	ROUND_M(C,D,E,F,G,H,A,B,k[30],W[14],  W[12],W[15],Z,W[7]) \
+	ROUND_K(A,B,C,D,E,F,G,H,k[24],W[8],  W[6],0,W[8],W[1]) \
+	ROUND_L(H,A,B,C,D,E,F,G,k[25],W[9],  W[7],0,0,W[2]) \
+	ROUND_L(G,H,A,B,C,D,E,F,k[26],W[10],  W[8],0,0,W[3]) \
+	ROUND_L(F,G,H,A,B,C,D,E,k[27],W[11],  W[9],0,0,W[4]) \
+	ROUND_L(E,F,G,H,A,B,C,D,k[28],W[12],  W[10],0,0,W[5]) \
+	ROUND_L(D,E,F,G,H,A,B,C,k[29],W[13],  W[11],0,0,W[6]) \
+	ROUND_M(C,D,E,F,G,H,A,B,k[30],W[14],  W[12],W[15],0,W[7]) \
 	ROUND_B(B,C,D,E,F,G,H,A,k[31],W[15],  W[13],W[0],W[15],W[8]) \
 	SHA256_32to63(A,B,C,D,E,F,G,H,W)
 
@@ -624,7 +623,6 @@ __constant ulong K[] = {
 	ROUND512_A(B,C,D,E,F,G,H,A,K[15],W[15]) \
 	SHA512_16to79(A,B,C,D,E,F,G,H,W)
 
-#define z 0UL
 //W[9]-W[14] are zeros
 #define SHA512_ZEROS(A, B, C, D, E, F, G, H, W)	  \
 	ROUND512_A(A,B,C,D,E,F,G,H,K[0],W[0]) \
@@ -643,21 +641,21 @@ __constant ulong K[] = {
 	ROUND512_Z(D,E,F,G,H,A,B,C,K[13]) \
 	ROUND512_Z(C,D,E,F,G,H,A,B,K[14]) \
 	ROUND512_A(B,C,D,E,F,G,H,A,K[15],W[15]) \
-	ROUND512_B(A,B,C,D,E,F,G,H,K[16],W[0],  z,W[1],W[0],z) \
-	ROUND512_B(H,A,B,C,D,E,F,G,K[17],W[1],  W[15],W[2],W[1],z) \
-	ROUND512_B(G,H,A,B,C,D,E,F,K[18],W[2],  W[0],W[3],W[2],z) \
-	ROUND512_B(F,G,H,A,B,C,D,E,K[19],W[3],  W[1],W[4],W[3],z) \
-	ROUND512_B(E,F,G,H,A,B,C,D,K[20],W[4],  W[2],W[5],W[4],z) \
-	ROUND512_B(D,E,F,G,H,A,B,C,K[21],W[5],  W[3],W[6],W[5],z) \
+	ROUND512_B(A,B,C,D,E,F,G,H,K[16],W[0],  0UL,W[1],W[0],0UL) \
+	ROUND512_B(H,A,B,C,D,E,F,G,K[17],W[1],  W[15],W[2],W[1],0UL) \
+	ROUND512_B(G,H,A,B,C,D,E,F,K[18],W[2],  W[0],W[3],W[2],0UL) \
+	ROUND512_B(F,G,H,A,B,C,D,E,K[19],W[3],  W[1],W[4],W[3],0UL) \
+	ROUND512_B(E,F,G,H,A,B,C,D,K[20],W[4],  W[2],W[5],W[4],0UL) \
+	ROUND512_B(D,E,F,G,H,A,B,C,K[21],W[5],  W[3],W[6],W[5],0UL) \
 	ROUND512_B(C,D,E,F,G,H,A,B,K[22],W[6],  W[4],W[7],W[6],W[15]) \
 	ROUND512_B(B,C,D,E,F,G,H,A,K[23],W[7],  W[5],W[8],W[7],W[0]) \
-	ROUND512_B(A,B,C,D,E,F,G,H,K[24],W[8],  W[6],z,W[8],W[1]) \
-	ROUND512_B(H,A,B,C,D,E,F,G,K[25],W[9],  W[7],z,z,W[2]) \
-	ROUND512_B(G,H,A,B,C,D,E,F,K[26],W[10],  W[8],z,z,W[3]) \
-	ROUND512_B(F,G,H,A,B,C,D,E,K[27],W[11],  W[9],z,z,W[4]) \
-	ROUND512_B(E,F,G,H,A,B,C,D,K[28],W[12],  W[10],z,z,W[5]) \
-	ROUND512_B(D,E,F,G,H,A,B,C,K[29],W[13],  W[11],z,z,W[6]) \
-	ROUND512_B(C,D,E,F,G,H,A,B,K[30],W[14],  W[12],W[15],z,W[7]) \
+	ROUND512_B(A,B,C,D,E,F,G,H,K[24],W[8],  W[6],0UL,W[8],W[1]) \
+	ROUND512_B(H,A,B,C,D,E,F,G,K[25],W[9],  W[7],0UL,0UL,W[2]) \
+	ROUND512_B(G,H,A,B,C,D,E,F,K[26],W[10],  W[8],0UL,0UL,W[3]) \
+	ROUND512_B(F,G,H,A,B,C,D,E,K[27],W[11],  W[9],0UL,0UL,W[4]) \
+	ROUND512_B(E,F,G,H,A,B,C,D,K[28],W[12],  W[10],0UL,0UL,W[5]) \
+	ROUND512_B(D,E,F,G,H,A,B,C,K[29],W[13],  W[11],0UL,0UL,W[6]) \
+	ROUND512_B(C,D,E,F,G,H,A,B,K[30],W[14],  W[12],W[15],0UL,W[7]) \
 	ROUND512_B(B,C,D,E,F,G,H,A,K[31],W[15],  W[13],W[0],W[15],W[8]) \
 	SHA512_32to79(A,B,C,D,E,F,G,H,W)
 

--- a/run/opencl/tezos_kernel.cl
+++ b/run/opencl/tezos_kernel.cl
@@ -201,7 +201,7 @@ __kernel void pbkdf2_sha512_tezos_final(__global const crack_t *in, __global tez
 	} sk;
 	ed25519_public_key pk;
 	uint idx = get_global_id(0);
-	memcpy_gp(&sk, in[idx].hash, sizeof(sk));
+	memcpy_macro(sk.u64, in[idx].hash, 4);
 	for (int i = 0; i < 4; i++)
 		sk.u64[i] = SWAP64(sk.u64[i]);
 	ed25519_publickey(sk.uc, pk);

--- a/run/opencl/tezos_kernel.cl
+++ b/run/opencl/tezos_kernel.cl
@@ -190,7 +190,6 @@ __kernel void pbkdf2_sha512_tezos_init(__global const pass_t *inbuffer,
 	}
 }
 
-#undef z /* was defined by opencl_sha2.h and used in SHA256_ZEROS, but conflicts with the below */
 #include "ed25519-donna/ed25519-donna.c"
 
 __kernel void pbkdf2_sha512_tezos_final(__global const crack_t *in, __global tezos_pk_t *out)

--- a/src/opencl_tezos_fmt_plug.c
+++ b/src/opencl_tezos_fmt_plug.c
@@ -21,9 +21,6 @@ john_register_one(&fmt_opencl_tezos);
 
 #include <stdint.h>
 #include <string.h>
-#ifdef _OPENMP
-#include <omp.h>
-#endif
 
 #include "misc.h"
 #include "common.h"
@@ -345,16 +342,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	WAIT_DONE
 
 	if (!ocl_autotune_running) {
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
 		for (index = 0; index < count; index++) {
 			if (!memcmp(cur_salt->raw_address + 2, host_pkh[index].pkh, 20)) {
 				cracked[index] = 1;
-#ifdef _OPENMP
-#pragma omp atomic
-#endif
-				any_cracked |= 1;
+				any_cracked = 1;
 			}
 		}
 	}
@@ -412,7 +403,7 @@ struct fmt_main fmt_opencl_tezos = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
+		FMT_CASE | FMT_8_BIT | FMT_HUGE_INPUT,
 		{ NULL },
 		{ FORMAT_TAG },
 		tezos_tests


### PR DESCRIPTION
This has many commits with incremental improvements of tezos-opencl and the shared/shareable OpenCL files that it uses.