### PR TITLE
ztex: fix crash on failed open, improve warning, add -g to Makefile.in

### DIFF
--- a/src/ztex/Makefile.in
+++ b/src/ztex/Makefile.in
@@ -5,7 +5,7 @@
 # modification, are permitted.
 
 CC = gcc
-CFLAGS = -c -Wall -O2
+CFLAGS = -c -Wall -O2 -g
 CFLAGS_TEST = -O
 #LD = ld
 RM = /bin/rm -f

--- a/src/ztex/pkt_comm/Makefile.in
+++ b/src/ztex/pkt_comm/Makefile.in
@@ -5,7 +5,7 @@
 # modification, are permitted.
 
 CC = gcc
-CFLAGS = -c -Wall -O2
+CFLAGS = -c -Wall -O2 -g
 
 OBJS = pkt_comm.o word_gen.o word_list.o cmp_config.o inpkt.o init_data.o
 

--- a/src/ztex/ztex.c
+++ b/src/ztex/ztex.c
@@ -494,6 +494,8 @@ int ztex_scan_new_devices(struct ztex_dev_list *new_dev_list,
 				break;
 			}
 		}
+		if (!ztex_dev)
+			continue;
 
 		// found new device
 		if (ZTEX_DEBUG) printf("found: SN %s productId: %d.%d\n",

--- a/src/ztex/ztex.c
+++ b/src/ztex/ztex.c
@@ -555,10 +555,12 @@ int ztex_scan_new_devices(struct ztex_dev_list *new_dev_list,
 		fprintf(stderr, "Warning: unable to open %d board(s): ",
 			num_fail_access + num_fail_other);
 		if (!num_fail_other) {
-			fprintf(stderr, "insufficient permissions or "
+			fprintf(stderr, "insufficient permissions "
+				"(see doc/README-ZTEX) or "
 				"another instance of john running.\n");
 		} else {
-			fprintf(stderr, "%d insufficient permissions or "
+			fprintf(stderr, "%d insufficient permissions "
+				"(see doc/README-ZTEX) or "
 				"another instance of john running, %d ",
 				num_fail_access, num_fail_other);
 			if (num_fail_other == 1)


### PR DESCRIPTION
Closes #5125.

Now it shows such warning:
```
$ ../run/john --test --format=descrypt-ztex
Warning: unable to open 2 board(s): insufficient permissions (see doc/README-ZTEX) or another instance of john running.
No ZTEX devices found.
```

The warning without `(see doc/README-ZTEX) ` was in place already. It was not reached though.