### PR TITLE
OpenCL formats: New keys review

### DIFF
--- a/src/opencl_agilekeychain_fmt_plug.c
+++ b/src/opencl_agilekeychain_fmt_plug.c
@@ -70,6 +70,7 @@ typedef struct {
 } agile_salt;
 
 static struct custom_salt *cur_salt;
+static int new_keys;
 
 static cl_int cl_error;
 static agile_password *inbuffer;
@@ -217,6 +218,8 @@ static void set_key(char *key, int index)
 		length = PLAINTEXT_LENGTH;
 	inbuffer[index].length = length;
 	memcpy(inbuffer[index].v, key, length);
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -236,9 +239,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-	        "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,

--- a/src/opencl_androidbackup_fmt_plug.c
+++ b/src/opencl_androidbackup_fmt_plug.c
@@ -280,7 +280,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_ansible_fmt_plug.c
+++ b/src/opencl_ansible_fmt_plug.c
@@ -55,6 +55,7 @@ static cl_int cl_error;
 static cl_mem mem_in, mem_out, mem_salt, mem_state;
 static cl_kernel split_kernel, final_kernel;
 static struct fmt_main *self;
+static int new_keys;
 
 static struct custom_salt *cur_salt;
 
@@ -215,9 +216,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
-		NULL, multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
+			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+			NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
@@ -270,6 +275,8 @@ static void set_key(char *key, int index)
 
 	memcpy(host_pass[index].v, key, saved_len);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_axcrypt2_fmt_plug.c
+++ b/src/opencl_axcrypt2_fmt_plug.c
@@ -86,6 +86,7 @@ typedef struct {
 } out_t;
 
 static struct custom_salt *cur_salt;
+static int new_keys;
 
 static pass_t *host_pass;
 static axcrypt2_salt_t *host_salt;
@@ -317,10 +318,14 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-				gws * sizeof(pass_t), host_pass,
-				0, NULL, multi_profilingEvent[0]),
-				"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			gws * sizeof(pass_t), host_pass,
+			0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run standard PBKDF2 kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
@@ -376,6 +381,8 @@ static void set_key(char *key, int index)
 	// ^= the whole uint64 with the ipad/opad mask
 	strncpy((char*)host_pass[index].v, key, PLAINTEXT_LENGTH);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_bitwarden_fmt_plug.c
+++ b/src/opencl_bitwarden_fmt_plug.c
@@ -61,6 +61,7 @@ static struct fmt_main *self;
 
 static unsigned int *cracked, cracked_size;
 static struct custom_salt *cur_salt;
+static int new_keys;
 
 #define STEP			0
 #define SEED			1024
@@ -232,9 +233,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
-		NULL, multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
+			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+			NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
@@ -288,6 +293,8 @@ static void set_key(char *key, int index)
 
 	memcpy(host_pass[index].v, key, saved_len);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_blockchain_fmt_plug.c
+++ b/src/opencl_blockchain_fmt_plug.c
@@ -253,7 +253,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
 			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
 				"Copy data to gpu");

--- a/src/opencl_dashlane_fmt_plug.c
+++ b/src/opencl_dashlane_fmt_plug.c
@@ -273,7 +273,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	}
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_diskcryptor_fmt_plug.c
+++ b/src/opencl_diskcryptor_fmt_plug.c
@@ -99,6 +99,7 @@ static struct fmt_main *self;
 
 static int any_cracked, *cracked;
 static size_t cracked_size;
+static int new_keys;
 
 #define STEP			0
 #define SEED			256
@@ -285,9 +286,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	}
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		gws * sizeof(pass_t), host_pass, 0, NULL,
-		multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			gws * sizeof(pass_t), host_pass, 0, NULL,
+			multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
@@ -365,6 +370,8 @@ static void set_key(char *key, int index)
 	if (len < 0)
 		len = strlen16((UTF16 *)host_pass[index].v);
 	host_pass[index].length = len << 1;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_dmg_fmt_plug.c
