### PR TITLE
Unicode formats with GPU-side encoding: Truncation matching

### DIFF
--- a/src/opencl_DES_bs_plug.c
+++ b/src/opencl_DES_bs_plug.c
@@ -14,7 +14,7 @@
 #include "common.h"
 #include "opencl_DES_bs.h"
 #include "../run/opencl/opencl_DES_hst_dev_shared.h"
-#include "unicode.h"
+#include "options.h"
 #include "bt_interface.h"
 #include "mask_ext.h"
 #include "logger.h"

--- a/src/opencl_axcrypt2_fmt_plug.c
+++ b/src/opencl_axcrypt2_fmt_plug.c
@@ -26,7 +26,6 @@ john_register_one(&fmt_opencl_axcrypt2);
 #include "common.h"
 #include "formats.h"
 #include "options.h"
-#include "unicode.h"
 #include "opencl_common.h"
 #include "axcrypt_common.h"
 #define VERSION_2_SUPPORT 1

--- a/src/opencl_diskcryptor_aes_fmt_plug.c
+++ b/src/opencl_diskcryptor_aes_fmt_plug.c
@@ -359,6 +359,10 @@ static void set_key(char *key, int index)
 
 static char *get_key(int index)
 {
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like how the GPU got it. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)orig_key[index], PLAINTEXT_LENGTH);
+
 	return orig_key[index];
 }
 

--- a/src/opencl_diskcryptor_fmt_plug.c
+++ b/src/opencl_diskcryptor_fmt_plug.c
@@ -369,6 +369,10 @@ static void set_key(char *key, int index)
 
 static char *get_key(int index)
 {
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like how the GPU got it. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)orig_key[index], PLAINTEXT_LENGTH);
+
 	return orig_key[index];
 }
 

--- a/src/opencl_krb5pa-md5_fmt_plug.c
+++ b/src/opencl_krb5pa-md5_fmt_plug.c
@@ -628,6 +628,10 @@ static char *get_key(int index)
 				mask_int_cand.int_cand[int_index].x[i];
 	}
 
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)out, PLAINTEXT_LENGTH);
+
 	return out;
 }
 

--- a/src/opencl_mscash2_fmt_plug.c
+++ b/src/opencl_mscash2_fmt_plug.c
@@ -186,6 +186,10 @@ static void set_key(char *key, int index) {
 }
 
 static  char *get_key(int index) {
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)key_host[index], MAX_PLAINTEXT_LENGTH);
+
 	return (char *)key_host[index] ;
 }
 

--- a/src/opencl_mscash_fmt_plug.c
+++ b/src/opencl_mscash_fmt_plug.c
@@ -448,6 +448,10 @@ static char *get_key(int index)
 				mask_int_cand.int_cand[int_index].x[i];
 	}
 
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)out, PLAINTEXT_LENGTH);
+
 	return out;
 }
 

--- a/src/opencl_nt_fmt_plug.c
+++ b/src/opencl_nt_fmt_plug.c
@@ -528,6 +528,10 @@ static char *get_key(int index)
 				mask_int_cand.int_cand[int_index].x[i];
 	}
 
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)out, PLAINTEXT_LENGTH);
+
 	return out;
 }
 

--- a/src/opencl_ntlmv2_fmt_plug.c
+++ b/src/opencl_ntlmv2_fmt_plug.c
@@ -669,6 +669,10 @@ static char *get_key(int index)
 				mask_int_cand.int_cand[int_index].x[i];
 	}
 
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)out, PLAINTEXT_LENGTH);
+
 	return out;
 }
 

--- a/src/opencl_oldoffice_fmt_plug.c
+++ b/src/opencl_oldoffice_fmt_plug.c
@@ -670,6 +670,10 @@ static char *get_key(int index)
 					mask_int_cand.int_cand[int_index].x[i];
 	}
 
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)out, PLAINTEXT_LENGTH);
+
 	return (char*)ret;
 }
 

--- a/src/opencl_pfx_fmt_plug.c
+++ b/src/opencl_pfx_fmt_plug.c
@@ -240,6 +240,11 @@ static char *get_key(int index)
 	uint32_t length = inbuffer[index].length;
 	memcpy(ret, inbuffer[index].v, length);
 	ret[length] = '\0';
+
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)ret, PLAINTEXT_LENGTH);
+
 	return ret;
 }
 

