### PR TITLE
sapH and PerRuleStats fixes

### DIFF
--- a/src/DMD5_fmt_plug.c
+++ b/src/DMD5_fmt_plug.c
@@ -313,7 +313,7 @@ static void set_salt(void *salt)
 
 static void set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, PLAINTEXT_LENGTH + 1);
+	strnzcpy(saved_key[index], key, PLAINTEXT_LENGTH + 1);
 }
 
 static char *get_key(int index)

--- a/src/NETSPLITLM_fmt_plug.c
+++ b/src/NETSPLITLM_fmt_plug.c
@@ -263,7 +263,7 @@ static void netsplitlm_set_key(char *key, int index)
 	const unsigned char magic[] = {0x4b, 0x47, 0x53, 0x21, 0x40, 0x23, 0x24, 0x25};
 	DES_key_schedule ks;
 
-	strnzcpyn((char *)saved_plain[index], key, PLAINTEXT_LENGTH + 1);
+	strnzcpy((char *)saved_plain[index], key, PLAINTEXT_LENGTH + 1);
 
 	/* Upper-case password */
 	enc_strupper((char *)saved_plain[index]);

--- a/src/krb5_db_fmt_plug.c
+++ b/src/krb5_db_fmt_plug.c
@@ -201,7 +201,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 		return ciphertext;
 
 	memcpy(out, FORMAT_TAG_18, TAG_LENGTH_18);
-	strnzcpyn(out + TAG_LENGTH_18, ciphertext, CIPHERTEXT_LENGTH_18 + SALT_SIZE + 1);
+	strnzcpy(out + TAG_LENGTH_18, ciphertext, CIPHERTEXT_LENGTH_18 + SALT_SIZE + 1);
 
 	return out;
 }

--- a/src/nukedclan_fmt_plug.c
+++ b/src/nukedclan_fmt_plug.c
@@ -247,7 +247,7 @@ static int cmp_exact(char *source, int index)
 
 static void nk_set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
 }
 
 static char *get_key(int index)

--- a/src/openbsdsoftraid_fmt_plug.c
+++ b/src/openbsdsoftraid_fmt_plug.c
@@ -185,7 +185,7 @@ static int cmp_exact(char *source, int index)
 
 static void set_key(char* key, int index)
 {
-	strnzcpyn(key_buffer[index], key, sizeof(*key_buffer));
+	strnzcpy(key_buffer[index], key, sizeof(*key_buffer));
 }
 
 static char *get_key(int index)

--- a/src/ospf_fmt_plug.c
+++ b/src/ospf_fmt_plug.c
@@ -299,7 +299,7 @@ static int cmp_exact(char *source, int index)
 
 static void ospf_set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
 }
 
 static char *get_key(int index)

--- a/src/pgpwde_fmt_plug.c
+++ b/src/pgpwde_fmt_plug.c
@@ -150,7 +150,7 @@ static int cmp_exact(char *source, int index)
 
 static void set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, sizeof(saved_key[index]));
+	strnzcpy(saved_key[index], key, sizeof(saved_key[index]));
 }
 
 static char *get_key(int index)

--- a/src/pst_fmt_plug.c
+++ b/src/pst_fmt_plug.c
@@ -102,7 +102,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 }
 
 static void set_key(char *key, int index) {
-	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
 }
 
 static int cmp_all(void *binary, int count)

--- a/src/sapH_fmt_plug.c
+++ b/src/sapH_fmt_plug.c
@@ -86,8 +86,7 @@ john_register_one(&fmt_sapH);
 #define BENCHMARK_COMMENT		" (SHA1x1024)"
 #define BENCHMARK_LENGTH		7
 
-#define SALT_LENGTH             16  /* the max used sized salt */
-#define CIPHERTEXT_LENGTH       132 /* max salt+sha512 + 2^32 iterations */
+#define SALT_LENGTH             32  /* the max used sized salt */
 
 #define BINARY_SIZE             16 /* we cut off all hashes down to 16 bytes */
 #define MAX_BINARY_SIZE         64 /* sha512 is 64 byte */
@@ -133,6 +132,7 @@ static struct fmt_tests tests[] = {
 	{"{x-isSHA512, 7500}ctlX6qYsWspafEzwoej6nFp7zRQQjr8y22vE+xeveIX2gUndAw9N2Gep5azNUwuxOe2o7tusF800OfB9tg4taWI4Tg==","booboo"},
 	{"{x-isSHA512, 7500}Qyrh2JXgGkvIfKYOJRdWFut5/pVnXI/vZvqJ7N+Tz9M1zUTXGWCZSom4az4AhqOuAahBwuhcKqMq/pYPW4h3cThvT2JaWVBw","hapy1CCe!"},
 	{"{x-isSHA512, 18009}C2+Sij3JyXPPDuQgsF6Zot7XnjRFX86X67tWJpUzXNnFw2dKcGPH6HDEzVJ8HN8+cJe4vZaOYTlmdz09gI7YEwECAwQFBgcICQoLDA0ODwA=","maxlen"},
+	{"{x-isSHA512, 15000}2VwEw7rHLfYYblKU/ol7t6I7i2UjDOYOEW4H2iEHiUvNmNkxmM5rX5jcEAeRM6W+KQ0QBCsx1hDo9wXm+rbQPrL67ov+dGn/z+3o4f9pdIaJaU61YYQwl37PoYA7SvRU","Init123456"},
 
 	{NULL}
 };
