### PR TITLE
Pipe mode bugfix

### DIFF
--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -1055,6 +1055,7 @@ REDO_AFTER_LMLOOP:
 		prerule = rpp_next(&ctx);
 
 /* A string that can't be produced by fgetl(). */
+	last = aligned.buffer[1];
 	last[0] = '\n';
 	last[1] = 0;
 


### PR DESCRIPTION
The "last word" logic would thrash the memory buffer.

Closes #4923