### PR TITLE
Disable the nvidia busy-wait workaround under macOS

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -419,7 +419,7 @@ AbortTemperature = 95
 SleepOnTemperature = 1
 
 # Enable a workaround for busy-waits, introducing calls to usleep(3).  This
-# currently only applies to nvidia.
+# currently only applies to nvidia (but not under macOS).
 AvoidBusyWait = Y
 
 [Options:OpenCL]

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -2385,6 +2385,7 @@ int opencl_prepare_dev(int sequential_id)
 		ocl_always_show_ws = cfg_get_bool(SECTION_OPTIONS, SUBSECTION_OPENCL,
 		                                  "AlwaysShowWorksizes", 0);
 
+#ifndef __APPLE__
 	if (gpu_nvidia(device_info[sequential_id])) {
 		opencl_avoid_busy_wait[sequential_id] = cfg_get_bool(SECTION_OPTIONS, SUBSECTION_GPU,
 		                                                     "AvoidBusyWait", 1);
@@ -2397,6 +2398,7 @@ int opencl_prepare_dev(int sequential_id)
 			log_event("- Busy-wait reduction %sabled", opencl_avoid_busy_wait[sequential_id] ? "en" : "dis");
 		}
 	}
+#endif
 
 	return sequential_id;
 }


### PR DESCRIPTION
Apple's drivers don't busy-wait.