### PR TITLE
fixes for crashes found with fuzzing

### DIFF
--- a/src/HDAA_fmt_plug.c
+++ b/src/HDAA_fmt_plug.c
@@ -174,6 +174,7 @@ static void done(void)
 static int valid(char *ciphertext, struct fmt_main *self)
 {
 	char *ctcopy, *keeptr, *p;
+	size_t user_len, realm_len, nonce_len, noncecount_len, clientnonce_len, qop_len;
 
 	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH) != 0)
 		return 0;
@@ -189,7 +190,12 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL) /* user */
 		goto err;
+	user_len = strlen(p);
 	if ((p = strtokm(NULL, "$")) == NULL) /* realm */
+		goto err;
+	realm_len = strlen(p);
+	/* snprintf() later would truncate data making hash uncrackable. */
+	if (user_len + realm_len + 2 > HTMP - PLAINTEXT_LENGTH - 1)
 		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL) /* method */
 		goto err;
@@ -197,17 +203,25 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL) /* nonce */
 		goto err;
+	nonce_len = strlen(p);
 	if ((p = strtokm(NULL, "$")) == NULL) /* End of legacy HDAA or noncecount */
 		goto end_hdaa_legacy;
+	noncecount_len = strlen(p);
 	if ((p = strtokm(NULL, "$")) == NULL) /* clientnonce */
 		goto err;
+	clientnonce_len = strlen(p);
 	if ((p = strtokm(NULL, "$")) == NULL) /* qop */
 		goto err;
+	qop_len = strlen(p);
 	if ((p = strtokm(NULL, "$")) != NULL)
+		goto err;
+	if (nonce_len + noncecount_len + clientnonce_len + qop_len + 32 + 5 > HTMP - CIPHERTEXT_LENGTH - 1)
 		goto err;
 
 end_hdaa_legacy:
 	MEM_FREE(keeptr);
+	if (nonce_len + 32 + 2 > HTMP - CIPHERTEXT_LENGTH - 1)
+		return 0;
 	return 1;
 
 err:

--- a/src/bitlocker_common.h
+++ b/src/bitlocker_common.h
@@ -4,6 +4,7 @@
 
 #include "formats.h"
 
+#define MAX_DATALEN             256
 #define MACLEN                  16
 #define SALTLEN                 16
 #define IVLEN                   12  // nonce length
@@ -24,7 +25,7 @@ typedef struct {
 	int data_size;
 	unsigned char salt[SALTLEN];
 	unsigned int iterations;
-	unsigned char data[256];
+	unsigned char data[MAX_DATALEN];
 	unsigned char iv[IVLEN]; // nonce
 	unsigned char mac[MACLEN];
 } bitlocker_custom_salt;

--- a/src/bitlocker_variable_code.h
+++ b/src/bitlocker_variable_code.h
@@ -152,6 +152,8 @@ static int bitlocker_common_valid(char *ciphertext, struct fmt_main *self)
 	value = atoi(p);
 	if ((p = strtokm(NULL, "$")) == NULL)   // data encrypted by aes_ccm key, contains encrypted volume master key (vmk)
 		goto err;
+	if (value > MAX_DATALEN)
+		goto err;
 	if (hexlenl(p, &extra) != value * 2 || extra)
 		goto err;
 

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -566,7 +566,8 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 	if (cp[cipherTextLen] && cp[cipherTextLen] != '$')
 		return 0;
 // NOTE if looking at this in the future, this was not my fix.
