### PR TITLE
Suppressor: Guarantee no false positives up to length 7 (even 8-bit)

### DIFF
--- a/src/suppressor.c
+++ b/src/suppressor.c
@@ -114,7 +114,7 @@ static MAYBE_INLINE uint32_t key_hash(const char *key, uint64_t *hash2)
 	}
 
 	if (p - (const unsigned char *)key + !!*p > 8) /* different hash than for any short 7-bit */
-		*(unsigned char *)hash2 |= 0x80;
+		((unsigned char *)hash2)[7] |= 0x80;
 
 	hash1 ^= extra;
 


### PR DESCRIPTION
This is a trivial change to the hash function that improves its guaranteed collision avoidance for/against short passwords.

Before this PR, we guaranteed:

1. No collisions between passwords of lengths up to 8 inclusive (not even with 8-bit bytes in them).
2. No collisions between longer passwords and pure 7-bit ASCII passwords of length up to 8 inclusive.

With this PR, we also guarantee:

3. No collisions between longer passwords and passwords of length up to 7 inclusive (not even with 8-bit bytes in them).

Collisions are still possible:

1. Between passwords of length 9+.
2. Between a password of length 9+ and a password of length 8 that ends in an 8-bit byte.

In all of these statements, the lengths are measured in bytes. "8-bit byte" refers to a byte value with the high bit set.