### PR TITLE
mask: added check of number of placeholders and ranges, fixes overflow

### DIFF
--- a/src/mask.c
+++ b/src/mask.c
@@ -1118,6 +1118,11 @@ static void parse_braces(char *mask, mask_parsed_ctx *parsed_mask)
 
 		j = i;
 		k++;
+		if (k > MAX_NUM_MASK_PLHDR) {
+			if (john_main_process)
+				fprintf(stderr, "Error: Mask parsing unsuccessful, too many ranges / custom placeholders\n");
+			error();
+		}
 	}
 
 	for (i = 0; i < MAX_NUM_MASK_PLHDR; i++)
@@ -1158,6 +1163,11 @@ static void parse_qtn(char *mask, mask_parsed_ctx *parsed_mask)
 				j++;
 			}
 			parsed_mask->stack_qtn[k++] = i;
+			if (k > MAX_NUM_MASK_PLHDR) {
+				if (john_main_process)
+					fprintf(stderr, "Error: Mask parsing unsuccessful, too many placeholders\n");
+				error();
+			}
 		}
 cont:
 		;


### PR DESCRIPTION
Closes #4115.

ASan showed where is the problem. For `?l?l...`:
```
==1869==ERROR: AddressSanitizer: global-buffer-overflow on address 0x56213f22b448 at pc 0x56213d5eafd1 bp 0x7ffccd2e5af0 sp 0x7ffccd2e5ae8
WRITE of size 4 at 0x56213f22b448 thread T0
    #0 0x56213d5eafd0 in parse_qtn /home/user/john/src/mask.c:1160
    #1 0x56213d5f73fc in finalize_mask /home/user/john/src/mask.c:2356
    #2 0x56213d5f9895 in mask_init /home/user/john/src/mask.c:2312
    #3 0x56213d5d7676 in john_run /home/user/john/src/john.c:1777
[...]

0x56213f22b448 is located 56 bytes to the left of global variable 'mask_gpu_is_static' defined in 'mask_ext.c:22:5' (0x56213f22b480) of size 4
0x56213f22b448 is located 0 bytes to the right of global variable 'parsed_mask' defined in 'mask.c:41:24' (0x56213f22ae60) of size 1512
```

For `[ab][ab]...`:
```
==3462==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55dc83b1c448 at pc 0x55dc81ee1ce6 bp 0x7fff2b185ee0 sp 0x7fff2b185ed8
WRITE of size 4 at 0x55dc83b1c448 thread T0
    #0 0x55dc81ee1ce5 in parse_braces /home/user/john/src/mask.c:1112
    #1 0x55dc81ee83c9 in finalize_mask /home/user/john/src/mask.c:2349
    #2 0x55dc81eea895 in mask_init /home/user/john/src/mask.c:2312
    #3 0x55dc81ec8676 in john_run /home/user/john/src/john.c:1777
[...]

0x55dc83b1c448 is located 56 bytes to the left of global variable 'mask_gpu_is_static' defined in 'mask_ext.c:22:5' (0x55dc83b1c480) of size 4
0x55dc83b1c448 is located 0 bytes to the right of global variable 'parsed_mask' defined in 'mask.c:41:24' (0x55dc83b1be60) of size 1512
```

New behaviour:
```
$ run/john --mask="`python -c 'print "?l" * 126'`" --stdout --verbosity=1
Warning: Verbosity decreased to minimum, candidates will not be printed!
Error: Mask parsing unsuccessful, too many placeholders

$ run/john --mask="`python -c 'print "[ab]" * 126'`" --stdout --verbosity=1
Warning: Verbosity decreased to minimum, candidates will not be printed!
Error: Mask parsing unsuccessful, too many ranges / custom placeholders
```

`* 125` is accepted.

`mask.h`:
```c
#define MAX_NUM_MASK_PLHDR 125
[...]

typedef struct {
	/* store locations of op braces in mask */
	int stack_op_br[MAX_NUM_MASK_PLHDR + 1];
	/* store locations of cl braces in mask */
	int stack_cl_br[MAX_NUM_MASK_PLHDR + 1];
	/* store locations of valid ? in mask */
	int stack_qtn[MAX_NUM_MASK_PLHDR + 1];
} mask_parsed_ctx;
```

So assignment at index `MAX_NUM_MASK_PLHDR` seems ok. And mask works correctly.

But initialization is written as `for (i = 0; i < MAX_NUM_MASK_PLHDR; i++)`. So my check for `k > MAX_NUM_MASK_PLHDR` looks bad.

In `parse_braces` I would add `break` on `i == strlen(mask)` and place check then. But I did not dare to change more code.

Should I change code to be more natural? Should I add comments to explain that checks are ok?