### PR TITLE
Avoid busy wait

### DIFF
--- a/src/opencl_hash_check_128_plug.c
+++ b/src/opencl_hash_check_128_plug.c
@@ -429,9 +429,18 @@ int ocl_hc_128_extract_info(struct db_salt *salt, void (*set_kernel_args)(void),
 		set_kernel_args_kpc();
 	}
 
+	BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
+	WAIT_INIT(gws)
+
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "failed in clEnqueueNDRangeKernel");
 
-	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, sizeof(cl_uint), hash_ids, 0, NULL, multi_profilingEvent[3]), "failed in reading back num cracked hashes.");
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_FALSE, 0, sizeof(cl_uint), hash_ids, 0, NULL, multi_profilingEvent[3]), "failed in reading back num cracked hashes.");
+
+	BENCH_CLERROR(clFlush(queue[gpu_id]), "failed in clFlush");
+	WAIT_SLEEP
+	BENCH_CLERROR(clFinish(queue[gpu_id]), "failed in clFinish");
+	WAIT_UPDATE
+	WAIT_DONE
 
 	if (hash_ids[0] > num_loaded_hashes) {
 		fprintf(stderr, "Error, crypt_all kernel.\n");

--- a/src/opencl_keepass_fmt_plug.c
+++ b/src/opencl_keepass_fmt_plug.c
@@ -63,7 +63,7 @@ static size_t insize, outsize, saltsize;
 #define STEP			0
 #define SEED			256
 
-#define HASH_LOOPS		100
+#define HASH_LOOPS		1000
 
 #define LOOP_COUNT		((keepass_salt->key_transf_rounds + HASH_LOOPS - 1) / HASH_LOOPS)
 
@@ -187,8 +187,10 @@ static void reset(struct db_main *db)
 	                       create_clobj, release_clobj,
 	                       sizeof(keepass_state), 0, db);
 
-	// iterations for benchmarking
-	int iter = db->salts->cost[0];
+	int iter = db->max_cost[0];
+
+	if (options.loader.min_cost[0])
+		iter = options.loader.min_cost[0];
 
 	// Auto tune execution from shared/included code, max. 200ms total.
 	autotune_run(self, iter, 0, 200);
@@ -266,24 +268,35 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		&global_work_size, lws, 0, NULL,
 		multi_profilingEvent[1]), "Run kernel");
 
+	WAIT_INIT(global_work_size)
 	for (i = 0; i < (ocl_autotune_running ? 1 : LOOP_COUNT); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 			kernel_loop, 1, NULL,
 			&global_work_size, lws, 0, NULL,
 			multi_profilingEvent[2]), "Run kernel");
+		WAIT_SLEEP
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "Error running loop kernel");
+		WAIT_UPDATE
 		opencl_process_event();
 	}
+	WAIT_DONE
 
+	WAIT_INIT(global_work_size)
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id],
 		kernel_final, 1, NULL,
 		&global_work_size, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run kernel");
 
 	// Read the result back
-	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0,
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_FALSE, 0,
 		outsize, outbuffer, 0, NULL, multi_profilingEvent[4]),
 		"Copy result back");
+
+	BENCH_CLERROR(clFlush(queue[gpu_id]), "Error in clFlush");
+	WAIT_SLEEP
+	BENCH_CLERROR(clFinish(queue[gpu_id]), "Error in clFinish");
+	WAIT_UPDATE
+	WAIT_DONE
 
 	return count;
 }

--- a/src/opencl_md5crypt_fmt_plug.c
+++ b/src/opencl_md5crypt_fmt_plug.c
@@ -382,22 +382,36 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
 
-	///Copy data to GPU memory
-	if (new_keys)
+	// Copy data to GPU memory
+	if (new_keys) {
+		WAIT_INIT(global_work_size)
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE,
 			0, insize, inbuffer, 0, NULL, multi_profilingEvent[0]),
 			"Copy memin");
+		BENCH_CLERROR(clFlush(queue[gpu_id]), "clFlush error");
+		WAIT_SLEEP
+		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish error");
+		WAIT_UPDATE
+		WAIT_DONE
+	}
 
