### PR TITLE
TrueCrypt formats: fixed overflows in handling of keyfiles

### DIFF
--- a/src/truecrypt_fmt_plug.c
+++ b/src/truecrypt_fmt_plug.c
@@ -61,6 +61,7 @@ john_register_one(&fmt_truecrypt_whirlpool);
 #include "pbkdf2_hmac_sha512.h"
 #include "pbkdf2_hmac_ripemd160.h"
 #include "pbkdf2_hmac_whirlpool.h"
+#include "john.h"
 
 /* 64 is the actual maximum used by Truecrypt software as of version 7.1a */
 #define PLAINTEXT_LENGTH        64
@@ -327,12 +328,18 @@ static void* get_salt(char *ciphertext)
 		/* read this into keyfiles_data[idx] */
 		fp = fopen(tpath, "rb");
 		if (!fp)
-			pexit("fopen %s", p);
+			pexit("fopen %s", tpath);
 
 		if (fseek(fp, 0L, SEEK_END) == -1)
 			pexit("fseek");
 
 		sz = ftell(fp);
+
+		if (sz > MAX_KFILE_SZ) {
+			if (john_main_process)
+				fprintf(stderr, "Error: keyfile '%s' is bigger than maximum size (MAX_KFILE_SZ is %d).\n", tpath, MAX_KFILE_SZ);
+			error();
+		}
 
 		if (fseek(fp, 0L, SEEK_SET) == -1)
 			pexit("fseek");

--- a/src/truecrypt_fmt_plug.c
+++ b/src/truecrypt_fmt_plug.c
@@ -193,7 +193,9 @@ static int valid(char* ciphertext, int pos)
 {
 	unsigned int i;
 	char *p, *q;
-	int nkeyfiles = -1;
+	int nkeyfiles, idx;
+	char tpath[PATH_BUFFER_SIZE];
+	size_t len;
 
 	p = ciphertext + pos;
 	q = strchr(p, '$');
@@ -204,10 +206,38 @@ static int valid(char* ciphertext, int pos)
 	} else {
 		if (q - p != 512 * 2)
 			return 0;
-		/* check keyfile(s) */
+		/* check number of keyfile(s) */
 		p = q + 1;
+		q = strchr(p, '$');
+		if (!q) /* number implies at least 1 filename */
+			return 0;
+		/* We use same buffer for number. */
+		len = q - p;
+		if (len > sizeof(tpath) - 1)
+			return 0;
+		memcpy(tpath, p, len);
+		tpath[len] = '\0';
+		if (!isdec(tpath))
+			return 0;
 		nkeyfiles = atoi(p);
 		if (nkeyfiles > MAX_KEYFILES || nkeyfiles < 1)
+			return 0;
+		/* check keyfile(s) */
+		for (idx = 0; idx < nkeyfiles; idx++) {
+			p = strchr(p, '$') + 1;
+			q = strchr(p, '$');
+
+			if (!q) { // last file
+				if (idx != nkeyfiles - 1)
+					return 0;
+				len = strlen(p);
+			} else {
+				len = q - p;
+			}
+			if (len > sizeof(tpath) - 1)
+				return 0;
+		}
+		if (q) // last expected filename is not last
 			return 0;
 	}
 
@@ -266,11 +296,11 @@ static void* get_salt(char *ciphertext)
 	static char buf[sizeof(struct cust_salt)+4];
 	struct cust_salt *s = (struct cust_salt *)mem_align(buf, 4);
 	unsigned int i;
-	char tpath[PATH_BUFFER_SIZE] = {0};
+	char tpath[PATH_BUFFER_SIZE];
 	char *p, *q;
 	int idx;
 	FILE *fp;
-	size_t sz;
+	size_t sz, len;
 
 	memset(s, 0, sizeof(struct cust_salt));
 
@@ -319,12 +349,18 @@ static void* get_salt(char *ciphertext)
 		q = strchr(p, '$');
 
 		if (!q) { // last file
-			memset(tpath, 0, sizeof(tpath) - 1);
-			strncpy(tpath, p, sizeof(tpath));
+			len = strlen(p);
 		} else {
-			memset(tpath, 0, sizeof(tpath) - 1);
-			strncpy(tpath, p, q-p);
+			len = q - p;
 		}
+		if (len > sizeof(tpath) - 1) {
+			// should never get here!  valid() should catch all lines with overly long paths
+			if (john_main_process)
+				fprintf(stderr, "Error, path is too long in truecrypt::get_salt(), [%.10s...]\n", p);
+			error();
+		}
+		memcpy(tpath, p, len);
+		tpath[len] = '\0';
 		/* read this into keyfiles_data[idx] */
 		fp = fopen(tpath, "rb");
 		if (!fp)


### PR DESCRIPTION
- fixed the minor problem about wrong name from #5068
- added check of file sizes in cpu and opencl formats in `get_salt`
- opencl format allocated memory in wrong function, so keyfiles did not work; fixed
- opencl format used strings without null bytes for candidates, so it crashed in `crypt_all` after a few seconds; so I changed 2 calls of `apply_keyfiles` providing length

`--format=TrueCrypt-opencl,tc_aes_xts,tc_ripemd160,tc_ripemd160boot,tc_sha512,tc_whirlpool --test` is ok.

`--fuzz` does not work due to filenames (#5068).

PR is ready.