### PR TITLE
PDF format: Allow P as signed or unsigned int - 32-bit build bugfix

### DIFF
--- a/src/pdf_fmt_plug.c
+++ b/src/pdf_fmt_plug.c
@@ -318,7 +318,7 @@ static void *get_salt(char *ciphertext)
 	p = strtokm(NULL, "*");
 	cs.length = atoi(p);
 	p = strtokm(NULL, "*");
-	cs.P = atoi(p);
+	cs.P = (int)strtoll(p, (char **)NULL, 10);
 	p = strtokm(NULL, "*");
 	cs.encrypt_metadata = atoi(p);
 	p = strtokm(NULL, "*");


### PR DESCRIPTION
Value can be -2147483648 .. 4294967295.  Closes #5114