### PR TITLE
fix gcc 11 warnings

### DIFF
--- a/src/bks_fmt_plug.c
+++ b/src/bks_fmt_plug.c
@@ -330,7 +330,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 			for (j = 0; j < SSE_GROUP_SZ_SHA1; ++j)
 				mackey[j] = real_keys[j];
-			pkcs12_pbe_derive_key_simd(1, cur_salt->iteration_count,
+			pkcs12_pbe_derive_key_simd_sha1(cur_salt->iteration_count,
 					MBEDTLS_PKCS12_DERIVE_MAC_KEY,
 					keys, lens, cur_salt->salt,
 					cur_salt->saltlen, mackey, mackeylen);
@@ -361,7 +361,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				iv[j] = iv_[j];
 				ckey[j] = ckey_[j];
 			}
-			pkcs12_pbe_derive_key_simd(1, cur_salt->iteration_count,
+			pkcs12_pbe_derive_key_simd_sha1(cur_salt->iteration_count,
 					MBEDTLS_PKCS12_DERIVE_IV,
 					keys,
 					lens, cur_salt->salt,
@@ -369,7 +369,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			// lengths get tromped on, so re-load them for the load keys call.
 			for (j = 0; j < SSE_GROUP_SZ_SHA1; ++j)
 				lens[j] = saved_len[index+j];
-			pkcs12_pbe_derive_key_simd(1, cur_salt->iteration_count,
+			pkcs12_pbe_derive_key_simd_sha1(cur_salt->iteration_count,
 					MBEDTLS_PKCS12_DERIVE_KEY,
 					keys,
 					lens, cur_salt->salt,

--- a/src/pfx_fmt_plug.c
+++ b/src/pfx_fmt_plug.c
@@ -220,7 +220,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				lens[j] = saved_len[index+j];
 				keys[j] = (const unsigned char*)(saved_key[index+j]);
 			}
-			pkcs12_pbe_derive_key_simd(cur_salt->mac_algo, cur_salt->iteration_count,
+			pkcs12_pbe_derive_key_simd_sha1(cur_salt->iteration_count,
 					MBEDTLS_PKCS12_DERIVE_MAC_KEY, keys,
 					lens, cur_salt->salt,
 					cur_salt->saltlen, mackey, mackeylen);
@@ -242,7 +242,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				lens[j] = saved_len[index+j];
 				keys[j] = (const unsigned char*)(saved_key[index+j]);
 			}
-			pkcs12_pbe_derive_key_simd(cur_salt->mac_algo, cur_salt->iteration_count,
+			pkcs12_pbe_derive_key_simd_sha256(cur_salt->iteration_count,
 					MBEDTLS_PKCS12_DERIVE_MAC_KEY, keys,
 					lens, cur_salt->salt,
 					cur_salt->saltlen, mackey, mackeylen);
@@ -265,7 +265,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				lens[j] = saved_len[index+j];
 				keys[j] = (const unsigned char*)(saved_key[index+j]);
 			}
-			pkcs12_pbe_derive_key_simd(cur_salt->mac_algo, cur_salt->iteration_count,
+			pkcs12_pbe_derive_key_simd_sha512(cur_salt->iteration_count,
 					MBEDTLS_PKCS12_DERIVE_MAC_KEY, keys,
 					lens, cur_salt->salt,
 					cur_salt->saltlen, mackey, mackeylen);

--- a/src/pkcs12.h
+++ b/src/pkcs12.h
@@ -55,11 +55,25 @@ int pkcs12_pbe_derive_key_simd( int md_type, int iterations, int id, const unsig
 		size_t pwdlen[SIMD_MAX_GROUP_PFX], const unsigned char *salt, size_t saltlen,
 		unsigned char *key[SIMD_MAX_GROUP_PFX], size_t keylen);
 
+
+int pkcs12_pbe_derive_key_simd_sha1( int iterations, int id, const unsigned char *pwd[SSE_GROUP_SZ_SHA1],
+		size_t pwdlen[SSE_GROUP_SZ_SHA1], const unsigned char *salt, size_t saltlen,
+		unsigned char *key[SSE_GROUP_SZ_SHA256], size_t keylen);
+
+int pkcs12_pbe_derive_key_simd_sha256( int iterations, int id, const unsigned char *pwd[SSE_GROUP_SZ_SHA256],
+		size_t pwdlen[SSE_GROUP_SZ_SHA256], const unsigned char *salt, size_t saltlen,
+		unsigned char *key[SSE_GROUP_SZ_SHA256], size_t keylen);
+
 #if defined(SIMD_COEF_64)
 
 #define SSE_GROUP_SZ_SHA512		(SIMD_COEF_64*SIMD_PARA_SHA512)
 
+int pkcs12_pbe_derive_key_simd_sha512( int iterations, int id, const unsigned char *pwd[SSE_GROUP_SZ_SHA512],
+		size_t pwdlen[SSE_GROUP_SZ_SHA512], const unsigned char *salt, size_t saltlen,
+		unsigned char *key[SSE_GROUP_SZ_SHA512], size_t keylen);
+
 #endif
+
 
 #endif
 

--- a/src/ripemd.c
+++ b/src/ripemd.c
@@ -238,7 +238,7 @@ static const sph_u32 IV320[10] = {
  * One round of RIPEMD. The data must be aligned for 32-bit access.
  */
 static void
-ripemd_round(const unsigned char *data, sph_u32 r[5])
+ripemd_round(const unsigned char *data, sph_u32 r[4])
 {
 #if SPH_LITTLE_FAST
 
@@ -527,7 +527,7 @@ sph_ripemd_comp(const sph_u32 msg[16], sph_u32 val[4])
  * One round of RIPEMD-128. The data must be aligned for 32-bit access.
  */
 static void
-ripemd128_round(const unsigned char *data, sph_u32 r[5])
+ripemd128_round(const unsigned char *data, sph_u32 r[4])
 {
 #if SPH_LITTLE_FAST
 
@@ -576,7 +576,7 @@ void sph_ripemd256_init(void *cc)
 }
 
 static void
-ripemd256_round(const unsigned char *data, sph_u32 r[10])
+ripemd256_round(const unsigned char *data, sph_u32 r[8])
 {
 #if SPH_LITTLE_FAST
 

--- a/src/sap_pse_fmt_plug.c
+++ b/src/sap_pse_fmt_plug.c
@@ -113,12 +113,12 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			pout[i] = key[i];
 			iout[i] = iv[i];
 		}
-		pkcs12_pbe_derive_key_simd(1,
+		pkcs12_pbe_derive_key_simd_sha1(
 				cur_salt->iterations,
 				MBEDTLS_PKCS12_DERIVE_KEY, (const unsigned char **)pin, lens,
 				cur_salt->salt, cur_salt->salt_size, pout, 24);
 
-		pkcs12_pbe_derive_key_simd(1,
+		pkcs12_pbe_derive_key_simd_sha1(
 				cur_salt->iterations,
 				MBEDTLS_PKCS12_DERIVE_IV, (const unsigned char **)pin, clens,
 				cur_salt->salt, cur_salt->salt_size, iout, 8);

--- a/src/zed_fmt_plug.c
+++ b/src/zed_fmt_plug.c
@@ -93,17 +93,21 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	int index;
 	const int count = *pcount;
 	int inc = 1;
+#if !defined(SIMD_COEF_32)
 	int algo = 0;
+#endif
 
 	if (cur_salt->algo == 21) {
-		algo = 1;
 #if defined(SIMD_COEF_32)
 		inc = SSE_GROUP_SZ_SHA1;
+#else
+		algo = 1;
 #endif
 	} else if (cur_salt->algo == 22) {
-		algo = 256;
 #if defined(SIMD_COEF_32)
 		inc = SSE_GROUP_SZ_SHA256;
+#else
+		algo = 256;
 #endif
 	}
 
@@ -132,7 +136,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				lens[j] = saved_len[index + j];
 				keys[j] = (const unsigned char*)(saved_key[index + j]);
 			}
-			pkcs12_pbe_derive_key_simd(algo, cur_salt->iteration_count,
+			pkcs12_pbe_derive_key_simd_sha1(cur_salt->iteration_count,
 			                           MBEDTLS_PKCS12_DERIVE_MAC_KEY, keys,
 			                           lens, cur_salt->salt,
 			                           salt_len, mackey,
@@ -147,7 +151,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				lens[j] = saved_len[index + j];
 				keys[j] = (const unsigned char*)(saved_key[index + j]);
 			}
-			pkcs12_pbe_derive_key_simd(algo, cur_salt->iteration_count,
+			pkcs12_pbe_derive_key_simd_sha256(cur_salt->iteration_count,
 			                           MBEDTLS_PKCS12_DERIVE_MAC_KEY, keys,
 			                           lens, cur_salt->salt,
 			                           salt_len, mackey,


### PR DESCRIPTION
As I described in #4637. Is this approach ok?

I renamed `mbedtls_pkcs12_derivation_simd1` into `...simd_sha1`. Also I added `static` to all `mbedtls_*` functions.

simd+openmp and non-simd+non-openmp build pass self-tests.