### PR TITLE
ZIP-opencl: Bugfix

### DIFF
--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -236,7 +236,7 @@ static void set_salt(void *salt)
 		HANDLE_CLERROR(clReleaseMemObject(cl_data), "Release mem data");
 		cl_data = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, datasize, NULL, &ret_code);
 		HANDLE_CLERROR(ret_code, "Error creating buffer");
-		HANDLE_CLERROR(clSetKernelArg(final_kernel, 1, sizeof(cl_data), &cl_data),
+		HANDLE_CLERROR(clSetKernelArg(final_kernel, 3, sizeof(cl_data), &cl_data),
 		               "Error while setting mem_salt kernel argument");
 	}
 	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_salt, CL_FALSE, 0, saltsize, &currentsalt, 0, NULL, NULL),


### PR DESCRIPTION
The format would crash and burn for data sizes larger than 1024. The bug would only surface when using explicit work sizes as opposed to autotune. Bug was introduced in 4320dbe38 (Sep 16 2021).