### PR TITLE
loader: add missing path_expand() causing skipping of default pot file

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -209,7 +209,7 @@ static void read_file(struct db_main *db, char *name, int flags,
 	warn_enc = (john_main_process && (options.target_enc != ENC_RAW) &&
 	            cfg_get_bool(SECTION_OPTIONS, NULL, "WarnEncoding", 0));
 
-	if (stat(name, &file_stat)) {
+	if (stat(path_expand(name), &file_stat)) {
 		if ((flags & RF_ALLOW_MISSING) && errno == ENOENT)
 			return;
 		pexit("stat: %s", path_expand(name));


### PR DESCRIPTION
#5131 broke loading cracks from the default pot. Problem was in place before my changes, but I moved it into the main code path so the default pot became affected.

From `strace` before this fix:
```
stat("$JOHN/john.pot", 0x7ffc791c56b0)  = -1 ENOENT (No such file or directory)
```

This PR is ready. Thanks!