-	///Run kernel
+	// Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
 		NULL, &global_work_size, lws, 0, NULL, multi_profilingEvent[1]),
 		"Set ND range");
+
+	// Read results
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_FALSE,
 		0, outsize, outbuffer, 0, NULL, multi_profilingEvent[2]),
 		"Copy data back");
 
-	///Await completion of all the above
+	// Await completion of kernel + result transfer
+	WAIT_INIT(global_work_size)
+	BENCH_CLERROR(clFlush(queue[gpu_id]), "clFlush error");
+	WAIT_SLEEP
 	BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish error");
+	WAIT_UPDATE
+	WAIT_DONE
 
 	new_keys = 0;
 	return count;

--- a/src/opencl_rar5_fmt_plug.c
+++ b/src/opencl_rar5_fmt_plug.c
@@ -238,13 +238,20 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		1, NULL, &global_work_size, lws, 0, NULL,
 		multi_profilingEvent[1]), "Run kernel");
 
+	BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
+
+	WAIT_INIT(global_work_size)
 	for (i = 0; i < (ocl_autotune_running ? 1 : loops); i++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], split_kernel,
 			1, NULL, &global_work_size, lws, 0, NULL,
 			multi_profilingEvent[2]), "Run split kernel");
+		WAIT_SLEEP
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "clFinish");
+		WAIT_UPDATE
 		opencl_process_event();
 	}
+	WAIT_DONE
+
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel,
 		1, NULL, &global_work_size, lws, 0, NULL,
 		multi_profilingEvent[3]), "Run final kernel");

--- a/src/opencl_rar_fmt_plug.c
+++ b/src/opencl_rar_fmt_plug.c
@@ -322,11 +322,18 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	}
 
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], RarInit, 1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "failed in clEnqueueNDRangeKernel");
+	BENCH_CLERROR(clFinish(queue[gpu_id]), "failed in clFinish");
+
+	WAIT_INIT(gws)
 	for (k = 0; k < (ocl_autotune_running ? 1 : (ITERATIONS / HASH_LOOPS)); k++) {
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[3]), "failed in clEnqueueNDRangeKernel");
+		WAIT_SLEEP
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "Error running loop kernel");
+		WAIT_UPDATE
 		opencl_process_event();
 	}
