### PR TITLE
Rename --no-loader-dupecheck option to --no-loader-dupe-check

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -145,7 +145,7 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   the current batch has been run among all salts.  Under some circumstances
   that may take a good while.  [magnum; 2020]
 
-- Add command-line option --loader-dupecheck=<yes/no>, overriding config file.
+- Add command-line option --[no-]loader-dupe-check, overriding config file.
   Mark the latter as deprecated in config file comments.  [magnum; 2020]
 
 - Add alternative syntax to --salts option for loading "N most populated

--- a/doc/OPTIONS
+++ b/doc/OPTIONS
@@ -50,14 +50,14 @@ this option would have the same result as having that word in the gecos
 field of all users named "root" in the input file.  If the wordlist is
 very large, sorting it will speed up loading.
 
---single-retest-guess=BOOL
+--[no-]single-retest-guess
 
 Override config file setting for SingleRetestGuess.  Setting this to false
 stops Single mode from re-testing guessed plaintexts with all other salts.
 This is normally only needed for attacking massive, salted, input files
 eg. where you intend to use the --loopback option later instead.
 
---loader-dupecheck=BOOL
+--no-loader-dupe-check
 
 Disable the dupe checking when loading hashes.  This can be used when
 loading massive input files that you know don't contain any dupes, for

--- a/run/john.conf
+++ b/run/john.conf
@@ -173,7 +173,7 @@ SingleWordsPairMax = 6
 
 # Setting this to false stops Single mode from re-testing guessed plaintexts
 # with all other salts.  This is deprecated: Use command-line per-session
-# option --single-retest-guess=no instead.
+# option --no-single-retest-guess instead.
 SingleRetestGuessed = Y
 
 # Max recursion depth for SingleRetestGuessed, so we don't blow the stack
@@ -247,7 +247,7 @@ LogCrackedPasswords = N
 PerRuleStats = N
 
 # Disable the dupe checking when loading hashes. For testing purposes only!
-# This is deprecated: Use per-session option --loader-dupecheck=no instead.
+# This is deprecated: Use per-session option --no-loader-dupe-check instead.
 NoLoaderDupeCheck = N
 
 # Default encoding for input files (ie. login/GECOS fields) and wordlists

--- a/src/options.c
+++ b/src/options.c
@@ -169,7 +169,7 @@ static struct opt_entry opt_list[] = {
 	{"fix-state-delay", FLG_ONCE, 0, FLG_CRACKING_CHK, OPT_REQ_PARAM, "%u", &options.max_fix_state_delay},
 	{"field-separator-char", FLG_ONCE, 0, FLG_PWD_SUP, OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &field_sep_char_str},
 	{"config", FLG_ONCE, 0, 0, USUAL_REQ_CLR | OPT_REQ_PARAM, OPT_FMT_STR_ALLOC, &options.config},
-	{"loader-dupecheck", FLG_ONCE, 0, FLG_CRACKING_CHK, OPT_TRISTATE, NULL, &options.loader_dupecheck},
+	{"loader-dupe-check", FLG_ONCE, 0, FLG_CRACKING_CHK, OPT_TRISTATE, NULL, &options.loader_dupecheck},
 	{"no-log", FLG_NOLOG, FLG_NOLOG, 0, FLG_TEST_CHK},
 	{"log-stderr", FLG_ONCE, 0, 0, USUAL_REQ_CLR | OPT_BOOL, NULL, &options.log_stderr},
 	{"crack-status", FLG_ONCE, 0, FLG_CRACKING_CHK, OPT_TRISTATE, NULL, &options.crack_status},
@@ -352,7 +352,7 @@ FUZZ_USAGE \
 "--max-run-time=[-]N        Gracefully exit after this many seconds (if negative,\n" \
 "                           reset timer on each crack)\n" \
 "--mkpc=N                   Request a lower max. keys per crypt\n" \
-"--no-loader-dupecheck      Disable the dupe checking when loading hashes\n" \
+"--no-loader-dupe-check     Disable the dupe checking when loading hashes\n" \
 "--pot=NAME                 Pot file to use\n" \
 "--regen-lost-salts=N       Brute force unknown salts (see doc/OPTIONS)\n" \
 "--reject-printable         Reject printable binaries\n" \

--- a/src/options.h
+++ b/src/options.h
@@ -269,12 +269,12 @@ struct options_main {
  */
 	int single_pair_max;
 /*
- * --[no]-single-retest-guess tri-state option (vs. deprecated config option)
+ * --[no-]single-retest-guess tri-state option (vs. deprecated config option)
  */
 	char *single_retest_guess;
 
 /*
- * --no-loader-dupecheck option tri-state option (vs. deprecated config option)
+ * --[no-]loader-dupe-check option tri-state option (vs. deprecated config option)
  */
 	int loader_dupecheck;
 


### PR DESCRIPTION
Also updates a couple of comments in john.conf to current option syntax