### PR TITLE
cloudkeychain: check input salt and masterkey lengths

### DIFF
--- a/src/cloudkeychain_common.h
+++ b/src/cloudkeychain_common.h
@@ -27,7 +27,7 @@ struct custom_salt {
 	unsigned char masterkey[CTLEN];
 	unsigned int plaintextlen;
 	unsigned int ivlen;
-	unsigned char iv[32];
+	unsigned char iv[IVLEN];
 	unsigned int cryptextlen;
 	unsigned char cryptext[CTLEN];
 	unsigned int expectedhmaclen;

--- a/src/cloudkeychain_common_plug.c
+++ b/src/cloudkeychain_common_plug.c
@@ -37,6 +37,8 @@ int cloudkeychain_valid(char *ciphertext, struct fmt_main *self)
 	if (!isdec(p))
 		goto err;
 	len = atoi(p);
+	if (len > SALTLEN)
+		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL)	/* salt */
 		goto err;
 	if (hexlenl(p, &extra)/2 != len || extra)
@@ -50,6 +52,8 @@ int cloudkeychain_valid(char *ciphertext, struct fmt_main *self)
 	if (!isdec(p))
 		goto err;
 	len = atoi(p);
+	if (len > CTLEN)
+		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL)	/* masterkey */
 		goto err;
 	if (hexlenl(p, &extra)/2 != len || extra)


### PR DESCRIPTION
Check lengths to avoid buffer overflow. Solves #5090 .