### PR TITLE
TrueCrypt fixes related to keyfiles

### DIFF
--- a/run/truecrypt2john.py
+++ b/run/truecrypt2john.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     options, remainder = parser.parse_args()
 
     keyfiles = []
-    if len(remainder) > 2:
+    if len(remainder) >= 2:
         keyfiles = remainder[1:]
 
     process_file(remainder[0], keyfiles, options)

--- a/src/truecrypt_fmt_plug.c
+++ b/src/truecrypt_fmt_plug.c
@@ -101,9 +101,6 @@ static unsigned char (*first_block_dec)[16];
 #define MAX_KFILE_SZ            1048576 /* 1 MB */
 #define MAX_KEYFILES            256
 
-// keyfile(s) data
-static unsigned char (*keyfiles_data)[MAX_KFILE_SZ];
-static int (*keyfiles_length);
 static int *cracked;
 
 static struct cust_salt {
@@ -125,6 +122,7 @@ static struct cust_salt {
 	int num_iterations;
 	int hash_type;
 	int nkeyfiles;
+	unsigned char kpool[KPOOL_SZ];
 } *psalt;
 
 static struct fmt_tests tests_ripemd160[] = {
@@ -171,10 +169,6 @@ static void init(struct fmt_main *self)
 			sizeof(*key_buffer));
 	first_block_dec = mem_calloc(self->params.max_keys_per_crypt,
 			sizeof(*first_block_dec));
-	keyfiles_data = mem_calloc(MAX_KEYFILES,
-			sizeof(*keyfiles_data));
-	keyfiles_length = mem_calloc(MAX_KEYFILES,
-			sizeof(int));
 	cracked = mem_calloc(sizeof(*cracked),
 			self->params.max_keys_per_crypt);
 	Twofish_initialise();
@@ -184,8 +178,6 @@ static void done(void)
 {
 	MEM_FREE(first_block_dec);
 	MEM_FREE(key_buffer);
-	MEM_FREE(keyfiles_data);
-	MEM_FREE(keyfiles_length);
 	MEM_FREE(cracked);
 }
 
@@ -295,12 +287,13 @@ static void* get_salt(char *ciphertext)
 {
 	static char buf[sizeof(struct cust_salt)+4];
 	struct cust_salt *s = (struct cust_salt *)mem_align(buf, 4);
-	unsigned int i;
 	char tpath[PATH_BUFFER_SIZE];
 	char *p, *q;
-	int idx;
+	int i, idx, kpool_idx;
 	FILE *fp;
 	size_t sz, len;
+	uint32_t crc;
+	unsigned char *keyfile_data;
 
 	memset(s, 0, sizeof(struct cust_salt));
 
@@ -361,7 +354,7 @@ static void* get_salt(char *ciphertext)
 		}
 		memcpy(tpath, p, len);
 		tpath[len] = '\0';
-		/* read this into keyfiles_data[idx] */
+		/* read this into keyfile_data */
 		fp = fopen(tpath, "rb");
 		if (!fp)
 			pexit("fopen %s", tpath);
@@ -370,6 +363,11 @@ static void* get_salt(char *ciphertext)
 			pexit("fseek");
 
 		sz = ftell(fp);
+
+		if (sz == 0) {
+			fclose(fp);
+			continue;
+		}
 
 		if (sz > MAX_KFILE_SZ) {
 			if (john_main_process)
@@ -380,24 +378,38 @@ static void* get_salt(char *ciphertext)
 		if (fseek(fp, 0L, SEEK_SET) == -1)
 			pexit("fseek");
 
-		if (fread(keyfiles_data[idx], 1, sz, fp) != sz)
+		keyfile_data = mem_alloc(sz);
+		if (fread(keyfile_data, 1, sz, fp) != sz)
 			pexit("fread");
 
-		keyfiles_length[idx] = sz;
 		fclose(fp);
+
+		/* Mix keyfile into kpool */
+		kpool_idx = 0;
+		crc = ~0U;
+		for (i = 0; i < sz; i++) {
+			crc = jtr_crc32(crc, keyfile_data[i]);
+			s->kpool[kpool_idx++] += (unsigned char)(crc >> 24);
+			s->kpool[kpool_idx++] += (unsigned char)(crc >> 16);
+			s->kpool[kpool_idx++] += (unsigned char)(crc >> 8);
+			s->kpool[kpool_idx++] += (unsigned char)(crc);
+			/* Wrap around */
+			if (kpool_idx == KPOOL_SZ)
+				kpool_idx = 0;
+		}
+
+		free(keyfile_data);
 	}
+
+	/* Once kpool is ready, number of keyfiles does not matter. */
+	s->nkeyfiles = 1;
 
 	return s;
 }
 
