### PR TITLE
Tezos fixups

### DIFF
--- a/run/tezos2john.py
+++ b/run/tezos2john.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
         data = json.loads(data)
         mnemonic, email, address = (" ".join(data["mnemonic"]), data["email"], data["pkh"])
         raw_address = binascii.hexlify(b58check_to_bin(address)).decode("ascii")
-        print("%s:$tezos$1*%s*%s*%s*%s*%s" % ("dummy", 2048, mnemonic, email, address, raw_address))
+        print("%s:$tezos$1*%s*%s*%s*%s*%s" % (email, 2048, mnemonic, email, address, raw_address))
         sys.exit(0)
     if len(myArgs) != 3:
         sys.stderr.write("Usage: %s \'mnemonic data (15 words)\' \'email\' \'public key\'\n" %
@@ -298,4 +298,4 @@ if __name__ == "__main__":
         sys.stderr.write("[ERROR] Invalid address, Please Check before continuing.\n")
         sys.exit(1)
 
-    print("%s:$tezos$1*%s*%s*%s*%s*%s" % ("dummy", 2048, mnemonic, email, address, raw_address))
+    print("%s:$tezos$1*%s*%s*%s*%s*%s" % (email, 2048, mnemonic, email, address, raw_address))

--- a/src/tezos_fmt_plug.c
+++ b/src/tezos_fmt_plug.c
@@ -111,7 +111,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	const int count = *pcount;
 	int index;
 #ifdef SIMD_COEF_64
-	static int warned;
+	static volatile int warned;
 #endif
 
 	if (any_cracked) {


### PR DESCRIPTION
- tezos2john.py: Put e-mail address into the first field
- Tezos format: Make it less likely we print the warning more than once