### PR TITLE
minor changes: pfx's valid() and bug in fallback in enc_uc()

### DIFF
--- a/src/pfx_common_plug.c
+++ b/src/pfx_common_plug.c
@@ -11,7 +11,7 @@
 
 int pfx_valid(char *ciphertext, struct fmt_main *self)
 {
-	char *p = ciphertext, *ctcopy, *keeptr, *p2;
+	char *p = ciphertext, *ctcopy, *keeptr;
 	int mac_algo, saltlen, hashhex, extra;
 
 	if (strncasecmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
@@ -65,26 +65,17 @@ int pfx_valid(char *ciphertext, struct fmt_main *self)
 		goto bail;
 	if ((p = strtokm(NULL, "$")) == NULL) // salt
 		goto bail;
-	if (hexlenl(p, &extra) > saltlen * 2 || extra)
-		goto bail;
-	if (!ishexlc(p))
+	if (hexlenl(p, &extra) != saltlen * 2 || extra)
 		goto bail;
 	if ((p = strtokm(NULL, "$")) == NULL) // data
 		goto bail;
 	if (hexlenl(p, &extra) > MAX_DATA_LENGTH * 2 || extra)
 		goto bail;
-	if (!ishexlc(p))
-		goto bail;
 	if ((p = strtokm(NULL, "$")) == NULL) // stored_hmac (not stored in salt)
 		goto bail;
 	if (hexlenl(p, &extra) != hashhex || extra)
 		goto bail;
-
-	p2 = strrchr(ciphertext, '$');
-	if (!p2)
-		goto bail;
-	++p2;
-	if (strcmp(p, p2))
+	if (strtokm(NULL, "$")) // no more fields
 		goto bail;
 
 	MEM_FREE(keeptr);

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -1840,7 +1840,7 @@ ucFallback:
 		src_len = dst_bufsize - 1;
 	for (i = 0; i < src_len; ++i)
 		if (*src >= 'a' && *src <= 'z')
-			*dst++ = *src++ | 0x20;
+			*dst++ = *src++ ^ 0x20;
 		else
 			*dst++ = *src++;
 	*dst = 0;


### PR DESCRIPTION
pfx: I removed `ishexlc` calls that repeat checks by `hexlenl`. I replaced `<` with `!=` for `saltlen` because `saltlen` is read from ciphertext, so there are no reasons for data and length to mismatch. Also I replaced `strrchr` check of the last field with plain check that the field is the last.

`enc_uc`: ascii fallback uses `| 0x20` to uppercase char, so it does not work. I guess it was copy-pasted from `enc_lc`. I replaced it with `^ 0x20`. Same change is possible for `enc_lc` to keep code similar. But I did not change it.

Locally I added test code for `enc_uc` in `valid()` of `raw-md5`:
```c
        char test[1024];
        enc_uc(test, 5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 600);
        printf("test: %s\n", test);
        exit(1);
```

```
$ ../run/john --test --format=raw-md5 --encoding=utf-8
NOTE: This is a debug build, speed will be lower than normal
Benchmarking: Raw-MD5 [MD5 128/128 SSE4.1 4x3, UTF-8]... test: aaaa
```

`--encoding=utf-8` is important here, otherwise fallback is not triggered. After fix, the example prints `AAAA`.