### PR TITLE
tezos-opencl: Compare pkh on device

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -247,6 +247,11 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Added support for ENCDataVault and encdatavault2john.py script [sylvainpelissier; 2021]
 
+- Optimize tezos-opencl by computing ed25519_publickey() and BLAKE2b on-device,
+  removing the CPU bottleneck.  This work was funded by the Tezos Foundation.
+  [Solar; 2021]
+
+
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 
 - Updated to 1.9.0 core, which brought the following relevant major changes:

--- a/run/opencl/ed25519-donna/README
+++ b/run/opencl/ed25519-donna/README
@@ -6,4 +6,5 @@ come from a previously #include'ed file before a #include of ed25519-donna.c.
 The filenames of original ed25519-donna have been preserved to allow for easy
 "diff -ur" against the original.
 
-The code stays in the public domain.
+The porting to OpenCL was funded by the Tezos Foundation, and the code stays in
+the public domain.

--- a/run/opencl/tezos_kernel.cl
+++ b/run/opencl/tezos_kernel.cl
@@ -1,10 +1,14 @@
 /*
- * This software is Copyright (c) 2018 Dhiru Kholia
+ * This software is
+ * Copyright (c) 2018 Dhiru Kholia
  * Copyright (c) 2019-2020 magnum
  * Copyright (c) 2021 Solar Designer
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
+ *
+ * Update to implement and use on-device ed25519_publickey() and BLAKE2b for
+ * great speedup was funded by the Tezos Foundation.
  */
 
 #include "pbkdf2_hmac_sha512_kernel.cl"

--- a/src/opencl_tezos_fmt_plug.c
+++ b/src/opencl_tezos_fmt_plug.c
@@ -8,6 +8,9 @@
  * modification, are permitted.
  *
  * Based on opencl_pbkdf2_hmac_sha512_fmt_plug.c file.
+ *
+ * Update to implement and use on-device ed25519_publickey() and BLAKE2b for
+ * great speedup was funded by the Tezos Foundation.
  */
 
 #include "arch.h"


### PR DESCRIPTION
This moves the pkh comparison from host to device, and transfers only one `uint` back most of the time.

As implemented, on a successful crack this re-transfers the entire zeroized `cracked` from host to device. Alternatively, we could re-transfer only one `uint` `*cracked`, but have the final kernel (re)set each other element of `cracked` each time it's run. This alternative approach would actually use more global memory bandwidth in the typical case of nothing getting cracked in a long time. However, it would also have the advantage of avoiding incorrect cracks in case something in `mem_final` on device side becomes non-zero by accident during a very long run. I have no clear preference here.