-	if (strlen(&cp[cipherTextLen]) > SALT_SIZE)
+	// dynamic_1552: $s1$$Uuser --> 6+len(s1)+1+len(user) <= SALT_SIZE
+	if (strlen(&cp[cipherTextLen]) > SALT_SIZE - 3)
 		return 0;
 // end NOTE.
 	if (pPriv->dynamic_FIXED_SALT_SIZE > 0 && ciphertext[pPriv->dynamic_SALT_OFFSET-1] != '$')

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -613,7 +613,9 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 					return 0; // username is too long
 			} else {
 				/* salt and username */
-				char *t = strstr(&ciphertext[pPriv->dynamic_SALT_OFFSET], "$$U");;
+				char *t = strstr(&ciphertext[pPriv->dynamic_SALT_OFFSET], "$$U");
+				if (!t)
+					return 0; // no username
 				/* salt_external_to_internal_convert parses fields from right to left, but it may overwrite found fields */
 				if (strstr(t + 3, "$$U"))
 					return 0; // second $$U is prohibited (for simplicity)

--- a/src/gpg_common_plug.c
+++ b/src/gpg_common_plug.c
@@ -368,6 +368,8 @@ int gpg_common_valid(char *ciphertext, struct fmt_main *self, int is_CPU_format)
 		if (!isdec(p))
 			goto err;
 		res = atoi(p);
+		if (res > sizeof(gpg_common_cur_salt->g))
+			goto err;
 		if ((p = strtokm(NULL, "*")) == NULL)
 			goto err;
 		if (hexlenl(p, &extra) != res*2 || extra)

--- a/src/ike-crack.h
+++ b/src/ike-crack.h
@@ -349,14 +349,14 @@ load_psk_params(const char *ciphertext, const char *nortel_user,
 	size_t skeyid_data_len;	/* Length of skeyid data */
 	unsigned char *hash_r_data;	/* Data for HASH_R hash */
 	size_t hash_r_data_len;	/* Length of hash_r */
-	char g_xr_hex[MAXLEN];	/* Individual PSK params as hex */
-	char g_xi_hex[MAXLEN];
-	char cky_r_hex[MAXLEN];
-	char cky_i_hex[MAXLEN];
-	char sai_b_hex[MAXLEN];
-	char idir_b_hex[MAXLEN];
-	char ni_b_hex[MAXLEN];
-	char nr_b_hex[MAXLEN];
+	char g_xr_hex[MAXLEN + 1];	/* Individual PSK params as hex */
+	char g_xi_hex[MAXLEN + 1];
+	char cky_r_hex[MAXLEN + 1];
+	char cky_i_hex[MAXLEN + 1];
+	char sai_b_hex[MAXLEN + 1];
+	char idir_b_hex[MAXLEN + 1];
+	char ni_b_hex[MAXLEN + 1];
+	char nr_b_hex[MAXLEN + 1];
 	char hash_r_hex[44];
 	unsigned char *g_xr;	/* Individual PSK params as binary */
 	unsigned char *g_xi;

--- a/src/krb5_asrep_fmt_plug.c
+++ b/src/krb5_asrep_fmt_plug.c
@@ -162,8 +162,8 @@ static void init(struct fmt_main *self)
 
 	omp_autotune(self, OMP_SCALE);
 
-	saved_key = mem_alloc_align(sizeof(*saved_key) *
-			self->params.max_keys_per_crypt,
+	saved_key = mem_calloc_align(self->params.max_keys_per_crypt,
+			sizeof(*saved_key),
 			MEM_ALIGN_CACHE);
 	saved_K1 = mem_alloc_align(sizeof(*saved_K1) *
 			self->params.max_keys_per_crypt,

--- a/src/loader.c
+++ b/src/loader.c
@@ -1358,6 +1358,7 @@ void ldr_free_db(struct db_main *db, int base)
 					dyna_salt_remove(psalt->salt);
 				psalt = psalt->next;
 			}
+			db->salts = NULL;
 		}
 		MEM_FREE(db->salt_hash);
 		MEM_FREE(db->cracked_hash);

--- a/src/net_md5_fmt_plug.c
+++ b/src/net_md5_fmt_plug.c
@@ -275,6 +275,8 @@ static char *prepare(char *fields[10], struct fmt_main *self) {
 		get_ptr();
 		if (text_in_dynamic_format_already(pDynamicFmt, hash))
 			return hash;
+		if (strlen(hash) + TAG_LENGTH + 1 > sizeof(buf))
+			return hash;
 		sprintf(buf, "%s%s", FORMAT_TAG, hash);
 		return buf;
 	}

--- a/src/nsec3_fmt_plug.c
+++ b/src/nsec3_fmt_plug.c
@@ -61,7 +61,7 @@ struct salt_t {
 	size_t zone_length;
 	uint16_t iterations;
 	unsigned char salt[N3_MAX_SALT_SIZE];
-	unsigned char zone_wf[N3_MAX_ZONE_SIZE];
+	unsigned char zone_wf[N3_MAX_ZONE_SIZE + 1];
 };
 
 static struct fmt_tests tests[] = {
@@ -145,9 +145,9 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 {
 	char *p, *q;
 	int i;
-	unsigned char zone[N3_MAX_ZONE_SIZE];
+	unsigned char zone[N3_MAX_ZONE_SIZE + 1];
 	int iter;
-	char salt[N3_MAX_SALT_SIZE + 1];
+	char salt[N3_MAX_SALT_SIZE * 2 + 1];
 	char hash[HASH_LENGTH * 2 + 1];
 
 	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))

--- a/src/o10glogon_fmt_plug.c
+++ b/src/o10glogon_fmt_plug.c
@@ -166,7 +166,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	ciphertext = cp+1;
 	len = strlen(ciphertext);
 	cp = strchr(ciphertext, '$');
-	if (!len || cp || len%16 || hexlenu(ciphertext, &extra) != len || extra)
+	if (!len || len > 80*2 || cp || len%16 || hexlenu(ciphertext, &extra) != len || extra)
 		return 0;
 	return 1;
 }

--- a/src/o3logon_fmt_plug.c
+++ b/src/o3logon_fmt_plug.c
@@ -159,7 +159,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	ciphertext = cp+1;
 	cp = strchr(ciphertext, '$');
 	len = strlen(ciphertext);
-	if (!len || cp || len%16 || hexlenu(ciphertext, &extra) != len || extra)
+	if (!len || len > 40*2 || cp || len%16 || hexlenu(ciphertext, &extra) != len || extra)
 		return 0;
 	return 1;
 }

