### PR TITLE
fixes of crashes found with fuzzing

### DIFF
--- a/src/electrum_fmt_plug.c
+++ b/src/electrum_fmt_plug.c
@@ -172,9 +172,11 @@ static int valid(char *ciphertext, struct fmt_main *self)
 			goto err;
 		if ((p = strtokm(NULL, "*")) == NULL) // data
 			goto err;
-		if (hexlenl(p, &extra) > 32 * 2 || extra)
+		if (hexlenl(p, &extra) != 32 * 2 || extra)
 			goto err;
 	}
+	if (strtokm(NULL, "*")) // no more fields
+		goto err;
 
 	MEM_FREE(keeptr);
 	return 1;

--- a/src/ntlmv1_mschapv2_fmt_plug.c
+++ b/src/ntlmv1_mschapv2_fmt_plug.c
@@ -516,6 +516,9 @@ static char *chap_prepare(char *split_fields[10], struct fmt_main *pFmt)
 	if (!strncmp(split_fields[1], FORMAT_TAG, FORMAT_TAG_LEN)) {
 		// check for a short format that has any extra trash fields, and if so remove them.
 		char *cp1, *cp2, *cp3;
+		static char *out;
+		if (!out)
+			out = mem_alloc_tiny(FORMAT_TAG_LEN + CHAP_CHALLENGE_LENGTH/4 + 1 + CIPHERTEXT_LENGTH + 3, MEM_ALIGN_NONE);
 		cp1 = split_fields[1];
 		cp1 += FORMAT_TAG_LEN;
 		cp2 = strchr(cp1, '$');
@@ -523,8 +526,9 @@ static char *chap_prepare(char *split_fields[10], struct fmt_main *pFmt)
 		if (cp2 && cp2-cp1 == CHAP_CHALLENGE_LENGTH/4) {
 			++cp2;
 			cp3 = strchr(cp2, '$');
-			if (cp3 && cp3-cp2 == CIPHERTEXT_LENGTH && (strlen(cp3) > 2 || cp3[2] != '$')) {
-				ret = str_alloc_copy(split_fields[1]);
+			if (cp3 && cp3-cp2 == CIPHERTEXT_LENGTH && (strlen(cp3) > 2 || cp3[1] != '$')) {
+				ret = out;
+				memcpy(ret, split_fields[1], cp3-split_fields[1] + 1);
 				ret[(cp3-split_fields[1]) + 1] = '$';
 				ret[(cp3-split_fields[1]) + 2] = 0;
 				//printf("Here is the cut item: %s\n", ret);

--- a/src/opencl_electrum_modern_fmt_plug.c
+++ b/src/opencl_electrum_modern_fmt_plug.c
@@ -271,7 +271,9 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if ((p = strtokm(NULL, "*")) == NULL) // data
 		goto err;
-	if (hexlenl(p, &extra) > 32 * 2 || extra)
+	if (hexlenl(p, &extra) != 32 * 2 || extra)
+		goto err;
+	if (strtokm(NULL, "*")) // no more fields
 		goto err;
 
 	MEM_FREE(keeptr);


### PR DESCRIPTION
I continued fuzzing started in #4971.

Exact command:
```
for f in `cat ../formats3`; do date; echo "  $f"; /usr/bin/time ./run/john --format="$f" --fuzz=run/fuzz.dic 1>out4/"$f"-out 2>out4/"$f"-err; done
```

I tried regular and opencl formats:
- `MSCHAPv2`, `electrum`, `electrum-modern-opencl` crash
- `KeePass-opencl`, `KeePass`, `LUKS` get killed by OOM (#4979)
- various truecrypt formats exit failing to open file with name `2$3` (to be reported as separate issue)
- `bks`, `dmg`, `dmg-opencl`, `monero`, `pfx`, `pfx-opencl`, `rsvp` spent 50 or more minutes with fuzzer and did not complete because I stopped it

I fixed the crashes.

`mschapv2`: `--fuzz=run/fuzz.dic` and `--test` are ok. The change is the same as for `mschapv2-naive`.

`electrum`, `electrum-modern-opencl`: `--test` is ok, `--fuzz=run/fuzz.dic` took 14 hours and was stopped. I added check that there are no additional fields, it is not required to fix crash.

PR is ready.