+	WAIT_DONE
+
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], RarFinal, 1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[4]), "failed in clEnqueueNDRangeKernel");
 
 	/*
@@ -337,14 +344,20 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		fmt_data *blob = pw->binary;
 		rar_file *file = blob->blob;
 
-		HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_FileBuf, CL_TRUE, 0,
+		WAIT_INIT(gws)
+		HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_FileBuf, CL_FALSE, 0,
 		                                    sizeof(rar_file) + file->gpu_size, file, 0, NULL, NULL),
 		               "failed in reading result");
+		BENCH_CLERROR(clFlush(queue[gpu_id]), "failed in clFlush");
 		HANDLE_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], RarCheck, 1, NULL, &gws, lws, 0, NULL,
 		                                      multi_profilingEvent[5]),
 		               "failed in clEnqueueNDRangeKernel");
-		HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], cl_OutputBuf, CL_TRUE, 0, sizeof(rar_out) * gws, output, 0,
+		HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], cl_OutputBuf, CL_FALSE, 0, sizeof(rar_out) * gws, output, 0,
 		                                   NULL, NULL), "failed in reading result");
+		WAIT_SLEEP
+		BENCH_CLERROR(clFinish(queue[gpu_id]), "failed in clFinish");
+		WAIT_UPDATE
+		WAIT_DONE
 
 		for (k = 0; k < count; k++)
 			if (output[k].key.w[4])
@@ -363,13 +376,19 @@ static int cmp_all(void *binary, int count)
 	int index;
 
 	if (count && !salt_single) {
-		HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_FileBuf, CL_TRUE, 0,
+		WAIT_INIT(gws)
+		HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_FileBuf, CL_FALSE, 0,
 		                                    sizeof(rar_file) + file->gpu_size, file, 0, NULL, NULL),
 		               "failed in reading result");
+		BENCH_CLERROR(clFlush(queue[gpu_id]), "failed in clFlush");
 		HANDLE_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], RarCheck, 1, NULL, &gws, lws, 0, NULL, NULL),
 		               "failed in clEnqueueNDRangeKernel");
-		HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], cl_OutputBuf, CL_TRUE, 0, sizeof(rar_out) * gws, output, 0,
+		HANDLE_CLERROR(clEnqueueReadBuffer(queue[gpu_id], cl_OutputBuf, CL_FALSE, 0, sizeof(rar_out) * gws, output, 0,
 		                                   NULL, NULL), "failed in reading result");
+		WAIT_SLEEP
+		BENCH_CLERROR(clFinish(queue[gpu_id]), "failed in clFinish");
+		WAIT_UPDATE
+		WAIT_DONE
 	}
 
 #ifdef _OPENMP

--- a/src/opencl_sha512crypt_fmt_plug.c
+++ b/src/opencl_sha512crypt_fmt_plug.c
@@ -623,10 +623,17 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 		                                   CL_FALSE, 0, sizeof(sha512_password) * gws, input_candidates, 0,
 		                                   NULL, multi_profilingEvent[0]),
 		              "failed in clEnqueueWriteBuffer pass_buffer");
+		WAIT_INIT(gws)
+		HANDLE_CLERROR(clFlush(queue[gpu_id]), "Error running clFlush");
+		WAIT_SLEEP
+		HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error running clFinish");
+		WAIT_UPDATE
+		WAIT_DONE
 	}
 
 	//Enqueue the kernel
 	if (_SPLIT_KERNEL_IN_USE) {
+		WAIT_INIT(gws)
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], prepare_kernel, 1,
 		                                     NULL, &gws, lws, 0, NULL, multi_profilingEvent[3]),
 		              "failed in clEnqueueNDRangeKernel I");
@@ -634,35 +641,59 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], preproc_kernel, 1,
 		                                     NULL, &gws, lws, 0, NULL, multi_profilingEvent[4]),
 		              "failed in clEnqueueNDRangeKernel II");
+		WAIT_SLEEP
+		HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error running prep kernels");
+		WAIT_UPDATE
+		WAIT_DONE
 
 		unsigned int i, iterations;
 		iterations = ocl_autotune_running ? 3 : (salt->rounds / HASH_LOOPS);
 
+		WAIT_INIT(gws)
 		for (i = 0; i < iterations; i++) {
 			BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL,
 			                                     &gws, lws, 0, NULL, (ocl_autotune_running ?
 			                                             multi_profilingEvent[split_events[i]] : NULL)),  //1, 5, 6
 			              "failed in clEnqueueNDRangeKernel");
 
-			HANDLE_CLERROR(clFinish(queue[gpu_id]),
-			               "Error running loop kernel");
+			WAIT_SLEEP
+			HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error running loop kernel");
+			WAIT_UPDATE
 			opencl_process_event();
 		}
+		WAIT_DONE
+
+		WAIT_INIT(gws)
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], final_kernel, 1,
 		                                     NULL, &gws, lws, 0, NULL, multi_profilingEvent[5]),
 		              "failed in clEnqueueNDRangeKernel III");
-	} else
+		WAIT_SLEEP
+		HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error running final kernel");
+		WAIT_UPDATE
+		WAIT_DONE
+	} else {
+		WAIT_INIT(gws)
 		BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1,
 		                                     NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]),
 		              "failed in clEnqueueNDRangeKernel");
+		WAIT_SLEEP
+		HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error running crypt kernel");
+		WAIT_UPDATE
+		WAIT_DONE
+	}
 
 	//Read back hashes
+	WAIT_INIT(gws)
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], hash_buffer, CL_FALSE, 0,
 	                                  sizeof(sha512_hash) * gws, output_hashes, 0, NULL,
 	                                  multi_profilingEvent[2]), "failed in reading data back");
 
 	//Do the work
+	BENCH_CLERROR(clFlush(queue[gpu_id]), "failed in clFlush");
+	WAIT_SLEEP
 	BENCH_CLERROR(clFinish(queue[gpu_id]), "failed in clFinish");
+	WAIT_UPDATE
+	WAIT_DONE
 
 	if (bitmap_of_lens & (bitmap_of_lens - 1))
 		//Build calculated hash list according to original plaintext list order.

--- a/src/opencl_tezos_fmt_plug.c
+++ b/src/opencl_tezos_fmt_plug.c
@@ -248,42 +248,6 @@ static void set_salt(void *salt)
 	HANDLE_CLERROR(clFlush(queue[gpu_id]), "failed in clFlush");
 }
 
-#include "timer.h"
-#define WAIT_INIT(work_size) { \
-	static uint64_t wait_last_work_size; \
-	int wait_sleep = (work_size >= wait_last_work_size); \
-	wait_last_work_size = work_size; \
-	static uint64_t wait_times[20], wait_min; \
-	static unsigned int wait_index; \
-	uint64_t wait_start = 0;
-#define WAIT_SLEEP \
-	if (gpu_nvidia(device_info[gpu_id])) { \
-		wait_start = john_get_nano(); \
-		uint64_t us = wait_min >> 10; /* 2.4% less than min */ \
-		if (wait_sleep && us >= 1000) \
-			usleep(us); \
-	}
-#define WAIT_UPDATE \
-	if (gpu_nvidia(device_info[gpu_id])) { \
-		uint64_t wait_new = john_get_nano() - wait_start; \
-		if (wait_new < wait_min && wait_new < wait_min * 1000 / 1012) /* 1.2% less than min */ \
-			wait_new = wait_new * 7 / 8; /* we might have overslept and don't know by how much */ \
-		if (wait_times[wait_index] == wait_min) { /* about to replace former minimum */ \
-			unsigned int i; \
-			wait_times[wait_index] = wait_min = ~(uint64_t)0; \
-			for (i = 0; i < sizeof(wait_times) / sizeof(wait_times[0]); i++) \
-				if (wait_times[i] < wait_min) \
-					wait_min = wait_times[i]; \
-		} \
-		wait_times[wait_index++] = wait_new; \
-		if (wait_index >= sizeof(wait_times) / sizeof(wait_times[0])) \
-			wait_index = 0; \
-		if (wait_new < wait_min) \
-			wait_min = wait_new; \
-		wait_sleep = 1; \
-	}
-#define WAIT_DONE }
-
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;