+++ b/src/opencl_dmg_fmt_plug.c
@@ -498,7 +498,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_electrum_modern_fmt_plug.c
+++ b/src/opencl_electrum_modern_fmt_plug.c
@@ -111,6 +111,7 @@ typedef struct {
 	cl_uint rounds;
 } state_t;
 
+static int new_keys;
 static pass_t *host_pass;			      /** plain ciphertexts **/
 static salt_t *host_salt;			      /** salt **/
 static crack_t *host_crack;			      /** cracked or no **/
@@ -379,9 +380,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		global_work_size * sizeof(pass_t), host_pass, 0, NULL,
-		multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			global_work_size * sizeof(pass_t), host_pass, 0, NULL,
+			multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
@@ -511,6 +516,8 @@ static void set_key(char *key, int index)
 	// ^= the whole uint64 with the ipad/opad mask
 	strncpy((char*)host_pass[index].v, key, PLAINTEXT_LENGTH);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_encfs_fmt_plug.c
+++ b/src/opencl_encfs_fmt_plug.c
@@ -291,7 +291,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_enpass_fmt_plug.c
+++ b/src/opencl_enpass_fmt_plug.c
@@ -329,7 +329,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_ethereum_fmt_plug.c
+++ b/src/opencl_ethereum_fmt_plug.c
@@ -63,6 +63,7 @@ typedef struct {
 	uint32_t hash[BINARY_SIZE / 4];
 } hash_t;
 
+static int new_keys;
 static pass_t *host_pass;                 /** plain ciphertexts **/
 static ethereum_salt_t *host_salt;        /** salt **/
 static hash_t *host_crack;                /** hash**/
@@ -279,9 +280,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
-		NULL, multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
+			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+			NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
@@ -331,6 +336,8 @@ static void set_key(char *key, int index)
 
 	memcpy(host_pass[index].v, key, saved_len);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_ethereum_presale_fmt_plug.c
+++ b/src/opencl_ethereum_presale_fmt_plug.c
@@ -274,7 +274,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
-	if (new_keys || ocl_autotune_running || global_work_size > keys_done) {
+	if (new_keys || global_work_size > keys_done) {
 		// Copy data to gpu
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
 			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,

--- a/src/opencl_fvde_fmt_plug.c
+++ b/src/opencl_fvde_fmt_plug.c
@@ -53,6 +53,7 @@ typedef struct {
 	} blob;
 } salt_t2;
 
+static int new_keys;
 static pass_t *host_pass;			      /** plain ciphertexts **/
 static salt_t2 *host_salt;			      /** salt **/
 static cl_int cl_error;
@@ -234,9 +235,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
-		NULL, multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
+			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+			NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
@@ -290,6 +295,8 @@ static void set_key(char *key, int index)
 
 	memcpy(host_pass[index].v, key, saved_len);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_geli_fmt_plug.c
+++ b/src/opencl_geli_fmt_plug.c
@@ -86,6 +86,7 @@ typedef struct {
 
 static custom_salt *cur_salt;
 
+static int new_keys;
 static pass_t *host_pass;
 static geli_salt_t *host_salt;
 static out_t *host_crack;
@@ -296,10 +297,14 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-				global_work_size * sizeof(pass_t), host_pass,
-				0, NULL, multi_profilingEvent[0]),
-				"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			global_work_size * sizeof(pass_t), host_pass,
+			0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run standard PBKDF2 kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
@@ -354,6 +359,8 @@ static void set_key(char *key, int index)
 	// ^= the whole uint64 with the ipad/opad mask
 	strncpy((char*)host_pass[index].v, key, PLAINTEXT_LENGTH);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_iwork_fmt_plug.c
+++ b/src/opencl_iwork_fmt_plug.c
@@ -258,7 +258,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_keychain_fmt_plug.c
+++ b/src/opencl_keychain_fmt_plug.c
@@ -79,6 +79,7 @@ static keychain_salt currentsalt;
 static cl_mem mem_in, mem_dk, mem_salt, mem_out;
 
 static size_t insize, dksize, saltsize, outsize;
+static int new_keys;
 
 #define STEP                    0
 #define SEED                    256
@@ -218,6 +219,8 @@ static void set_key(char *key, int index)
 
 	inbuffer[index].length = length;
 	memcpy(inbuffer[index].v, key, length);
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -237,9 +240,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
 	        "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,

--- a/src/opencl_keyring_fmt_plug.c
+++ b/src/opencl_keyring_fmt_plug.c
@@ -86,6 +86,7 @@ static keyring_hash *outbuffer;
 static keyring_salt currentsalt;
 static cl_mem mem_in, mem_out, mem_setting;
 static struct fmt_main *self;
+static int new_keys;
 
 #define insize (sizeof(keyring_password) * global_work_size)
 #define outsize (sizeof(keyring_hash) * global_work_size)
@@ -312,13 +313,15 @@ static void set_salt(void *salt)
 	HANDLE_CLERROR(clFlush(queue[gpu_id]), "clFlush failed in set_salt()");
 }
 
