### PR TITLE
small changes, including disabling init of ztex boards during fuzzing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,10 @@ John the Ripper is released under GNU GPL v2 "or later", with portions also avai
 Solar Designer's current preference is that new code contributions be licensed under very liberal terms:
 ```
 /*
- * This software is Copyright (c) YEAR YOUR NAME <your at e-mail.address>,<br>
- * and it is hereby released to the general public under the following terms:<br>
- * Redistribution and use in source and binary forms, with or without<br>
- * modification, are permitted.<br>
+ * This software is Copyright (c) YEAR YOUR NAME <your at e-mail.address>,
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  */
 ```
 This is a heavily cut-down “BSD license”. You may also include the warranty disclaimer.

--- a/doc/DYNAMIC_EXPRESSIONS
+++ b/doc/DYNAMIC_EXPRESSIONS
@@ -65,7 +65,7 @@ Casing (note: only a few things can be cased)
   lc($p) and uc($p) are for lower/upper casing the password.
 ** If uc($u) or lc($u) are used in the expression, then ALL $u must be done
    the same way.  This also applies to the password.
-   so  md5($u.$p.$) is valid, but md5(uc($u).$p.$u) is not valid
+   so md5($u.$p.$u) is valid, but md5(uc($u).$p.$u) is not valid
    This is a limitation of the dynamic format in general.
    When using constants, they must be appended with commas to the end of
      the expression.  NOTE, if there are any ':' chars used in constants

--- a/doc/DYNAMIC_EXPRESSIONS
+++ b/doc/DYNAMIC_EXPRESSIONS
@@ -62,7 +62,7 @@ Variables:
 Casing (note: only a few things can be cased)
   lc($u) is for lower case of the user name (proper unicode lower casing)
   uc($u) is for upper case of the user name (again, proper unicode up casing)
