### PR TITLE
Add key-string pattern to cisco2john

### DIFF
--- a/run/cisco2john.pl
+++ b/run/cisco2john.pl
@@ -163,7 +163,7 @@ while (<>) {
 			print STDERR $1, "\n";
 		}
 		# password 7 <obfuscated>
-	} elsif (m/(?:password|md5|ascii|key|hex|encryption .*) 7 ([\dA-F]+)/) {
+	} elsif (m/(?:password|md5|ascii|key|key-string|hex|encryption .*) 7 ([\dA-F]+)/) {
 		#print "in2: $_\n";
 		notice();
 		my $pw = cisco_decrypt($1);


### PR DESCRIPTION
For example with [HSRP](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/ipapp_fhrp/configuration/xe-3s/fhp-xe-3s-book/fhp-hsrp-md5.html#GUID-D59AF97B-6E86-42AE-A270-F1347D59AFF5) use `key-string` rather than `key` for type 7 passwords, so you get something like:

```
standby 1 authentication md5 key-string 7 071B245F5A
```

This meant that they weren't being picked up by cisco2john