-static void keyring_set_key(char *key, int index)
+static void set_key(char *key, int index)
 {
 	uint8_t length = strlen(key);
 	if (length > PLAINTEXT_LENGTH)
 		length = PLAINTEXT_LENGTH;
 	inbuffer[index].length = length;
 	memcpy(inbuffer[index].v, key, length);
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -338,8 +341,12 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
@@ -421,7 +428,7 @@ struct fmt_main fmt_opencl_keyring = {
 		fmt_default_salt_hash,
 		NULL,
 		set_salt,
-		keyring_set_key,
+		set_key,
 		get_key,
 		fmt_default_clear_keys,
 		crypt_all,

--- a/src/opencl_keystore_fmt_plug.c
+++ b/src/opencl_keystore_fmt_plug.c
@@ -316,7 +316,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
 
-	if (new_keys || ocl_autotune_running) {
+	if (new_keys) {
 		if (key_idx)
 			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys,
 				CL_FALSE, 0, 4 * key_idx, saved_plain, 0, NULL,

--- a/src/opencl_krb5_asrep_aes_fmt_plug.c
+++ b/src/opencl_krb5_asrep_aes_fmt_plug.c
@@ -336,7 +336,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = gws * ocl_v_width;
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_krb5pa-md5_fmt_plug.c
+++ b/src/opencl_krb5pa-md5_fmt_plug.c
@@ -120,7 +120,7 @@ static cl_uint *loaded_hashes, max_num_loaded_hashes, *hash_ids, *bitmaps, max_h
 static cl_ulong bitmap_size_bits;
 
 static unsigned int key_idx;
-static unsigned int set_new_keys = 1;
+static unsigned int new_keys;
 static struct fmt_main *self;
 static cl_uint *zero_buffer;
 
@@ -586,7 +586,7 @@ static void set_key(char *_key, int index)
 	}
 	if (len)
 		saved_plain[key_idx++] = *key & (0xffffffffU >> (32 - (len << 3)));
-	set_new_keys = 1;
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -851,13 +851,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand %d\n", __FUNCTION__, count, local_work_size, gws, key_idx, mask_int_cand.num_int_cand);
 
 	// copy keys to the device
-	if (set_new_keys || ocl_autotune_running) {
+	if (new_keys) {
 		if (key_idx)
 			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_FALSE, 0, 4 * key_idx, saved_plain, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer buffer_keys.");
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_FALSE, 0, 4 * gws, saved_idx, 0, NULL, multi_profilingEvent[1]), "failed in clEnqueueWriteBuffer buffer_idx.");
 		if (!mask_gpu_is_static)
 			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_FALSE, 0, 4 * gws, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
-		set_new_keys = 0;
+		new_keys = 0;
 	}
 
 	current_salt = salt->sequential_id;

--- a/src/opencl_krb5pa-sha1_fmt_plug.c
+++ b/src/opencl_krb5pa-sha1_fmt_plug.c
@@ -505,7 +505,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = gws * ocl_v_width;
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_lastpass_cli_fmt_plug.c
+++ b/src/opencl_lastpass_cli_fmt_plug.c
@@ -212,7 +212,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
-	if (new_keys || ocl_autotune_running) {
+	if (new_keys) {
 		// Copy data to gpu
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
 			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,

--- a/src/opencl_lastpass_fmt_plug.c
+++ b/src/opencl_lastpass_fmt_plug.c
@@ -206,7 +206,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
-	if (new_keys || ocl_autotune_running) {
+	if (new_keys) {
 		// Copy data to gpu
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
 			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,

--- a/src/opencl_mscash_fmt_plug.c
+++ b/src/opencl_mscash_fmt_plug.c
@@ -54,7 +54,7 @@ static cl_uint *loaded_hashes, max_num_loaded_hashes, *hash_ids, *bitmaps, max_h
 static cl_ulong bitmap_size_bits;
 
 static unsigned int key_idx;
-static unsigned int set_new_keys;
+static unsigned int new_keys;
 static struct fmt_main *self;
 static cl_uint *zero_buffer;
 
@@ -375,7 +375,6 @@ static int get_hash_6(int index) { return hash_tables[current_salt][hash_ids[3 +
 static void clear_keys(void)
 {
 	key_idx = 0;
-	set_new_keys = 0;
 }
 
 static void set_key(char *_key, int index)
@@ -406,7 +405,7 @@ static void set_key(char *_key, int index)
 	}
 	if (len)
 		saved_plain[key_idx++] = *key & (0xffffffffU >> (32 - (len << 3)));
-	set_new_keys = 1;
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -671,13 +670,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand %d\n", __FUNCTION__, count, local_work_size, gws, key_idx, mask_int_cand.num_int_cand);
 
 	// copy keys to the device
-	if (set_new_keys || ocl_autotune_running) {
+	if (new_keys) {
 		if (key_idx)
 			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_FALSE, 0, 4 * key_idx, saved_plain, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer buffer_keys.");
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_FALSE, 0, 4 * gws, saved_idx, 0, NULL, multi_profilingEvent[1]), "failed in clEnqueueWriteBuffer buffer_idx.");
 		if (!mask_gpu_is_static)
 			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_FALSE, 0, 4 * gws, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
-		set_new_keys = 0;
+		new_keys = 0;
 	}
 
 	current_salt = salt->sequential_id;

--- a/src/opencl_ntlmv2_fmt_plug.c
+++ b/src/opencl_ntlmv2_fmt_plug.c
@@ -107,7 +107,7 @@ static cl_uint *loaded_hashes, max_num_loaded_hashes, *hash_ids, *bitmaps, max_h
 static cl_ulong bitmap_size_bits;
 
 static unsigned int key_idx;
-static unsigned int set_new_keys = 1;
+static unsigned int new_keys = 1;
 static struct fmt_main *self;
 static cl_uint *zero_buffer;
 
@@ -596,7 +596,6 @@ static void *get_salt(char *ciphertext)
 static void clear_keys(void)
 {
 	key_idx = 0;
-	set_new_keys = 1;
 }
 
 static void set_key(char *_key, int index)
@@ -627,7 +626,7 @@ static void set_key(char *_key, int index)
 	}
 	if (len)
 		saved_plain[key_idx++] = *key & (0xffffffffU >> (32 - (len << 3)));
-	set_new_keys = 1;
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -892,13 +891,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand %d\n", __FUNCTION__, count, local_work_size, gws, key_idx, mask_int_cand.num_int_cand);
 
 	// copy keys to the device
-	if (set_new_keys || ocl_autotune_running) {
+	if (new_keys) {
 		if (key_idx)
 			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_FALSE, 0, 4 * key_idx, saved_plain, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer buffer_keys.");
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_FALSE, 0, 4 * gws, saved_idx, 0, NULL, multi_profilingEvent[1]), "failed in clEnqueueWriteBuffer buffer_idx.");
 		if (!mask_gpu_is_static)
 			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_FALSE, 0, 4 * gws, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
-		set_new_keys = 0;
+		new_keys = 0;
 	}
 
 	current_salt = salt->sequential_id;

--- a/src/opencl_odf_fmt_plug.c
+++ b/src/opencl_odf_fmt_plug.c
@@ -70,6 +70,7 @@ static cl_mem mem_in, mem_out, mem_setting;
 static odf_password *saved_key;
 static odf_out *crypt_out;
 static odf_salt currentsalt;
+static int new_keys;
 
 static size_t insize, outsize, settingsize;
 
@@ -206,6 +207,8 @@ static void set_salt(void *salt)
 static void set_key(char *key, int index)
 {
 	strnzcpy(saved_key[index].v, key, sizeof(saved_key[index].v));
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -221,9 +224,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, saved_key, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, saved_key, 0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,

--- a/src/opencl_office_fmt_plug.c
+++ b/src/opencl_office_fmt_plug.c
@@ -358,7 +358,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	gws = GET_NEXT_MULTIPLE(count, local_work_size);
 
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_key, CL_FALSE, 0, UNICODE_LENGTH * gws, saved_key, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer saved_key");
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_len, CL_FALSE, 0, sizeof(int) * gws, saved_len, 0, NULL, multi_profilingEvent[1]), "failed in clEnqueueWriteBuffer saved_len");
 		new_keys = 0;

--- a/src/opencl_oldoffice_fmt_plug.c
+++ b/src/opencl_oldoffice_fmt_plug.c
@@ -528,7 +528,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	//printf("%s(%d) lws "Zu" gws "Zu" kidx %u k %d mult %u\n", __FUNCTION__, count, lws, gws, key_idx, new_keys, mask_int_cand.num_int_cand);
 
-	if (new_keys || ocl_autotune_running) {
+	if (new_keys) {
 		/* Self-test kludge */
 		if (idx_offset > 4 * (gws + 1))
 			idx_offset = 0;

--- a/src/opencl_openbsdsoftraid_fmt_plug.c
+++ b/src/opencl_openbsdsoftraid_fmt_plug.c
@@ -269,7 +269,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, PLAINTEXT_LENGTH * scalar_gws, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_pbkdf2_hmac_md4_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_md4_fmt_plug.c
@@ -270,7 +270,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	/// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_pbkdf2_hmac_md5_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_md5_fmt_plug.c
@@ -267,7 +267,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	/// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_pbkdf2_hmac_sha1_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha1_fmt_plug.c
@@ -292,7 +292,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	/// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
@@ -49,6 +49,7 @@ static cl_int cl_error;
 static cl_mem mem_in, mem_out, mem_salt, mem_state;
 static cl_kernel split_kernel, final_kernel;
 static struct fmt_main *self;
+static int new_keys;
 
 #define STEP			0
 #define SEED			1024
@@ -228,9 +229,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #endif
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
-		NULL, multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
+			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+			NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
@@ -283,6 +288,8 @@ static void set_key(char *key, int index)
 
 	memcpy(host_pass[index].v, key, saved_len);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_pem_fmt_plug.c
+++ b/src/opencl_pem_fmt_plug.c
@@ -286,7 +286,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_pfx_fmt_plug.c
+++ b/src/opencl_pfx_fmt_plug.c
@@ -90,6 +90,7 @@ static pfx_password *inbuffer;
 static pfx_salt currentsalt;
 static cl_mem mem_in, mem_out, mem_setting;
 static struct fmt_main *self;
+static int new_keys;
 
 static size_t insize, outsize, settingsize;
 
@@ -225,13 +226,15 @@ static void set_salt(void *salt)
 	HANDLE_CLERROR(clFlush(queue[gpu_id]), "clFlush failed in set_salt()");
 }
 
-static void pfx_set_key(char *key, int index)
+static void set_key(char *key, int index)
 {
 	uint32_t length = strlen(key);
 	if (length > PLAINTEXT_LENGTH)
 		length = PLAINTEXT_LENGTH;
 	inbuffer[index].length = length;
 	memcpy(inbuffer[index].v, key, length);
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -256,9 +259,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
@@ -336,7 +343,7 @@ struct fmt_main fmt_opencl_pfx = {
 		fmt_default_salt_hash,
 		NULL,
 		set_salt,
-		pfx_set_key,
+		set_key,
 		get_key,
 		fmt_default_clear_keys,
 		crypt_all,

--- a/src/opencl_pgpsda_fmt_plug.c
+++ b/src/opencl_pgpsda_fmt_plug.c
@@ -65,6 +65,7 @@ static cl_mem mem_in, mem_out, mem_setting;
 static struct fmt_main *self;
 
 static size_t insize, outsize, settingsize;
+static int new_keys;
 
 // This file contains auto-tuning routine(s). Has to be included after formats definitions.
 #include "opencl_autotune.h"
@@ -207,6 +208,8 @@ static void set_key(char *key, int index)
 		length = PLAINTEXT_LENGTH;
 	inbuffer[index].length = length;
 	memcpy(inbuffer[index].v, key, length);
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -228,9 +231,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,

--- a/src/opencl_pgpwde_fmt_plug.c
+++ b/src/opencl_pgpwde_fmt_plug.c
@@ -60,6 +60,7 @@ typedef struct {
 } pgpwde_salt;
 
 static struct custom_salt *cur_salt;
+static int new_keys;
 
 static cl_int cl_error;
 static pgpwde_password *inbuffer;
@@ -195,6 +196,8 @@ static void set_key(char *key, int index)
 
 	inbuffer[index].length = length;
 	memcpy(inbuffer[index].v, key, length);
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -215,9 +218,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,

--- a/src/opencl_rar5_fmt_plug.c
+++ b/src/opencl_rar5_fmt_plug.c
@@ -57,6 +57,8 @@ john_register_one(&fmt_ocl_rar5);
 
 #include "../run/opencl/opencl_pbkdf2_hmac_sha256.h"
 
+static int new_keys;
+
 static pass_t *host_pass;			      /** plain ciphertexts **/
 static salt_t *host_salt;			      /** salt **/
 static crack_t *host_crack;			      /** hash**/
@@ -223,9 +225,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	loops += host_salt->rounds % HASH_LOOPS > 0;
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
-		CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
-		NULL, multi_profilingEvent[0]), "Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in,
+			CL_FALSE, 0, global_work_size * sizeof(pass_t), host_pass, 0,
+			NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel,
@@ -257,6 +263,8 @@ static void set_key(char *key, int index)
 
 	memcpy(host_pass[index].v, key, saved_len);
 	host_pass[index].length = saved_len;
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)

--- a/src/opencl_rar_fmt_plug.c
+++ b/src/opencl_rar_fmt_plug.c
@@ -314,8 +314,12 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	salt_single = (salt->count == 1);
 
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_key, CL_FALSE, 0, UNICODE_LENGTH * gws, saved_key, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer saved_key");
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_len, CL_FALSE, 0, sizeof(int) * gws, saved_len, 0, NULL, multi_profilingEvent[1]), "failed in clEnqueueWriteBuffer saved_len");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_key, CL_FALSE, 0, UNICODE_LENGTH * gws, saved_key, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer saved_key");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_len, CL_FALSE, 0, sizeof(int) * gws, saved_len, 0, NULL, multi_profilingEvent[1]), "failed in clEnqueueWriteBuffer saved_len");
+
+		new_keys = 0;
+	}
 
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], RarInit, 1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "failed in clEnqueueNDRangeKernel");
 	for (k = 0; k < (ocl_autotune_running ? 1 : (ITERATIONS / HASH_LOOPS)); k++) {

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -60,7 +60,7 @@ static OFFSET_TABLE_WORD *offset_table = NULL;
 static cl_uint *loaded_hashes = NULL, num_loaded_hashes, *hash_ids = NULL, *bitmaps = NULL;
 static unsigned int hash_table_size, offset_table_size, shift64_ht_sz, shift64_ot_sz, shift128_ht_sz, shift128_ot_sz;
 static cl_ulong bitmap_size_bits = 0;
-static unsigned int keys_changed = 1;
+static unsigned int new_keys = 1;
 
 static unsigned int key_idx = 0;
 static struct fmt_main *self;
@@ -414,7 +414,7 @@ static void set_key(char *_key, int index)
 	if (len)
 		saved_plain[key_idx++] = *key & (0xffffffffU >> (32 - (len << 3)));
 
-	keys_changed = 1;
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -727,16 +727,17 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	global_work_size = count;
 
-	if (keys_changed) {
-	// copy keys to the device
-	if (key_idx)
-		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_TRUE, 0, 4 * key_idx, saved_plain, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_keys.");
+	if (new_keys) {
+		// copy keys to the device
+		if (key_idx)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_TRUE, 0, 4 * key_idx, saved_plain, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_keys.");
 
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_TRUE, 0, 4 * global_work_size, saved_idx, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_idx.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_TRUE, 0, 4 * global_work_size, saved_idx, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_idx.");
 
-	if (!mask_gpu_is_static)
-		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_TRUE, 0, 4 * global_work_size, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
-	keys_changed = 0;
+		if (!mask_gpu_is_static)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_TRUE, 0, 4 * global_work_size, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
+
+		new_keys = 0;
 	}
 
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &global_work_size, lws, 0, NULL, NULL), "failed in clEnqueueNDRangeKernel");

