### PR TITLE
Fix valid() bugs found by fuzzing in several formats

### DIFF
--- a/src/FG2_fmt_plug.c
+++ b/src/FG2_fmt_plug.c
@@ -102,6 +102,8 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		return 0;
 	if (strlen(ciphertext) != HASH_LENGTH)
 		return 0;
+	if (ciphertext[HASH_LENGTH - 1] != '=')
+		return 0;
 
 	return 1;
 }

--- a/src/FGT_fmt_plug.c
+++ b/src/FGT_fmt_plug.c
@@ -109,6 +109,8 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		return 0;
 	if (strlen(ciphertext) != HASH_LENGTH)
 		return 0;
+	if (ciphertext[HASH_LENGTH - 1] != '=')
+		return 0;
 
 	return 1;
 }

--- a/src/lastpass_sniffed_fmt_plug.c
+++ b/src/lastpass_sniffed_fmt_plug.c
@@ -160,12 +160,12 @@ static void *get_salt(char *ciphertext)
 static void *get_binary(char *ciphertext)
 {
 	static unsigned int out[4];
-	char Tmp[48];
+	char Tmp[sizeof(out)];
 	char *p;
 	ciphertext += FORMAT_TAG_LEN;
 	p = strchr(ciphertext, '$')+1;
 	p = strchr(p, '$')+1;
-	base64_convert(p, e_b64_mime, strlen(p), Tmp, e_b64_raw, sizeof(Tmp), 0, 0);
+	base64_convert(p, e_b64_mime, strlen(p), Tmp, e_b64_raw, sizeof(Tmp), flg_Base64_DONOT_NULL_TERMINATE, 0);
 	memcpy(out, Tmp, 16);
 	return out;
 }

--- a/src/lastpass_sniffed_fmt_plug.c
+++ b/src/lastpass_sniffed_fmt_plug.c
@@ -126,6 +126,8 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if (strlen(p) > 50) /* not exact! */
 		goto err;
+	if (strtokm(NULL, "$"))	/* no more fields  */
+		goto err;
 	MEM_FREE(keeptr);
 	return 1;
 

--- a/src/openbsdsoftraid_common_plug.c
+++ b/src/openbsdsoftraid_common_plug.c
@@ -56,6 +56,8 @@ int openbsdsoftraid_valid(char* ciphertext, struct fmt_main *self, int is_cpu)
 		if (!is_cpu && kdf_type != 1)
 			goto err;
 	}
+	if (strtokm(NULL, "$")) /* no more fields */
+		goto err;
 
 	MEM_FREE(keeptr);
 	return 1;
@@ -104,24 +106,19 @@ void *openbsdsoftraid_get_binary(char *ciphertext)
 		ARCH_WORD dummy;
 	} buf;
 	unsigned char *out = buf.c;
-	char *p, *cc = NULL;
+	char *p;
 	int i;
 
 	p = strrchr(ciphertext, '$') + 1;
 
 	if (strlen(p) == 1) { // hack, last field is kdf type
-		cc = strdup(ciphertext);
-		cc[strlen(ciphertext) - 2] = 0;
-		p = strrchr(cc, '$') + 1;
-
+		p -= 2 * BINARY_SIZE + 1;
 	}
 	for (i = 0; i < BINARY_SIZE; i++) {
 		out[i] = (atoi16[ARCH_INDEX(*p)] << 4) |
 			atoi16[ARCH_INDEX(p[1])];
 		p += 2;
 	}
-	if (cc)
-		MEM_FREE(cc);
 
 	return out;
 }


### PR DESCRIPTION
Related to #4971.

`--test` is ok. `--fuzz` is ok.