### PR TITLE
added #ifdef to fix broken ztex build

### DIFF
--- a/src/ztex_common.c
+++ b/src/ztex_common.c
@@ -25,8 +25,10 @@ void ztex_init()
 {
 	static int ztex_initialized;
 
+#ifdef HAVE_FUZZ
 	if (options.flags & FLG_FUZZ_CHK)
 		return;
+#endif
 
 	if (ztex_initialized)
 		return;


### PR DESCRIPTION
@AlbertVeli found that I broke ztex build in e4f352f2947ec37954f0753bf52f8b1154d92b2d.

`make` fails after `configure` with `--enable-ztex` without `--enable-fuzz`:
```
ztex_common.c: In function ‘ztex_init’:
ztex_common.c:29:22: error: ‘FLG_FUZZ_CHK’ undeclared (first use in this function); did you mean ‘FLG_PIPE_CHK’?
  if (options.flags & FLG_FUZZ_CHK)
                      ^~~~~~~~~~~~
```

PR is ready.