### PR TITLE
dmg2john: replaced inlined htonl() with john_htonl(), fixes big-endian

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -304,7 +304,7 @@ DES_std.o:	DES_std.c arch.h common.h memory.h DES_std.h os.h os-autoconf.h autoc
 
 detect.o:	detect.c
 
-dmg2john.o:	dmg2john.c autoconfig.h arch.h filevault.h misc.h jumbo.h memory.h os.h os-autoconf.h
+dmg2john.o:	dmg2john.c autoconfig.h arch.h filevault.h misc.h jumbo.h memory.h johnswap.h os.h os-autoconf.h
 
 dummy.o:	dummy.c common.h arch.h memory.h formats.h params.h misc.h jumbo.h autoconfig.h options.h list.h loader.h getopt.h os.h os-autoconf.h
 

--- a/src/dmg2john.c
+++ b/src/dmg2john.c
@@ -239,7 +239,7 @@ static void hash_plugin_parse_hash(char *in_filepath)
 			fprintf(stderr, "Unable to seek in %s\n", filename);
 			goto bailout;
 		}
-		if (read(fd, &header, sizeof(cencrypted_v1_header)) < 1) {
+		if (read(fd, &header, sizeof(cencrypted_v1_header)) != sizeof(cencrypted_v1_header)) {
 			fprintf(stderr, "%s is not a DMG file!\n", filename);
 			goto bailout;
 		}
@@ -277,7 +277,7 @@ static void hash_plugin_parse_hash(char *in_filepath)
 			fprintf(stderr, "Unable to seek in %s\n", filename);
 			goto bailout;
 		}
-		if (read(fd, &header2, sizeof(cencrypted_v2_header)) < 1) {
+		if (read(fd, &header2, sizeof(cencrypted_v2_header)) != sizeof(cencrypted_v2_header)) {
 			fprintf(stderr, "%s is not a DMG file!\n", filename);
 			goto bailout;
 		}

--- a/src/dmg2john.c
+++ b/src/dmg2john.c
@@ -42,23 +42,11 @@
 #include "misc.h"
 #include "jumbo.h"
 #include "memory.h"
+#include "johnswap.h"
 
-#ifndef ntohl
-#if ARCH_LITTLE_ENDIAN
-#define htonl(x) ((((x)>>24) & 0xffL) | (((x)>>8) & 0xff00L) | \
-		(((x)<<8) & 0xff0000L) | (((x)<<24) & 0xff000000L))
-
-#define ntohl(x) ((((x)>>24) & 0xffL) | (((x)>>8) & 0xff00L) | \
-		(((x)<<8) & 0xff0000L) | (((x)<<24) & 0xff000000L))
-#else
-#define htonl(x) (x)
-#define ntohl(x) (x)
-#endif
-#endif
-
-#ifndef ntohll
-#define ntohll(x) (((uint64_t) ntohl((x) >> 32)) | (((uint64_t) ntohl((uint32_t) ((x) & 0xFFFFFFFF))) << 32))
-#endif
+#define htonl(x) john_htonl((x))
+#define ntohl(x) john_ntohl((x))
+#define ntohll(x) john_ntohll((x))
 
 #define LARGE_ENOUGH 8192
 

--- a/src/dmg2john.c
+++ b/src/dmg2john.c
@@ -44,55 +44,53 @@
 #include "memory.h"
 #include "johnswap.h"
 
