### PR TITLE
raw-md5, raw-md4: fixed broken build with reversing disabled

### DIFF
--- a/src/rawMD4_fmt_plug.c
+++ b/src/rawMD4_fmt_plug.c
@@ -230,6 +230,7 @@ static char *source(char *source, void *binary)
 
 #ifndef REVERSE_STEPS
 #undef SSEi_REVERSE_STEPS
+#define SSEi_REVERSE_STEPS 0
 #endif
 
 static int crypt_all(int *pcount, struct db_salt *salt)

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -247,6 +247,7 @@ static char *source(char *source, void *binary)
 
 #ifndef REVERSE_STEPS
 #undef SSEi_REVERSE_STEPS
+#define SSEi_REVERSE_STEPS 0
 #endif
 
 static int crypt_all(int *pcount, struct db_salt *salt)


### PR DESCRIPTION
Commenting out `#define REVERSE_STEPS` in `rawMD5_fmt_plug.c` breaks `raw-md5` format: `FAILED (cmp_all(1))`.

Comparing to `raw-sha256`, the code missed this line: `#define SSEi_REVERSE_STEPS 0`. Hence the fix.

Interestingly building does not fail. `SSEi_REVERSE_STEPS` is a member of enum. So `#undef SSEi_REVERSE_STEPS` does not matter.

(The problem was found during CracktheCon 2022 hash cracking contest.)