--- a/src/opencl_sappse_fmt_plug.c
+++ b/src/opencl_sappse_fmt_plug.c
@@ -215,6 +215,10 @@ static char *get_key(int index)
 	memcpy(ret, inbuffer[index].v, length);
 	ret[length] = '\0';
 
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)ret, PLAINTEXT_LENGTH);
+
 	return ret;
 }
 

--- a/src/opencl_zed_fmt_plug.c
+++ b/src/opencl_zed_fmt_plug.c
@@ -210,6 +210,11 @@ static char *get_key(int index)
 
 	memcpy(ret, inbuffer[index].v, length);
 	ret[length] = '\0';
+
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)ret, PLAINTEXT_LENGTH);
+
 	return ret;
 }
 

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -454,15 +454,15 @@ inline unsigned int strlen16(const UTF16 *str)
 
 /*
  * Strlen of UTF-8 (in characters, not octets).
- * Will return a "truncated" length if fed with bad data.
+ * Will return a "truncated" length (negative) if fed with bad data.
  */
-inline unsigned int strlen8(const UTF8 *source)
+inline int strlen8(const UTF8 *source)
 {
 	int targetLen = 0;
 	const UTF8 *sourceEnd = source + strlen((char*)source);
 	unsigned int extraBytesToRead;
 
-	while (source < sourceEnd) {
+	while (*source && source < sourceEnd) {
 		if (*source < 0xC0) {
 			source++;
 			targetLen++;
@@ -470,22 +470,44 @@ inline unsigned int strlen8(const UTF8 *source)
 				break;
 			continue;
 		}
-/*
- * The original code in ConvertUTF.c has a much larger (slower) lookup table
- * including zeros. This point must not be reached with *source < 0xC0
- */
-		extraBytesToRead =
-		    opt_trailingBytesUTF8[*source & 0x3f];
-		if ((source + extraBytesToRead >= sourceEnd) ||
-		    (extraBytesToRead > 3)) {
-			return targetLen;
-		}
+		extraBytesToRead = opt_trailingBytesUTF8[*source & 0x3f];
+		if ((source + extraBytesToRead >= sourceEnd) || (extraBytesToRead > 3))
+			return -targetLen;
 		source += extraBytesToRead + 1;
 		targetLen++;
-		if (*source == 0 || source >= sourceEnd)
+		if (source >= sourceEnd)
 			break;
 	}
 	return targetLen;
+}
+/*
+ * Truncate (in place) a UTF-8 string at position 'len' (in characters, not octets), or when
+ * invalid UTF-8 is seen (using the same Q'n'D logic that the kernels do).
+ */
+inline void truncate_utf8(UTF8 *string, int len)
+{
+	int targetLen = 0;
+	const UTF8 *stringEnd = string + strlen((char*)string);
+	unsigned int extraBytesToRead;
+
+	while (*string && string < stringEnd && *string && targetLen < len) {
+		if (*string < 0xC0) {
+			string++;
+			targetLen++;
+			continue;
+		}
+		extraBytesToRead = opt_trailingBytesUTF8[*string & 0x3f];
+		if ((string + extraBytesToRead >= stringEnd) || (extraBytesToRead > 3)) {
+			*string = 0;
+			return;
+		}
+		string += extraBytesToRead + 1;
+		targetLen++;
+		if (string >= stringEnd)
+			break;
+	}
+	if (targetLen >= len)
+		*string = 0;
 }
 
 /*

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -204,9 +204,14 @@ extern size_t strlen_any(const void* str);
 
 /*
  * Return length (in characters) of a UTF-8 string
- * Will return a "truncated" length if fed with invalid data.
+ * Will return a "truncated" length (negative) if fed with invalid data.
  */
-extern unsigned int strlen8(const UTF8 *source);
+extern int strlen8(const UTF8 *source);
+
+/*
+ * Truncate (in place) a UTF-8 string at position 'len' (in characters, not octets).
+ */
+extern void truncate_utf8(UTF8 *string, int len);
 
 /*
  * Check if a string is valid UTF-8.  Returns true if the string is valid


### PR DESCRIPTION
The cracking modes can't afford exact rejecting based on multibyte candidate length, so simply allows eg. 81 bytes for a format that can process up to 27 Unicode characters.

The formats then truncate correctly (can also happen due to invalid UTF-8) and sometimes the truncated candidate ends up in "unintended" cracking.

When this happens, we must ensure that get_key() truncates the same way as the GPU code did, in order to report the correct candidate.

Closes #4965