### PR TITLE
Fix more uses of malloc()'ed pointers without NULL check (issue #5035)

### DIFF
--- a/src/bks_fmt_plug.c
+++ b/src/bks_fmt_plug.c
@@ -116,7 +116,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 
 	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH) != 0)
 		return 0;
-	ctcopy = strdup(ciphertext);
+	ctcopy = xstrdup(ciphertext);
 	keeptr = ctcopy;
 	ctcopy += FORMAT_TAG_LENGTH;
 	if ((p = strtokm(ctcopy, "$")) == NULL) // format
@@ -189,7 +189,7 @@ static void *get_salt(char *ciphertext)
 	char *p = ciphertext, *ctcopy, *keeptr;
 	memset(&cs, 0, sizeof(cs));
 
-	ctcopy = strdup(ciphertext);
+	ctcopy = xstrdup(ciphertext);
 	keeptr = ctcopy;
 	ctcopy += FORMAT_TAG_LENGTH;
 	p = strtokm(ctcopy, "$");

--- a/src/diskcryptor_common_plug.c
+++ b/src/diskcryptor_common_plug.c
@@ -6,10 +6,11 @@
  */
 
 #include "arch.h"
-#include "diskcryptor_common.h"
+#include "memory.h"
 #include "jumbo.h"
 #include "johnswap.h"
 #include "xts.h"
+#include "diskcryptor_common.h"
 
 // #define DEBUG 1
 
@@ -35,7 +36,7 @@ int diskcryptor_valid(char *ciphertext, struct fmt_main *self)
 	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH) != 0)
 		return 0;
 
-	ctcopy = strdup(ciphertext);
+	ctcopy = xstrdup(ciphertext);
 	keeptr = ctcopy;
 
 	ctcopy += TAG_LENGTH;

--- a/src/dmg2john.c
+++ b/src/dmg2john.c
@@ -448,6 +448,10 @@ static void hash_plugin_parse_hash(char *in_filepath)
 
 		/* read starting chunk(s) */
 		chunk1 = (unsigned char *)malloc(data_size);
+		if (!chunk1) {
+			fprintf(stderr, "Error allocating memory while processing %s\n", filename);
+			goto bailout;
+		}
 		if (lseek(fd, header2.dataoffset + cno * 4096LL, SEEK_SET) < 0) {
 			fprintf(stderr, "Unable to seek in %s\n", filename);
 			free(chunk1);

--- a/src/enpass_common_plug.c
+++ b/src/enpass_common_plug.c
@@ -4,6 +4,7 @@
 
 #include "arch.h"
 #include "misc.h"
+#include "memory.h"
 #include "common.h"
 #include "enpass_common.h"
 
@@ -13,7 +14,7 @@ int enpass_valid(char *ciphertext, struct fmt_main *self)
 	int extra;
 	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
 		return 0;
-	ctcopy = strdup(ciphertext);
+	ctcopy = xstrdup(ciphertext);
 	keeptr = ctcopy;
 	ctcopy += FORMAT_TAG_LEN;
 	if ((p = strtokm(ctcopy, "$")) == NULL)	/* version */

--- a/src/episerver_fmt_plug.c
+++ b/src/episerver_fmt_plug.c
@@ -50,6 +50,7 @@ john_register_one(&fmt_episerver);
 #include "sha.h"
 #include "sha2.h"
 #include "misc.h"
+#include "memory.h"
 #include "common.h"
 #include "formats.h"
 #include "params.h"
@@ -186,7 +187,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 
 	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
 		return 0;
-	if (!(ctcopy = strdup(ciphertext)))
+	if (!(ctcopy = xstrdup(ciphertext)))
 		return 0;
 	keeptr = ctcopy;
 	ctcopy += FORMAT_TAG_LEN;	/* skip leading '$episerver$*' */

--- a/src/jumbo.c
+++ b/src/jumbo.c
@@ -353,8 +353,14 @@ int setenv(const char *name, const char *val, int overwrite) {
 		if (str)
 			return 0;
 	}
+	if (strlen(name) > 0x10000000 || strlen(val) > 0x10000000) {
+		errno = ENOMEM;
+		return -1;
+	}
 	len = strlen(name)+1+strlen(val)+1;
 	str = malloc(len);
+	if (!str)
+		return -1;
 	sprintf(str, "%s=%s", name, val);
 	putenv(str);
 	return 0;

--- a/src/memory.c
+++ b/src/memory.c
@@ -129,15 +129,15 @@ void *mem_realloc(void *old_ptr, size_t size)
 	return res;
 }
 
-char *xstrdup (const char* str)
+char *xstrdup(const char *str)
 {
 	char *res = strdup(str);
 
-	if (res == NULL) {
-		fprintf(stderr, "xstrdup(): %s\n", strerror (ENOMEM));
+	if (!res) {
+		fprintf(stderr, "xstrdup(): %s\n", strerror(ENOMEM));
 		error();
 	}
-	
+
 	return res;
 }
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -99,11 +99,11 @@ extern void *mem_alloc_align(size_t size, size_t align);
 extern void *mem_calloc_align(size_t count, size_t size, size_t align);
 
 /*
- * Creates a new null terminated copy of the given string using strdup() and 
- * retruns a pointer to it. The allocation is done using malloc(). 
- * If an error occurs in the memory allocation, the function does not return
+ * Creates a new NUL-terminated copy of the given string using strdup() and
+ * returns a pointer to it.  The allocation is done using malloc().
+ * If an error occurs, the function does not return.
  */
-extern char *xstrdup(const char* str);
+extern char *xstrdup(const char *str);
 
 /*
  * Frees memory allocated with mem_alloc() and sets the pointer to NULL.

--- a/src/tgtsnarf.c
+++ b/src/tgtsnarf.c
@@ -190,7 +190,10 @@ fetch_tgt(char *host, char *user, char *realm, unsigned char *dst, int size)
   to.sin_port = htons(750);
 
   /* Fill in our TGT request. */
-  ktext.length = make_req(ktext.dat, user, realm);
+  int ktext_length = make_req(ktext.dat, user, realm);
+  if (ktext_length < 0)
+    return (-1);
+  ktext.length = ktext_length;
 
   /* Send it to KDC. */
   if ((sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {

--- a/src/vncpcap2john.c
+++ b/src/vncpcap2john.c
@@ -205,6 +205,11 @@ _Bool Packet_Reader_kick(struct Packet_Reader* self)
 		snprintf(buf, sizeof buf, "%s-%d", inet_ntoa(ip_header->ip_dst), ntohs(tcp->th_dport));
 		self->dest_addr_str = strdup(buf);
 
+		if (!self->src_addr_str || !self->dest_addr_str) {
+			fprintf(stderr, "%s:%d: strdup failed\n", __FUNCTION__, __LINE__);
+			exit(EXIT_FAILURE);
+		}
+
 		return true;	// successfully got a TCP packet of some kind (yay)
 	}
 
@@ -270,6 +275,10 @@ _Bool VNC_Auth_Reader_find_next(struct Packet_Reader* reader, char** id_out, cha
 				*response_out = response;
 				snprintf(buf, sizeof buf, "%s to %s", from, to);
 				*id_out = strdup(buf);
+				if (!*id_out) {
+					fprintf(stderr, "%s:%d: strdup failed\n", __FUNCTION__, __LINE__);
+					exit(EXIT_FAILURE);
+				}
 				free(from); free(to);
 				return true;
 			} else {


### PR DESCRIPTION
This is untested yet. It should fix #5035.

I think the only remaining place would be in MSVC-specific `vc_fixed_snprintf` - I'll just let that one crash if it's ever compiled in.