--- a/src/pbkdf2_hmac_common_plug.c
+++ b/src/pbkdf2_hmac_common_plug.c
@@ -245,9 +245,11 @@ int pbkdf2_hmac_md5_valid(char *ciphertext, struct fmt_main *self)
 	if (!(ptr = strtokm(NULL, delim)))
 		goto error;
 	len = strlen(ptr); // binary hex length
-	if (len < PBKDF2_MDx_BINARY_SIZE || len > PBKDF2_MDx_MAX_BINARY_SIZE || len & 1)
+	if (len < PBKDF2_MDx_BINARY_SIZE * 2 || len > PBKDF2_MDx_MAX_BINARY_SIZE * 2 || len & 1)
 		goto error;
 	if (!ishexlc(ptr))
+		goto error;
+	if (strtokm(NULL, delim)) // no more fields
 		goto error;
 	MEM_FREE(keeptr);
 	return 1;

--- a/src/rawSHA512_common_plug.c
+++ b/src/rawSHA512_common_plug.c
@@ -159,6 +159,11 @@ int sha512_common_valid_nsldap(char *ciphertext, struct fmt_main *self)
 	len = strspn(ciphertext, NSLDAP_BASE64_ALPHABET);
 	if (len < (DIGEST_SIZE+1+2)/3*4-2)
 		return 0;
+	if (len < strlen(ciphertext) - 2)
+		return 0;
+	/* Max length needs at least 1 =; assumes (DIGEST_SIZE + NSLDAP_SALT_LEN) % 2 == 2. */
+	if (len > NSLDAP_CIPHERTEXT_LENGTH - 1)
+		return 0;
 
 	len = strspn(ciphertext, NSLDAP_BASE64_ALPHABET "=");
 	if (len != strlen(ciphertext))