-#define htonl(x) john_htonl((x))
-#define ntohl(x) john_ntohl((x))
-#define ntohll(x) john_ntohll((x))
+#define inplace_ntohl(x) do { (x) = john_ntohl((x)); } while (0)
 
 #define LARGE_ENOUGH 8192
 
 static void header_byteorder_fix(cencrypted_v1_header *hdr)
 {
-	hdr->kdf_iteration_count = htonl(hdr->kdf_iteration_count);
-	hdr->kdf_salt_len = htonl(hdr->kdf_salt_len);
-	hdr->len_wrapped_aes_key = htonl(hdr->len_wrapped_aes_key);
-	hdr->len_hmac_sha1_key = htonl(hdr->len_hmac_sha1_key);
-	hdr->len_integrity_key = htonl(hdr->len_integrity_key);
+	inplace_ntohl(hdr->kdf_iteration_count);
+	inplace_ntohl(hdr->kdf_salt_len);
+	inplace_ntohl(hdr->len_wrapped_aes_key);
+	inplace_ntohl(hdr->len_hmac_sha1_key);
+	inplace_ntohl(hdr->len_integrity_key);
 }
 
 static void header2_byteorder_fix(cencrypted_v2_header *header)
 {
-	header->version = ntohl(header->version);
-	header->enc_iv_size = ntohl(header->enc_iv_size);
-	header->encMode = ntohl(header->encMode);
-	header->encAlg = ntohl(header->encAlg);
-	header->keyBits = ntohl(header->keyBits);
-	header->prngalg = ntohl(header->prngalg);
-	header->prngkeysize = ntohl(header->prngkeysize);
-	header->blocksize = ntohl(header->blocksize);
-	header->datasize = ntohll(header->datasize);
-	header->dataoffset = ntohll(header->dataoffset);
-	header->keycount = ntohl(header->keycount);
+	inplace_ntohl(header->version);
+	inplace_ntohl(header->enc_iv_size);
+	inplace_ntohl(header->encMode);
+	inplace_ntohl(header->encAlg);
+	inplace_ntohl(header->keyBits);
+	inplace_ntohl(header->prngalg);
+	inplace_ntohl(header->prngkeysize);
+	inplace_ntohl(header->blocksize);
+	header->datasize = john_ntohll(header->datasize);
+	header->dataoffset = john_ntohll(header->dataoffset);
+	inplace_ntohl(header->keycount);
 }
 
 static void v2_key_header_pointer_byteorder_fix(cencrypted_v2_key_header_pointer *key_header_pointer)
 {
-	key_header_pointer->header_type = ntohl(key_header_pointer->header_type);
-	key_header_pointer->header_offset = ntohl(key_header_pointer->header_offset);
-	key_header_pointer->header_size = ntohl(key_header_pointer->header_size);
+	inplace_ntohl(key_header_pointer->header_type);
+	inplace_ntohl(key_header_pointer->header_offset);
+	inplace_ntohl(key_header_pointer->header_size);
 }
 
 static void v2_password_header_byteorder_fix(cencrypted_v2_password_header *password_header)
 {
-	password_header->algorithm = ntohl(password_header->algorithm);
-	password_header->prngalgo = ntohl(password_header->prngalgo);
-	password_header->itercount = ntohl(password_header->itercount);
-	password_header->salt_size = ntohl(password_header->salt_size);
-	password_header->iv_size = ntohl(password_header->iv_size);
-	password_header->blob_enc_keybits = ntohl(password_header->blob_enc_keybits);
-	password_header->blob_enc_algo = ntohl(password_header->blob_enc_algo);
-	password_header->blob_enc_padding = ntohl(password_header->blob_enc_padding);
-	password_header->blob_enc_mode = ntohl(password_header->blob_enc_mode);
-	password_header->keyblobsize = ntohl(password_header->keyblobsize);
+	inplace_ntohl(password_header->algorithm);
+	inplace_ntohl(password_header->prngalgo);
+	inplace_ntohl(password_header->itercount);
+	inplace_ntohl(password_header->salt_size);
+	inplace_ntohl(password_header->iv_size);
+	inplace_ntohl(password_header->blob_enc_keybits);
+	inplace_ntohl(password_header->blob_enc_algo);
+	inplace_ntohl(password_header->blob_enc_padding);
+	inplace_ntohl(password_header->blob_enc_mode);
+	inplace_ntohl(password_header->keyblobsize);
 }
 
 static void print_hex(unsigned char *str, int len)


### PR DESCRIPTION
Closes #5075

I tested this way:
```
$ ./run/dmg2john ../john-samples/Apple_DMG/* > dmg_orig.pw
[...]

[... changed code ...]
$ ./run/dmg2john ../john-samples/Apple_DMG/* > dmg_new.pw
[...]
$ cmp dmg_orig.pw dmg_new.pw
```

I removed `#ifndef ntohl`. `ntohl` is not defined for me. Actually all calls are located in `*_fix` functions at the beginning of file with linear code. So `sed` would work too.

Somehow `dmg2john` is not mentioned in `Makefile.legacy`.

`htonll` is not used. Together with names of functions, it makes me think that `htonl` should be `ntohl` really.

Changing functions, it might be more elegant to use specific macro to assign in place, like that:
```c
	inplace_fix(hdr->kdf_iteration_count);
// instead of
	hdr->kdf_iteration_count = htonl(hdr->kdf_iteration_count);
```

(And to make it more convenient (and implicit), it is possible to use `_Generic` to distinguish 32-bit and 64-bit fields. It would bump C to C11 though. Expanding idea further, I would list all fields with macro and sum `sizeof` of fields to `assert` that none of fields are skipped (in run-time unfortunately).)

If these possibilities should not be implemented, then PR is ready.