### PR TITLE
zip2john: Ignore bzip2-compressed files for pkzip

### DIFF
--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -778,12 +778,17 @@ static int process_legacy(zip_file *zfp, zip_ptr *p)
 
 		scan_for_data_descriptor(zfp, p);
 
+		if (p->cmptype != 0 && p->cmptype != 8) {
+			fprintf(stderr, "%s/%s is not encrypted, or stored with non-handled compression type=%"PRIu16"\n",
+			        zfp->fname, p->file_name, p->cmptype);
+			return 0;
+		}
+
 		// Ok, now set checksum bytes.  This will depend upon if from crc, or from timestamp
 		if (p->flags & FLAG_LOCAL_SIZE_UNKNOWN)
 			sprintf(p->cs, "%02x%02x", p->lastmod_time >> 8, p->lastmod_time & 0xFF);
 		else
 			sprintf(p->cs, "%02x%02x", (p->crc >> 24) & 0xFF, (p->crc >> 16) & 0xFF);
-
 
 		fprintf(stderr,
 		        "%s/%s PKZIP%s Encr: %s%scmplen=%"PRIu64", decmplen=%"PRIu64", crc=%08X ts=%04X cs=%s type=%"PRIu16"\n",


### PR DESCRIPTION
A bug lead to it sometimes being accepted by zip2john, only to be rejected by the format.

While we should ultimately support bzip2 compression, this first step is a good start.

See #4124