-  lc($p and uc($p) are for lower/upper casing the password.
+  lc($p) and uc($p) are for lower/upper casing the password.
 ** If uc($u) or lc($u) are used in the expression, then ALL $u must be done
    the same way.  This also applies to the password.
    so  md5($u.$p.$) is valid, but md5(uc($u).$p.$u) is not valid

--- a/doc/INSTALL-FEDORA
+++ b/doc/INSTALL-FEDORA
@@ -10,7 +10,7 @@ build CPU fallback chains for any x86-64 CPU.
     (see below), you may simply enter the "run" directory and invoke John from
     there, e.g. with:
 
-    ./john --list=build-options
+    ./john --list=build-info
 
     Commands not explicitly prefixed by "sudo" must be run as a regular user
     (the one that will use JtR) rather than as root.

--- a/doc/INSTALL-UBUNTU
+++ b/doc/INSTALL-UBUNTU
@@ -10,7 +10,7 @@ build CPU fallback chains for any x86-64 CPU.
     (see below), you may simply enter the "run" directory and invoke John from
     there, e.g. with:
 
-    ./john --list=build-options
+    ./john --list=build-info
 
     Commands not explicitly prefixed by "sudo" must be run as a regular user
     (the one that will use JtR) rather than as root.

--- a/doc/MASK
+++ b/doc/MASK
@@ -104,44 +104,44 @@ We have on-device mask mode support for most fast hash types for which
 we have OpenCL support at all.  Further, such on-device mask support can
 be used along with a host-provided stream of partial candidate passwords
 to form a variety of hybrid modes.  For example, these are all valid:
- 
+
 Test any 7-character printable ASCII strings, with a reasonable number
 of the mask positions being processed on device (JtR decides to
 optimally split the mask between host and device):
 
 --mask='?a?a?a?a?a?a?a'
- 
+
 Ditto:
- 
+
 --mask='?a' --min-length=7 --max-length=7
 
 Ditto, but for range of lengths 1 to 8:
- 
+
 --mask='?a' --min-length=1 --max-length=8
- 
+
 Can also use length ranges with more complex masks, where the last mask
 component would be the one extended to higher lengths:
- 
+
 --mask='start?l?d' --min-length=7 --max-length=14
- 
+
 Use the host's incremental mode to test strings of digits in a smart
 order, then append 3 more digits in a dumber order on device, no
 specific length (so let incremental mode switch lengths back and forth
 like it usually does):
- 
+
 --incremental=digits --mask='?w?d?d?d'
- 
+
 Ditto, but limit this to (total) length of 8 (adjusts incremental mode
 to only produces length 5 for its portion):
- 
+
 --incremental=digits --mask='?w?d?d?d' --min-length=8 --max-length=8
- 
+
 Have the host generate all-lowercase substrings in a smart order, then
 prepend an uppercase letter and append 3 digits, at least some of this
 on device:
- 
+
 --incremental=lower --mask='?u?w?d?d?d'
- 
+
 Read a wordlist on host, apply wordlist rules on host, then append 3
 digits on device:
 

--- a/doc/README-OPENCL
+++ b/doc/README-OPENCL
@@ -172,7 +172,7 @@ cards by adding the 'Option "Interactive"' line to /etc/X11/xorg.conf:
 
 At this time we are not aware of any way to check or change this for AMD cards.
 What we do know is that some old AMD drivers will crash after repeated runs of
-as short durations as 200 ms, necessating a reboot.  If this happens, just
+as short durations as 200 ms, necessitating a reboot.  If this happens, just
 upgrade your driver.
 
 

--- a/doc/SHOW_FORMATS.md
+++ b/doc/SHOW_FORMATS.md
@@ -251,8 +251,8 @@ Formats to be tried may be limited with `--format=` option.
   - ad-hoc dynamic formats may be specified this way (e.g.
     `--format='sha512($s.sha512($p.$s).$p)'`, see doc/DYNAMIC ),
 
-- multiple formats may be specified by mask in `--format=` option
-  (e.g. `--format=*crypt`, `--format=mssql*`),
+- multiple formats may be specified in `--format=` option
+  (e.g. with wildcard `--format=*crypt`; see doc/OPTIONS ),
 
   - set of formats in john may differ between builds, so
     `--list=formats` with `--format=` may be used to check that

--- a/src/base64_convert.c
+++ b/src/base64_convert.c
@@ -798,6 +798,7 @@ size_t base64_convert(const void *from, b64_convert_type from_t, size_t from_len
 				case e_b64_mime:	/* mime */
 				{
 					if (to_len < from_len+1) {
+						if (alloced) MEM_FREE(fromWrk);
 						if (err) *err = ERR_base64_to_buffer_sz;
 						return 0;
 					}

--- a/src/c3_fmt.c
+++ b/src/c3_fmt.c
@@ -627,7 +627,7 @@ static int cmp_exact(char *source, int index)
 
 /*
  * For generic crypt(3), the algorithm is returned as the first "tunable cost":
- * 0: unknown (shouldn't happen
+ * 0: unknown (shouldn't happen)
  * 1: descrypt
  * 2: md5crypt
  * 3: sunmd5

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -8423,7 +8423,7 @@ int text_in_dynamic_format_already(struct fmt_main *pFmt, char *ciphertext)
 // if caseType == 4, return upcaseFirstChar(locase(cp))
 static char *HandleCase(char *cp, int caseType)
 {
-	static UTF8 dest[256];
+	static UTF8 dest[512];
 
 	switch(caseType) {
 		case 1:

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -8429,13 +8429,15 @@ static char *HandleCase(char *cp, int caseType)
 		case 1:
 			return cp;
 		case 2:
-			enc_uc(dest, sizeof(dest), (unsigned char*)cp, strlen(cp));
+			/* -1 is a temporary workaround for #5029 */
+			enc_uc(dest, sizeof(dest) - 1, (unsigned char*)cp, strlen(cp));
 			if (!strcmp((char*)dest, cp))
 				return cp;
 			break;
 		case 3:
 		case 4:
-			enc_lc(dest, sizeof(dest), (unsigned char*)cp, strlen(cp));
+			/* -1 is a temporary workaround for #5029 */
+			enc_lc(dest, sizeof(dest) - 1, (unsigned char*)cp, strlen(cp));
 			if (caseType == 4)
 				dest[0] = low2up_ansi(dest[0]);
 			if (!strcmp((char*)dest, cp))

--- a/src/luks_fmt_plug.c
+++ b/src/luks_fmt_plug.c
@@ -394,7 +394,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	if (is_inlined) {
 		if ((p = strtokm(NULL, "$")) == NULL)	/* dump data */
 			goto err;
-		len = (afsize + 2) / 3 * 4;
+		len = ((size_t)afsize + 2) / 3 * 4;
 		if (len != strlen(p))
 			goto err;
 		/* check base64 and precise number of trailing = */

--- a/src/pkzip_fmt_plug.c
+++ b/src/pkzip_fmt_plug.c
@@ -232,7 +232,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		if ((cp = strtokm(NULL, "*")) == NULL) goto Bail;
 		if (type > 1) {
 			if (type == 3) {
-				if ( strlen(cp) != data_len) {
+				if (strlen(cp) != data_len) {
 					sFailStr = "invalid checksum value";
 					goto Bail;
 				}
@@ -1456,7 +1456,7 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 
 			C = PKZ_MULT(*b++,key2);
 			SigChecked = 0;
-			if ( salt->H[cur_hash_idx].compType == 0) {
+			if (salt->H[cur_hash_idx].compType == 0) {
 				// handle a stored file.
 				// We can ONLY deal with these IF we are handling 'magic' testing.
 
@@ -1490,10 +1490,10 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 			// https://github.com/openwall/john/issues/467
 			// Ok, if this is a code 3, we are done.
 			// Code moved to after the check for stored type.  (FIXED)  This check was INVALID for a stored type file.
-			if ( (C & 6) == 6)
+			if ((C & 6) == 6)
 				goto Failed_Bailout;
 #endif
-			if ( (C & 6) == 0) {
+			if ((C & 6) == 0) {
 				// Check that checksum2 is 0 or 1.  If not, I 'think' we can be done
 				if (C > 1)
 					goto Failed_Bailout;
@@ -1501,7 +1501,7 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 				// these 2 values are checksumed, so it is easy to tell if the data is WRONG.
 				// correct data is u16_1 == (u16_2^0xFFFF)
 				curDecryBuf[0] = C;
-				for (e = 0; e <= 4; ) {
+				for (e = 0; e <= 4;) {
 					key0.u = jtr_crc32 (key0.u, curDecryBuf[e]);
 					key1.u = (key1.u + key0.c[KB1]) * 134775813 + 1;
 					key2.u = jtr_crc32 (key2.u, key1.c[KB2]);
@@ -1541,7 +1541,7 @@ static int crypt_all(int *pcount, struct db_salt *_salt)
 
 				curDecryBuf[0] = C;
 
-				if ((C&6) == 4) { // inflate 'code' 2  (variable table)
+				if ((C & 6) == 4) { // inflate 'code' 2  (variable table)
 #if (ZIP_DEBUG==2)
 					static unsigned count, found;
 					++count;

--- a/src/ztex_common.c
+++ b/src/ztex_common.c
@@ -25,6 +25,9 @@ void ztex_init()
 {
 	static int ztex_initialized;
 
+	if (options.flags & FLG_FUZZ_CHK)
+		return;
+
 	if (ztex_initialized)
 		return;
 


### PR DESCRIPTION
`--fuzz` did not work for `ztex` formats without boards connected with `No ZTEX devices found.`, so I added a check.

Meanwhile `--fuzz-dump` worked.

I completed `--format=ztex --fuzz=run/fuzz.dic` with the fix without real boards connected.

`max_keys_per_crypt` is set in `device_format_reset` based on number of boards (and mask in use). But fuzzing does not call `reset`.

I checked my last statement with `gdb` (both `nt` and `raw-md5` use `fmt_default_reset`):
```
$ printf 'break fmt_default_reset \n run --format=raw-md5,nt --fuzz\n bt' | gdb ./run/john
[...]
[Inferior 1 (process 31908) exited with code 01]
(gdb) No stack.
(gdb) quit
```

Other changes are minor.

Maybe I should join commits for `doc` into single.

If I should not, then this PR is ready.