### PR TITLE
prohibit FIFOs for wordlist+fork and as pot files

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -225,7 +225,8 @@ static void read_file(struct db_main *db, char *name, int flags,
 	}
 
 	if (!(file = fopen(path_expand(name), "r"))) {
-		if ((flags & RF_ALLOW_MISSING) && errno == ENOENT) return;
+		if ((flags & RF_ALLOW_MISSING) && errno == ENOENT)
+			return;
 		pexit("fopen: %s", path_expand(name));
 	}
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -247,15 +247,13 @@ static void read_file(struct db_main *db, char *name, int flags,
 			     options.input_enc == UTF_8)) {
 				if (!valid_utf8((UTF8*)u8check)) {
 					warn_enc = 0;
-					fprintf(stderr, "Warning: invalid UTF-8"
-					        " seen reading %s\n", name);
+					fprintf(stderr, "Warning: invalid UTF-8 seen reading %s\n", path_expand(name));
 				}
 			} else if (options.input_enc != UTF_8 &&
 			           (line != line_buf ||
 			            valid_utf8((UTF8*)u8check) > 1)) {
 				warn_enc = 0;
-				fprintf(stderr, "Warning: UTF-8 seen reading "
-				        "%s\n", name);
+				fprintf(stderr, "Warning: UTF-8 seen reading %s\n", path_expand(name));
 			}
 		}
 		process_line(db, line);

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #endif
 
+#define NEED_OS_FORK
 #include "os.h"
 
 #if !AC_BUILT
@@ -573,6 +574,14 @@ void do_wordlist_crack(struct db_main *db, const char *name, int rules)
 			pexit("fstat");
 
 		file_is_fifo = ((st.st_mode & S_IFMT) == S_IFIFO);
+
+#if OS_FORK
+		if (options.fork && file_is_fifo) {
+			if (john_main_process)
+				fprintf(stderr, "Error, cannot use --fork with FIFO as wordlist file.\n");
+			error();
+		}
+#endif
 
 		if (john_main_process)
 			log_event("- %s %s: %.100s", loopBack ? "Loopback pot" : "Wordlist",

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -607,8 +607,7 @@ void do_wordlist_crack(struct db_main *db, const char *name, int rules)
 		jtr_fseek64(word_file, 0, SEEK_SET);
 		if (file_len == 0 && !loopBack) {
 			if (john_main_process)
-				fprintf(stderr, "Error, dictionary file is "
-				        "empty\n");
+				fprintf(stderr, "Error, wordlist file is empty\n");
 			error();
 		}
 


### PR DESCRIPTION
- The first commit addresses #5000 as @solardiz suggested. Opening of file is done before `fstat`, so john waits other end of fifo to be opened and only then exits with error. I guess it is ok because user would be going to provide input, if we protect from intentional use.
- The second commit prohibits use of fifos as .pot files. Fifo as argument to `--loopback=` would be opened twice. So it would hang even with intentional use.
- Also I noticed that several warnings print 'name' without `path_expand()`. But 2 cases had `path_expand()` called earlier. The 2 fixed cases are not such.

I cannot say that I tested it well. I think there might be some consequences I could not foresee.