### PR TITLE
Fix build warnings for EncDataVault formats

### DIFF
--- a/src/encdatavault_common.h
+++ b/src/encdatavault_common.h
@@ -6,9 +6,9 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
- * 
+ *
  * This file is for common code between the two formats.
- * 
+ *
  */
 #include <string.h>
 
@@ -38,7 +38,7 @@ typedef union buffer_128_u {
 	uint64_t u64[2];
 } buffer_128;
 
-static struct salt {
+typedef struct {
 	unsigned int version;
 	unsigned int algo_id;
 	unsigned char iv[ENC_IV_SIZE];
@@ -47,7 +47,7 @@ static struct salt {
 	unsigned int iterations;
 	unsigned char encrypted_data[ENC_BLOCK_SIZE];
 	unsigned char keychain[ENC_KEYCHAIN_SIZE];
-} *cur_salt;
+} custom_salt;
 
 void enc_xor_block(uint64_t *dst, const uint64_t *src);
 void enc_aes_ctr_iterated(const unsigned char *in, unsigned char *out, const unsigned char *key,

--- a/src/encdatavault_common_plug.c
+++ b/src/encdatavault_common_plug.c
@@ -6,9 +6,9 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
- * 
+ *
  * This file is for common code between the two formats.
- * 
+ *
  */
 #include "encdatavault_common.h"
 
@@ -146,7 +146,7 @@ void *get_salt_common(char *ciphertext, int is_pbkdf2)
 {
 	int i;
 	char *p = ciphertext, *ctcopy, *keeptr;
-	static struct salt cs;
+	static custom_salt cs;
 
 	memset(&cs, 0, sizeof(cs));
 	ctcopy = xstrdup(ciphertext);

--- a/src/encdatavault_md5_fmt_plug.c
+++ b/src/encdatavault_md5_fmt_plug.c
@@ -30,7 +30,7 @@ john_register_one(&fmt_encdadatavault_md5);
 #define PLAINTEXT_LENGTH          	125
 #define BINARY_SIZE               	0
 #define BINARY_ALIGN              	1
-#define SALT_SIZE                 	sizeof(struct salt)
+#define SALT_SIZE                 	sizeof(custom_salt)
 #define SALT_ALIGN                	4
 #define MIN_KEYS_PER_MD5_CRYPT		1
 #define MAX_KEYS_PER_MD5_CRYPT		1
@@ -76,6 +76,7 @@ static struct fmt_tests encdatavault_md5_tests[] = {
 	{ NULL }
 };
 
+static custom_salt *cur_salt;
 static int *cracked;
 static int any_cracked;
 static size_t cracked_size;
@@ -109,7 +110,7 @@ static void *get_salt_md5(char *ciphertext)
 
 static void set_salt(void *salt)
 {
-	cur_salt = (struct salt *)salt;
+	cur_salt = (custom_salt *)salt;
 }
 
 static int crypt_all_md5(int *pcount, struct db_salt *salt)

--- a/src/encdatavault_pbkdf2_fmt_plug.c
+++ b/src/encdatavault_pbkdf2_fmt_plug.c
@@ -34,7 +34,7 @@ john_register_one(&fmt_encdadatavault_pbkdf2);
 #define PLAINTEXT_LENGTH          	125
 #define BINARY_SIZE               	0
 #define BINARY_ALIGN              	1
-#define SALT_SIZE                 	sizeof(struct salt)
+#define SALT_SIZE                 	sizeof(custom_salt)
 #define SALT_ALIGN                	4
 #ifdef SIMD_COEF_32
 #define MIN_KEYS_PER_PBKDF2_CRYPT	SSE_GROUP_SZ_SHA256
@@ -60,6 +60,7 @@ static struct fmt_tests encdatavault_pbkdf2_tests[] = {
 	{ NULL }
 };
 
+static custom_salt *cur_salt;
 static int *cracked;
 static int any_cracked;
 static size_t cracked_size;
@@ -93,7 +94,7 @@ static void *get_salt_pbkdf2(char *ciphertext)
 
 static void set_salt(void *salt)
 {
-	cur_salt = (struct salt *)salt;
+	cur_salt = (custom_salt *)salt;
 }
 
 static int crypt_all_pbkdf2(int *pcount, struct db_salt *salt)
@@ -125,7 +126,7 @@ static int crypt_all_pbkdf2(int *pcount, struct db_salt *salt)
 			key_len = nb_keys * ENC_KEY_SIZE;
 		} else {
 			key_len = ENC_MAX_KEY_NUM * ENC_KEY_SIZE;
-		} 
+		}
 #ifdef SIMD_COEF_32
 		int lens[MIN_KEYS_PER_PBKDF2_CRYPT];
 		unsigned char *pin[MIN_KEYS_PER_PBKDF2_CRYPT], *pout[MIN_KEYS_PER_PBKDF2_CRYPT];
@@ -228,7 +229,7 @@ static char *get_key(int index)
 
 static unsigned int tunable_cost_iterations(void *_salt)
 {
-	struct salt *cs = (struct salt *)_salt;
+	custom_salt *cs = (custom_salt *)_salt;
 	return cs->iterations;
 }
 


### PR DESCRIPTION
Closes #5100

Also includes some whitespace violation fixes that my editor handled automagically, as they all should.