### PR TITLE
mask: fix crash on `"?l[aa]" * 125`

### DIFF
--- a/src/mask.c
+++ b/src/mask.c
@@ -1082,7 +1082,8 @@ static void parse_braces(char *mask, mask_parsed_ctx *parsed_mask)
 	int i, j ,k;
 	int cl_br_enc;
 
-	for (i = 0; i < MAX_NUM_MASK_PLHDR; i++) {
+	/* The last element is worst-case boundary for search_stack(). */
+	for (i = 0; i <= MAX_NUM_MASK_PLHDR; i++) {
 		store_cl(i, -1);
 		store_op(i, -1);
 	}
@@ -1146,7 +1147,8 @@ static void parse_qtn(char *mask, mask_parsed_ctx *parsed_mask)
 {
 	int i, j, k;
 
-	for (i = 0; i < MAX_NUM_MASK_PLHDR; i++)
+	/* The last element is worst-case boundary for search_stack(). */
+	for (i = 0; i <= MAX_NUM_MASK_PLHDR; i++)
 		parsed_mask->stack_qtn[i] = -1;
 
 	for (i = 0, k = 0; i < strlen(mask); i++) {


### PR DESCRIPTION
#5040 fixed problem with too many placeholders (#4115) and similar problem with too many ranges. But `"?l[aa]" * 125` causes crash in other place. `* 124` does not crash.

```
$ run/john --mask="`python -c 'print "?l[aa]" * 125'`" --stdout
=================================================================
==21478==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55cf2ab055c8 at pc 0x55cf28ec2b32 bp 0x7ffc67081b70 sp 0x7ffc67081b68
READ of size 4 at 0x55cf2ab055c8 thread T0
    #0 0x55cf28ec2b31 in search_stack /home/user/john/src/mask.c:1182
    #1 0x55cf28ed069c in finalize_mask /home/user/john/src/mask.c:2372
    #2 0x55cf28ed2a05 in mask_init /home/user/john/src/mask.c:2322
[...]
0x55cf2ab055c8 is located 56 bytes to the left of global variable 'mask_gpu_is_static' defined in 'mask_ext.c:22:5' (0x55cf2ab05600) of size 4
0x55cf2ab055c8 is located 0 bytes to the right of global variable 'parsed_mask' defined in 'mask.c:41:24' (0x55cf2ab04fe0) of size 1512
SUMMARY: AddressSanitizer: global-buffer-overflow /home/user/john/src/mask.c:1182 in search_stack
```

I just added checks to end loops in the crashing function before reading past max number of elements.

Unless there would be comments requiring a changes, this PR is ready.