--- a/src/rsvp_fmt_plug.c
+++ b/src/rsvp_fmt_plug.c
@@ -191,7 +191,6 @@ static void done(void)
 static int valid(char *ciphertext, struct fmt_main *self)
 {
 	char *p, *strkeep;
-	int version;
 
 	if (strncmp(ciphertext, FORMAT_TAG, TAG_LENGTH))
 		return 0;
@@ -201,8 +200,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 
 	if ((p = strtokm(p, "$")) == NULL) /* version */
 		goto err;
-	version = atoi(p);
-	if (version != 1  && version != 2 && version != 3 && version != 4 && version != 5 && version != 6)
+	if (p[0] < '1' || p[0] > '6' || p[1])
 		goto err;
 
 	if ((p = strtokm(NULL, "$")) == NULL) /* salt */

--- a/src/scrypt_fmt.c
+++ b/src/scrypt_fmt.c
@@ -198,7 +198,7 @@ static char *prepare(char *fields[10], struct fmt_main *self)
 		//from: {"$ScryptKDF.pm$*16384*8*1*VHRuaXZOZ05INWJs*JjrOzA8pdPhLvLh8sY64fLLaAjFUwYCXMmS16NXcn0A=","password"},
 		//to:   {"$7$C6..../....TtnivNgNH5bl$acXnAzE8oVzGwW9Tlu6iw7fq021J/1sZmEKhcLBrT02","password"},
 		int N, r, p;
-		if (strlen(fields[1]) > sizeof(tmp)+FMT_SCRYPTKDF_LEN)
+		if (strlen(fields[1]) >= sizeof(tmp)+FMT_SCRYPTKDF_LEN)
 			return fields[1];
 		strcpy(tmp, &fields[1][FMT_SCRYPTKDF_LEN]);
 		cp = strtokm(tmp, "*");
@@ -225,6 +225,8 @@ static char *prepare(char *fields[10], struct fmt_main *self)
 		encode64_uint32_fixed((uint8_t*)tmp6, sizeof(tmp6), p, 30);
 		tmp6[5]=0;
 		memset(tmp4, 0, sizeof(tmp4));
+		if (strlen(cp) >= sizeof(tmp4))
+			return fields[1];
 		base64_convert_cp(cp, e_b64_mime, strlen(cp), tmp4, e_b64_raw, sizeof(tmp4), flg_Base64_NO_FLAGS, 0);
 		memset(tmp2, 0, sizeof(tmp2));
 		base64_convert_cp(cp2, e_b64_mime, strlen(cp2), tmp2, e_b64_cryptBS, sizeof(tmp2),flg_Base64_NO_FLAGS, 0);
@@ -245,6 +247,9 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	unsigned tmp;
 
 	if (strncmp(ciphertext, FMT_TAG7, FMT_TAG7_LEN))
+		return 0;
+
+	if (strlen(ciphertext) >= BINARY_SIZE)
 		return 0;
 
 	for (p = ciphertext + FMT_TAG7_LEN; p < ciphertext + (FMT_TAG7_LEN + 1 + 5 + 5); p++)

--- a/src/ssh_common_plug.c
+++ b/src/ssh_common_plug.c
@@ -44,9 +44,11 @@ int ssh_valid(char *ciphertext, struct fmt_main *self)
 	if (!isdec(p))
 		goto err;
 	len = atoi(p);
+	if (len > N)
+		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL)	/* ciphertext */
 		goto err;