--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -303,13 +303,21 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, 0, NULL, multi_profilingEvent[0]), "Failed transferring keys");
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_idx, CL_FALSE, idx_offset, 4 * (gws + 1) - idx_offset, saved_idx + (idx_offset / 4), 0, NULL, multi_profilingEvent[0]), "Failed transferring index");
+		BENCH_CLERROR(clFinish(queue[gpu_id]), "failed in clFinish");
 
 		new_keys = 0;
 	}
 
+	WAIT_INIT(gws)
 	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[1]), "Failed running crypt kernel");
 
-	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], cl_crack_count_ret, CL_TRUE, 0, sizeof(cl_uint), &crack_count_ret, 0, NULL, NULL), "failed reading results back");
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], cl_crack_count_ret, CL_FALSE, 0, sizeof(cl_uint), &crack_count_ret, 0, NULL, NULL), "failed reading results back");
+
+	BENCH_CLERROR(clFlush(queue[gpu_id]), "failed in clFlush");
+	WAIT_SLEEP
+	BENCH_CLERROR(clFinish(queue[gpu_id]), "failed in clFinish");
+	WAIT_UPDATE
+	WAIT_DONE
 
 	if (crack_count_ret) {
 		if (crack_count_ret > count)


### PR DESCRIPTION
Move the macros for avoiding busy-waits to shared header. Use it for 7z-opencl. I intend to add more formats to this PR before merging.

~Because of different code path/kernels used depending on salt, I added a couple of `clFinish()` and also changed a blocking `clEnqueueReadBuffer()` to a non-blocking one with an explicit `clFinish()` after. I think it's all sensible but would appreciate comments.~

Looking at virtual figures, they went from more or less 1:1 to eg. 26850 c/s real, 139264 c/s virtual (for a 3-second run) and I presume the latter should mean about 80% decrease of busy-waiting, right?