### PR TITLE
Change meaning of %N rules where N=0

### DIFF
--- a/doc/RULES
+++ b/doc/RULES
@@ -279,9 +279,11 @@ s?CY	replace all characters of class C in the word with Y
 U	reject the word unless it is valid UTF-8 (use with -u rule reject)
 eC	title case, where C is the separation character
 e?C	title case, with chars from class C as separation characters.
-	NOTE, see hashcat specific 'E' rule which is generic title case for space
-	only characters.  The 'e' rule extendeded more powerful version.
+	NOTE, see hashcat specific 'E' rule which is generic title case for
+	space only characters.  The 'e' rule is its extended version.
 
+For %NX and %N?C, using N=0 will make it find the last occurrence of X or
+class C (and as always, set p to the position of it) or reject if none found.
 Note that U will accept plain ASCII. It will only reject words that contain
 8-bit characters but can't be parsed as UTF-8. It can be used to reject
 invalid input words, or to reject invalid output words after applying other

--- a/src/rules.c
+++ b/src/rules.c
@@ -1177,12 +1177,12 @@ char *rules_apply(char *word_in, char *rule, int split, char *last)
 
 		case '%':
 			{
-				int count = 0, required, pos;
+				int count = 0, last = -1, required, pos;
 				POSITION(required)
 				CLASS_export_pos(0,
-				    if (++count >= required) break, {})
-				if (count < required) REJECT
-				rules_vars['p'] = pos;
+				    last = pos; if (++count >= required && required) break, {})
+				if (!count || count < required) REJECT
+				rules_vars['p'] = (last >= 0 ? last : pos);
 			}
 			break;
 


### PR DESCRIPTION
Until now it was just the same as N=1.  This changes its meaning to find the *last* occurrence of character/class (useful because p will be set to the position of it).

Example use: Permute last digit using `%0?d op[0-9]`

Closes #5179