--- a/src/opencl_sappse_fmt_plug.c
+++ b/src/opencl_sappse_fmt_plug.c
@@ -72,6 +72,7 @@ static cl_mem mem_in, mem_out, mem_setting;
 static struct fmt_main *self;
 
 static size_t insize, outsize, settingsize;
+static int new_keys;
 
 #define STEP			0
 #define SEED			256
@@ -197,7 +198,7 @@ static void set_salt(void *salt)
 	HANDLE_CLERROR(clFlush(queue[gpu_id]), "clFlush failed in set_salt()");
 }
 
-static void sappse_set_key(char *key, int index)
+static void set_key(char *key, int index)
 {
 	uint32_t length = strlen(key);
 
@@ -205,6 +206,8 @@ static void sappse_set_key(char *key, int index)
 		length = PLAINTEXT_LENGTH;
 	inbuffer[index].length = length;
 	memcpy(inbuffer[index].v, key, length);
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -229,9 +232,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
@@ -305,7 +312,7 @@ struct fmt_main fmt_opencl_sappse = {
 		fmt_default_salt_hash,
 		NULL,
 		set_salt,
-		sappse_set_key,
+		set_key,
 		get_key,
 		fmt_default_clear_keys,
 		crypt_all,

--- a/src/opencl_sha1crypt_fmt_plug.c
+++ b/src/opencl_sha1crypt_fmt_plug.c
@@ -264,7 +264,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	        count, local_work_size, global_work_size, scalar_gws);
 #endif
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_solarwinds_fmt_plug.c
+++ b/src/opencl_solarwinds_fmt_plug.c
@@ -268,7 +268,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_strip_fmt_plug.c
+++ b/src/opencl_strip_fmt_plug.c
@@ -240,7 +240,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
-	if (new_keys || ocl_autotune_running) {
+	if (new_keys) {
 		// Copy data to gpu
 		insize = sizeof(pbkdf2_password) * global_work_size;
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,

--- a/src/opencl_telegram_fmt_plug.c
+++ b/src/opencl_telegram_fmt_plug.c
@@ -319,7 +319,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	scalar_gws = global_work_size * ocl_v_width;
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_vmx_fmt_plug.c
+++ b/src/opencl_vmx_fmt_plug.c
@@ -263,7 +263,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_KPC_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	if (ocl_autotune_running || new_keys) {
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, key_buf_size, inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
 		new_keys = 0;
 	}

--- a/src/opencl_xsha512_fmt_plug.c
+++ b/src/opencl_xsha512_fmt_plug.c
@@ -81,7 +81,7 @@ typedef struct {
 static xsha512_key *gkey;
 static xsha512_hash *ghash;
 static xsha512_salt gsalt;
-static uint8_t xsha512_key_changed;
+static uint8_t new_keys;
 static uint8_t hash_copy_back;
 
 //OpenCL variables:
@@ -228,7 +228,7 @@ static void set_key(char *key, int index)
 		length = PLAINTEXT_LENGTH;
 	gkey[index].length = length;
 	memcpy(gkey[index].v, key, length);
-	xsha512_key_changed = 1;
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -356,21 +356,21 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
-	///Copy data to GPU memory
-	if (xsha512_key_changed || ocl_autotune_running) {
+	// Copy data to GPU memory
+	if (new_keys) {
 		BENCH_CLERROR(clEnqueueWriteBuffer
 		    (queue[gpu_id], mem_in, CL_FALSE, 0, insize, gkey, 0, NULL,
 			multi_profilingEvent[0]), "Copy memin");
+
+		new_keys = 0;
 	}
 
-	///Run kernel
+	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel
 	    (queue[gpu_id], crypt_kernel, 1, NULL, &global_work_size, lws,
 		0, NULL, multi_profilingEvent[1]), "Set ND range");
 
-	/// Reset key to unchanged and hashes uncopy to host
-	xsha512_key_changed = 0;
-    hash_copy_back = 0;
+	hash_copy_back = 0;
 
 	return count;
 }

--- a/src/opencl_zed_fmt_plug.c
+++ b/src/opencl_zed_fmt_plug.c
@@ -63,6 +63,7 @@ static cl_mem mem_in, mem_out, mem_setting;
 static struct fmt_main *self;
 
 static size_t insize, outsize, settingsize;
+static int new_keys;
 
 #define STEP			0
 #define SEED			256
@@ -201,6 +202,8 @@ static void set_key(char *key, int index)
 		length = PLAINTEXT_LENGTH;
 	inbuffer[index].length = length;
 	memcpy(inbuffer[index].v, key, length);
+
+	new_keys = 1;
 }
 
 static char *get_key(int index)
@@ -226,9 +229,13 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
 	// Copy data to gpu
-	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
-		insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
-		"Copy data to gpu");
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0,
+			insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
+			"Copy data to gpu");
+
+		new_keys = 0;
+	}
 
 	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,

--- a/src/rar_common.c
+++ b/src/rar_common.c
@@ -25,6 +25,7 @@ static unsigned char *saved_salt;
 static unsigned char *saved_key;
 static int (*cracked);
 static unpack_data_t (*unpack_data);
+static int new_keys;
 
 static unsigned int *saved_len;
 #ifndef RAR_OPENCL_FORMAT
@@ -167,6 +168,8 @@ static void set_key(char *key, int index)
 	memcpy(&saved_key[UNICODE_LENGTH * index], buf, UNICODE_LENGTH);
 
 	saved_len[index] = plen << 1;
+
+	new_keys = 1;
 }
 
 static void *get_binary(char *ciphertext)


### PR DESCRIPTION
First commit drops the obsolete `ocl_autotune_running` check from `new_keys` logic.

Second commit adds `new_keys` logic to a bunch of formats that lacked it. Some of them may be so slow it's fairly pointless but it doesn't hurt anyway.

All tests out fine now. I reverted adding `new_keys` logic to pwsafe-opencl because it made it fail TS. I have yet to understand why.

Closes #4932