### PR TITLE
Wordlist mode: Optionally log per-rule statistics

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -243,8 +243,7 @@ LogCrackedPasswords = N
 #  cut -c14- john.log | grep '^Score ' | sort -rnk 2 | cut -d: -f2- | sed 's/\\/\\\\/g; s/\[/\\[/g; s/^-: //'
 # or for use on the slowest hashes:
 #  cut -c14- john.log | grep '^Score ' | sort -nk 4 | cut -d: -f2- | sed 's/\\/\\\\/g; s/\[/\\[/g; s/^-: //'
-# Please note that the statistics are skewed by buffering and parallelism,
-# which can be disabled with "--mkpc=1" (with major performance impact)
+# Please note that enabling this option has some performance impact
 PerRuleStats = N
 
 # Disable the dupe checking when loading hashes. For testing purposes only!

--- a/run/john.conf
+++ b/run/john.conf
@@ -239,6 +239,14 @@ ShowRemainOnStatus = N
 # Write cracked passwords to the log file (default is just the user name)
 LogCrackedPasswords = N
 
+# Log per-rule statistics usable to generate re-ordered rule set with:
+#  cut -c14- john.log | grep '^Score ' | sort -rnk 2 | cut -d: -f2- | sed 's/\\/\\\\/g; s/\[/\\[/g; s/^-: //'
+# or for use on the slowest hashes:
+#  cut -c14- john.log | grep '^Score ' | sort -nk 4 | cut -d: -f2- | sed 's/\\/\\\\/g; s/\[/\\[/g; s/^-: //'
+# Please note that the statistics are skewed by buffering and parallelism,
+# which can be disabled with "--mkpc=1" (with major performance impact)
+PerRuleStats = N
+
 # Disable the dupe checking when loading hashes. For testing purposes only!
 # This is deprecated: Use per-session option --loader-dupecheck=no instead.
 NoLoaderDupeCheck = N

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -1375,8 +1375,13 @@ EndOfFile:
 		if (rules) {
 next_rule:
 			if (rules > 1 && prerule) {
+				unsigned long long p = status.cands, fake_p = 0;
+				if (!(options.flags & FLG_STDOUT)) do {
+					crk_process_key("injected wrong password");
+					fake_p++;
+				} while (p == status.cands);
 				unsigned int g = status.guess_count - prev_g;
-				unsigned long long p = status.cands - prev_p;
+				p = status.cands - fake_p - prev_p;
 				double score = p ? (g ? (double)g * g : 1e-9) / (double)p : 0;
 				double pg = (double)(p ? p : 1e9) / (g ? g : 1e-9);
 				log_event("- Score %.18f for %.2f p/g %ug %llup during rule #%d :%.100s",


### PR DESCRIPTION
This adds the `PerRuleStats` setting, disabled by default, for logging of per-rule statistics and scores usable to generate an order-optimized rule set. The setting also aligns rules to whole buffers, by injecting just enough instances of a fake password to infer when the buffer has filled and been processed.

This is related to the ongoing work on #5003 and #5004.