### PR TITLE
move -DDEBUG for ASan builds in memory.c (closes #5013)

### DIFF
--- a/src/krb5_db_fmt_plug.c
+++ b/src/krb5_db_fmt_plug.c
@@ -253,7 +253,8 @@ static void *get_binary(char *ciphertext)
 		p = ciphertext + TAG_LENGTH_3;
 	}
 
-	if (!out) out = mem_alloc_tiny(binary_size, MEM_ALIGN_WORD);
+	/* 32 is max possible binary_size above */
+	if (!out) out = mem_alloc_tiny(32, MEM_ALIGN_WORD);
 	p = strstr(p, "$") + 1;
 
 	for (; i < binary_size; i++) {

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -86,7 +86,7 @@
 #include "mask_ext.h"
 #include "john.h"
 #include "version.h"
-#include "listconf.h" /* must be included after version.h */
+#include "listconf.h" /* must be included after version.h and misc.h */
 
 #ifdef NO_JOHN_BLD
 #define JOHN_BLD "unk-build-type"

--- a/src/memory.c
+++ b/src/memory.c
@@ -18,15 +18,15 @@
 #include <malloc.h>
 #endif
 
-#if defined(WITH_ASAN) && !defined(DEBUG)
-#define DEBUG
-#endif
-
 #include "arch.h"
 #include "misc.h"
 #include "memory.h"
 #include "common.h"
 #include "johnswap.h"
+
+#if defined(WITH_ASAN) && !defined(DEBUG)
+#define DEBUG
+#endif
 
 #if (defined (_MSC_VER) || HAVE___MINGW_ALIGNED_MALLOC)
 char *strdup_MSVC(const char *str)

--- a/src/options.c
+++ b/src/options.c
@@ -50,7 +50,7 @@
 #include "prince.h"
 #endif
 #include "version.h"
-#include "listconf.h" /* must be included after version.h */
+#include "listconf.h" /* must be included after version.h and misc.h */
 #include "jumbo.h"
 
 struct options_main options;


### PR DESCRIPTION
BTW there is such check in `memory.c`:
```c
#if defined(WITH_ASAN) || defined(DEBUG)
```

It could be reduced to just `defined(DEBUG)` because `WITH_ASAN` implies `DEBUG` now.