-	if (hexlen(p, &extra) / 2 != len || extra)
+	if (hexlen(p, &extra) != len * 2 || extra)
 		goto err;
 	if (cipher == 2 || cipher == 6) {
 		if ((p = strtokm(NULL, "$")) == NULL)	/* rounds */
@@ -83,7 +85,7 @@ err:
 
 char *ssh_split(char *ciphertext, int index, struct fmt_main *self)
 {
-	static char buf[sizeof(struct custom_salt)+100];
+	static char buf[sizeof(struct custom_salt) * 2 + 100];
 
 	if (strnlen(ciphertext, LINE_BUFFER_SIZE) < LINE_BUFFER_SIZE &&
 	    strstr(ciphertext, "$SOURCE_HASH$"))

--- a/src/ssha512_fmt_plug.c
+++ b/src/ssha512_fmt_plug.c
@@ -143,7 +143,7 @@ static void * get_salt(char * ciphertext)
 	len = strlen(ciphertext);
 	base64_convert(ciphertext, e_b64_mime, len, realcipher, e_b64_raw, sizeof(realcipher), flg_Base64_DONOT_NULL_TERMINATE, 0);
 
-	// We now support any salt length up to NSLDAP_SALT_SIZE
+	// We now support any salt length up to NSLDAP_SALT_LEN
 	cursalt.len = (len + 3) / 4 * 3 - DIGEST_SIZE;
 	p = &ciphertext[len];
 	while (*--p == '=')

--- a/src/vtp_fmt_plug.c
+++ b/src/vtp_fmt_plug.c
@@ -132,6 +132,8 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	if (!isdec(p))
 		goto err;
 	res = atoi(p);
+	if (res > sizeof(cur_salt->vlans_data))
+		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL)  /* vlans data */
 		goto err;
 	if (strlen(p) / 2 != res)
@@ -144,6 +146,8 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	if (!isdec(p))
 		goto err;
 	res = atoi(p);
+	if (res > 72 + sizeof(cur_salt->trailer_data))
+		goto err;
 	if ((p = strtokm(NULL, "$")) == NULL)  /* salt */
 		goto err;
 	if (strlen(p) / 2 != res)

--- a/src/wow_srp_fmt_plug.c
+++ b/src/wow_srp_fmt_plug.c
@@ -102,9 +102,10 @@ john_register_one(&fmt_blizzard);
 #define BINARY_SIZE		4
 #define BINARY_ALIGN		4
 #define FULL_BINARY_SIZE	32
-#define SALT_SIZE		(64+3)
-#define SALT_ALIGN		1
 #define USERNAMELEN             32
+#define ONLY_SALT_SIZE		(64+3)
+#define SALT_SIZE		(1 + ONLY_SALT_SIZE + USERNAMELEN + 1)
+#define SALT_ALIGN		1
 
 #define MIN_KEYS_PER_CRYPT	1
 #define MAX_KEYS_PER_CRYPT	1
@@ -216,7 +217,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		return 0;
 	if (((p - q) & 1))
 		return 0;
-	if (p - q >= 2 * SALT_SIZE)
+	if (p - q >= 2 * ONLY_SALT_SIZE)
 		return 0;
 	while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 		q++;


### PR DESCRIPTION
It closes #5157. It affects the following formats:
```
rsvp,gpg,bitlocker,net-md5,o10glogon,o3logon,SSHA512,ike,dynamic_15,vtp,nsec3,wowsrp,SSH,hdaa,PBKDF2-HMAC-MD5,krb5asrep,scrypt,dynamic_1552,bitlocker-opencl,gpg-opencl,SSH-opencl,PBKDF2-HMAC-MD5-opencl
```

`--test=0` and `--fuzz=../run/fuzz.dic` are ok.

I prepared fixes quickly, so some of them might be suboptimal.

JFYI I was caught by the following problem fixing `wowsrp`: I increased buffer size right in `get_salt` instead of change to `SALT_SIZE`. So salt would be truncated and there would be a crash during cracking or uncrackable hash. Self-tests do not catch such mistake: all tests worked well with smaller buffer. Fuzzer does not catch it too.

My fixes for memory leaks in #5158 introduced use-after-free for dynamic salts because `ldr_free_db` is called in fuzzer and in john.
```
==4006==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d00001bbe8 at pc 0x5604db9ddef1 bp 0x7ffc3e4223f0 sp 0x7ffc3e4223e8
READ of size 1 at 0x60d00001bbe8 thread T0
    #0 0x5604db9ddef0 in dyna_salt_remove_fp /home/user/john/src/dyna_salt.c:56
    #1 0x5604dba2dd33 in ldr_free_db /home/user/john/src/loader.c:1358
    #2 0x5604dba1ede3 in john_done /home/user/john/src/john.c:1953
    #3 0x5604dba1ede3 in main /home/user/john/src/john.c:2083
```

The problem affects a subset of formats using `dyna_salt` (approximately `gpg,7z,pkzip,zip` + their opencl variants).

The last commit fixes the use-after-free. To allow excessive calls to `ldr_free_db`, I just set `db->salts` to `NULL` in `ldr_free_db`. I am not sure if it is ok. But ASan does not report leaks. I would like this bit to be reviewed better.

If everything is fine, this PR is ready. Thanks!