@@ -168,7 +168,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	char *cp = ciphertext;
 	char *keeptr;
 	int len, hash_len=0;
-	char tmp[MAX_BINARY_SIZE+SALT_LENGTH];
+	char tmp[MAX_BINARY_SIZE+SALT_LENGTH+1];
 	/* first check for 'simple' signatures before allocation other stuff. */
 	if (!strncmp(cp, FORMAT_TAG, FORMAT_TAG_LEN))
 		hash_len = SHA1_BINARY_SIZE;
@@ -197,8 +197,16 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	len = base64_convert(cp, e_b64_mime, strlen(cp), tmp, e_b64_raw,
 	                     sizeof(tmp), flg_Base64_MIME_TRAIL_EQ|flg_Base64_DONOT_NULL_TERMINATE, 0);
 	len -= hash_len;
-	if (len < 1 || len > SALT_LENGTH)
+	if (len < 1)
 		goto err;
+	if (len > SALT_LENGTH) {
+		static int warned;
+		if (!warned) {
+			fprintf(stderr, "Warning: " FORMAT_LABEL " salt longer than max supported\n");
+			warned = 1;
+		}
+		goto err;
+	}
 
 	MEM_FREE(keeptr);
 	return 1;
@@ -214,7 +222,7 @@ static void set_salt(void *salt)
 
 static void set_key(char *key, int index)
 {
-	strnzcpyn(saved_plain[index], key, sizeof(*saved_plain));
+	strnzcpy(saved_plain[index], key, sizeof(*saved_plain));
 }
 
 static char *get_key(int index)

--- a/src/ssh_fmt_plug.c
+++ b/src/ssh_fmt_plug.c
@@ -497,7 +497,7 @@ static int cmp_exact(char *source, int index)
 #undef set_key /* OpenSSL DES clash */
 static void set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
 }
 
 static char *get_key(int index)

--- a/src/sunmd5_fmt_plug.c
+++ b/src/sunmd5_fmt_plug.c
@@ -399,7 +399,7 @@ static void set_salt(void *salt)
 
 static void set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
 }
 
 static char *get_key(int index)

--- a/src/truecrypt_fmt_plug.c
+++ b/src/truecrypt_fmt_plug.c
@@ -549,7 +549,7 @@ static int cmp_exact(char *source, int idx)
 
 static void set_key(char* key, int index)
 {
-	strnzcpyn((char*)key_buffer[index], key, sizeof(*key_buffer));
+	strnzcpy((char*)key_buffer[index], key, sizeof(*key_buffer));
 }
 
 static char *get_key(int index)

--- a/src/vdi_fmt_plug.c
+++ b/src/vdi_fmt_plug.c
@@ -306,7 +306,7 @@ static int cmp_exact(char *source, int index)
 
 static void set_key(char* key, int index)
 {
-	strnzcpyn((char*)key_buffer[index], key, sizeof(*key_buffer));
+	strnzcpy((char*)key_buffer[index], key, sizeof(*key_buffer));
 }
 
 static char *get_key(int index)

--- a/src/vms_fmt_plug.c
+++ b/src/vms_fmt_plug.c
@@ -149,7 +149,7 @@ static void done(void)
  */
 static void set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
 }
 
 static char *get_key(int index)

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -1400,7 +1400,7 @@ next_rule:
 			if (rules > 1 && prerule) {
 				unsigned long long p = status.cands, fake_p = 0;
 				if (!(options.flags & FLG_STDOUT)) do {
-					if (crk_direct_process_key("injected wrong password"))
+					if (crk_direct_process_key("PerRuleStats"))
 						goto done;
 					fake_p++;
 				} while (p == status.cands);

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -1400,7 +1400,8 @@ next_rule:
 			if (rules > 1 && prerule) {
 				unsigned long long p = status.cands, fake_p = 0;
 				if (!(options.flags & FLG_STDOUT)) do {
-					crk_direct_process_key("injected wrong password");
+					if (crk_direct_process_key("injected wrong password"))
+						goto done;
 					fake_p++;
 				} while (p == status.cands);
 				unsigned int g = status.guess_count - prev_g;
@@ -1450,6 +1451,7 @@ next_rule:
 	if (pipe_input)
 		goto GRAB_NEXT_PIPE_LOAD;
 
+done:
 	crk_done();
 	rec_done(event_abort || (status.pass && db->salts));
 

--- a/src/wow_srp_fmt_plug.c
+++ b/src/wow_srp_fmt_plug.c
@@ -403,7 +403,7 @@ static void set_salt(void *salt)
 
 static void set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
 	enc_strupper(saved_key[index]);
 }
 

--- a/src/zip_fmt_plug.c
+++ b/src/zip_fmt_plug.c
@@ -102,7 +102,7 @@ static void set_salt(void *salt)
 
 static void set_key(char *key, int index)
 {
-	strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
 }
 
 static char *get_key(int index)


### PR DESCRIPTION
This fixes sapH #5155.

I also include in here a fix for an issue I identified at the same time: it was unsafe to continue calling `crk_direct_process_key()` ignoring its return value - when it returns non-zero, it doesn't ensure the index is wrapped from max back to 0, so a subsequent call could result in a call to the format's `set_key()` with the slightly out of bounds index.

Also, I change the injected password to literal string `PerRuleStats`. This is for two reasons: (1) it's shorter, so is less likely to exceed a format's maximum, and (2) it will remind the user of the stats being enabled.