-static int apply_keyfiles(unsigned char *pass, size_t pass_memsz, int nkeyfiles)
+static int apply_keyfiles(unsigned char *pass, size_t pass_memsz)
 {
-	int pl, k;
-	unsigned char *kpool;
-	unsigned char *kdata;
-	int kpool_idx;
-	size_t i, kdata_sz;
-	uint32_t crc;
+	int pl, i;
 
 	if (pass_memsz < MAX_PASSSZ) {
 		error();
@@ -406,34 +418,9 @@ static int apply_keyfiles(unsigned char *pass, size_t pass_memsz, int nkeyfiles)
 	pl = strlen((char *)pass);
 	memset(pass+pl, 0, MAX_PASSSZ-pl);
 
-	if ((kpool = mem_calloc(1, KPOOL_SZ)) == NULL) {
-		error();
-	}
-
-	for (k = 0; k < nkeyfiles; k++) {
-		kpool_idx = 0;
-		kdata_sz = keyfiles_length[k];
-		kdata = keyfiles_data[k];
-		crc = ~0U;
-
-		for (i = 0; i < kdata_sz; i++) {
-			crc = jtr_crc32(crc, kdata[i]);
-			kpool[kpool_idx++] += (unsigned char)(crc >> 24);
-			kpool[kpool_idx++] += (unsigned char)(crc >> 16);
-			kpool[kpool_idx++] += (unsigned char)(crc >> 8);
-			kpool[kpool_idx++] += (unsigned char)(crc);
-
-			/* Wrap around */
-			if (kpool_idx == KPOOL_SZ)
-				kpool_idx = 0;
-		}
-	}
-
 	/* Apply keyfile pool to passphrase */
 	for (i = 0; i < KPOOL_SZ; i++)
-		pass[i] += kpool[i];
-
-	MEM_FREE(kpool);
+		pass[i] += psalt->kpool[i];
 
 	return 0;
 }
@@ -520,7 +507,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 			/* process keyfile(s) */
 			if (psalt->nkeyfiles) {
-				apply_keyfiles(key, 64, psalt->nkeyfiles);
+				apply_keyfiles(key, 64);
 				ksz = 64;
 			}
 		}
@@ -540,7 +527,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 				/* process keyfile(s) */
 				if (psalt->nkeyfiles) {
-					apply_keyfiles(Keys[j], 64, psalt->nkeyfiles);
+					apply_keyfiles(Keys[j], 64);
 					lens[j] = 64;
 				}
 


### PR DESCRIPTION
`truecrypt2john.py` got simple fix. Without the fix, the tool omits keyfiles when only one keyfile is specified on command line.

Formats got fix for #5072. Each ciphertext with keyfiles gets its own allocated memory that the keyfiles are read into. So I can crack both volumes in the example with `TrueCrypt/TC-Volume`.

I used `mem_alloc_tiny`, so allocated memory is freed at the end of john's work. The proper way is to use `dyna_salt`, but I did not check this way yet. I had idea to collect allocated pointers into a list and free them in `done()`, but it seems similar to `mem_alloc_tiny`.

I repeated the fix for opencl format. But I did not test it. It turned out that keyfiles do not work at all (on pocl).

Cpu format is a bit tested.

So at the moment, this PR is a preview of changes.

Is it normal to include pointers into the salt struct? Comments mention salt dupe-removal. So I know that I touch ground unknown to me.