### PR TITLE
NSEC3: performance improvements, OpenMP and more

### DIFF
--- a/src/nsec3_fmt_plug.c
+++ b/src/nsec3_fmt_plug.c
@@ -60,10 +60,10 @@ john_register_one(&fmt_nsec3);
 
 struct salt_t {
 	size_t salt_length;
-	size_t zone_length;
+	size_t zone_wf_length;
 	uint16_t iterations;
 	unsigned char salt[NSEC3_MAX_SALT_SIZE];
-	unsigned char zone_wf[DOMAINNAME_MAX_SIZE + 1];
+	unsigned char zone_wf[DOMAINNAME_MAX_SIZE];
 };
 
 static struct fmt_tests tests[] = {
@@ -164,7 +164,7 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 {
 	char *p, *q;
 	int i;
-	unsigned char zone[DOMAINNAME_MAX_SIZE + 1];
+	unsigned char zone[DOMAINNAME_MAX_SIZE];
 	int iter;
 	char salt[NSEC3_MAX_SALT_SIZE * 2 + 1];
 	char hash[HASH_LENGTH * 2 + 1];
@@ -268,7 +268,7 @@ static void *salt(char *ciphertext)
 	out.salt_length = (unsigned char)((salt_length) / 2);
 
 	p = strchr(q + 1, '$') + 1;
-	out.zone_length =  parse_zone(p, out.zone_wf);
+	out.zone_wf_length =  parse_zone(p, out.zone_wf);
 
 	return &out;
 }
@@ -318,7 +318,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	SHA1_Init(&sha_ctx);
 	if (saved_key_length > 0)
 		SHA1_Update(&sha_ctx, saved_wf_label, saved_key_length + 1);
-	SHA1_Update(&sha_ctx, saved_salt.zone_wf, saved_salt.zone_length);
+	SHA1_Update(&sha_ctx, saved_salt.zone_wf, saved_salt.zone_wf_length);
 	SHA1_Update(&sha_ctx, saved_salt.salt, salt_length);
 	SHA1_Final((unsigned char *)crypt_out, &sha_ctx);
 	while (iterations--) {

--- a/src/nsec3_fmt_plug.c
+++ b/src/nsec3_fmt_plug.c
@@ -86,20 +86,26 @@ static unsigned char saved_wf_label[PLAINTEXT_LENGTH + 2];
 static SHA_CTX sha_ctx;
 static uint32_t crypt_out[5];
 
-static void convert_label_wf(void)
+/*
+ * convert a sequence of DNS labels to wire format
+ * out needs space for labels_length+1 bytes
+ * If labels_length == 0, out remains untouched
+ */
+static void labels_to_wireformat(unsigned char *labels,
+                                 int labels_length, unsigned char *out)
 {
-	int last_dot = saved_key_length - 1;
+	int last_dot;
 	int i;
-	unsigned char *out = saved_wf_label;
-	if (saved_key_length == 0)
+	if (labels_length == 0)
 		return;
 	++out;
+	last_dot = labels_length - 1;
 	for (i = last_dot ; i >= 0;) {
-		if (saved_key[i] == '.') {
+		if (labels[i] == '.') {
 			out[i] = (unsigned char)(last_dot - i);
 			last_dot = --i;
 		} else {
-			out[i] = tolower(saved_key[i]);
+			out[i] = tolower(labels[i]);
 			--i;
 		}
 	}
@@ -287,7 +293,7 @@ static void set_salt(void *salt)
 static void set_key(char *key, int index)
 {
 	saved_key_length = strnzcpyn((char *)saved_key, key, sizeof(saved_key));
-	convert_label_wf();
+	labels_to_wireformat(saved_key, saved_key_length, saved_wf_label);
 }
 
 static  char *get_key(int index)

--- a/src/nsec3_fmt_plug.c
+++ b/src/nsec3_fmt_plug.c
@@ -94,7 +94,7 @@ static void convert_label_wf(void)
 	if (saved_key_length == 0)
 		return;
 	++out;
-	for (i = last_dot ; i >= 0; ) {
+	for (i = last_dot ; i >= 0;) {
 		if (saved_key[i] == '.') {
 			out[i] = (unsigned char)(last_dot - i);
 			last_dot = --i;
@@ -129,7 +129,7 @@ static size_t parse_zone(char *zone, unsigned char *zone_wf_out)
 			memcpy(&zone_wf_out[++index], lbl_start, lbl_len);
 		}
 		index += lbl_len;
-		lbl_start = lbl_end+1;
+		lbl_start = lbl_end + 1;
 		if (lbl_start - zone == zone_len) {
 			zone_wf_out[index] = 0;
 			break;
@@ -177,11 +177,11 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 			q = p;
 			while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 				++q;
-			if (*q != '$' || q-p > NSEC3_MAX_SALT_SIZE*2 || (q-p) % 2)
+			if (*q != '$' || q - p > NSEC3_MAX_SALT_SIZE * 2 || (q - p) % 2)
 				return 0;
 			strncpy(salt, p, q - p);
 			salt[q - p] = 0;
-			if (q-p > 0 && !ishexlc(salt))
+			if (q - p > 0 && !ishexlc(salt))
 				return 0;
 			break;
 		case 3:
@@ -189,13 +189,13 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 			q = p;
 			while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 				++q;
-			if (*q != '$' || q-p > HASH_LENGTH*2 || (q-p) % 2)
+			if (*q != '$' || q - p > HASH_LENGTH * 2 || (q - p) % 2)
 				return 0;
 			strncpy(hash, p, q - p);
 			hash[q - p] = 0;
 			if (!ishexlc(hash))
 				return 0;
-			p = q+1;
+			p = q + 1;
 			break;
 		}
 	}
@@ -225,7 +225,7 @@ static void *get_binary(char *ciphertext)
 
 	for (i = 0; i < BINARY_SIZE; ++i) {
 		out[i] = (atoi16[ARCH_INDEX(*p)] << 4) |
-			atoi16[ARCH_INDEX(p[1])];
+		         atoi16[ARCH_INDEX(p[1])];
 		p += 2;
 	}
 	return out;
@@ -246,15 +246,15 @@ static void *salt(char *ciphertext)
 
 	p = strchr(p, '$') + 1;
 	q = strchr(p, '$');
-	salt_length = q-p;
+	salt_length = q - p;
 	for (i = 0; i < salt_length; i += 2) {
-		out.salt[i/2] = (atoi16[ARCH_INDEX(*p)] << 4 |
-				atoi16[ARCH_INDEX(p[1])]);
+		out.salt[i / 2] = (atoi16[ARCH_INDEX(*p)] << 4 |
+		                   atoi16[ARCH_INDEX(p[1])]);
 		p += 2;
 	}
-	out.salt_length = (unsigned char)((salt_length)/2);
+	out.salt_length = (unsigned char)((salt_length) / 2);
 
-	p = strchr(q+1, '$') + 1;
+	p = strchr(q + 1, '$') + 1;
 	out.zone_length =  parse_zone(p, out.zone_wf);
 
 	return &out;
@@ -286,7 +286,7 @@ static void set_salt(void *salt)
 
 static void set_key(char *key, int index)
 {
-	saved_key_length = strnzcpyn((char*)saved_key, key, sizeof(saved_key));
+	saved_key_length = strnzcpyn((char *)saved_key, key, sizeof(saved_key));
 	convert_label_wf();
 }
 
@@ -304,7 +304,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	SHA1_Init(&sha_ctx);
 	if (saved_key_length > 0)
-		SHA1_Update(&sha_ctx, saved_wf_label, saved_key_length+1);
+		SHA1_Update(&sha_ctx, saved_wf_label, saved_key_length + 1);
 	SHA1_Update(&sha_ctx, saved_salt.zone_wf, saved_salt.zone_length);
 	SHA1_Update(&sha_ctx, saved_salt.salt, salt_length);
 	SHA1_Final((unsigned char *)crypt_out, &sha_ctx);

--- a/src/nsec3_fmt_plug.c
+++ b/src/nsec3_fmt_plug.c
@@ -410,7 +410,7 @@ struct fmt_main fmt_nsec3 = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_8_BIT | FMT_OMP,
+		FMT_8_BIT | FMT_OMP | FMT_OMP_BAD,
 #if FMT_MAIN_VERSION > 11
 		{ NULL },
 #endif

--- a/src/nsec3_fmt_plug.c
+++ b/src/nsec3_fmt_plug.c
@@ -52,7 +52,6 @@ john_register_one(&fmt_nsec3);
 // max total length of a domainname in wire format
 #define DOMAINNAME_MAX_SIZE             255
 #define LABEL_MAX_SIZE                  63
-#define HASH_LENGTH                     20
 #define SALT_SIZE                       sizeof(struct salt_t)
 #define SALT_ALIGN                      sizeof(size_t)
 #define FORMAT_TAG                      "$NSEC3$"
@@ -167,7 +166,7 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 	unsigned char zone[DOMAINNAME_MAX_SIZE];
 	int iter;
 	char salt[NSEC3_MAX_SALT_SIZE * 2 + 1];
-	char hash[HASH_LENGTH * 2 + 1];
+	char hash[BINARY_SIZE * 2 + 1];
 
 	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
 		return 0;
@@ -202,7 +201,7 @@ static int valid(char *ciphertext, struct fmt_main *pFmt)
 			q = p;
 			while (atoi16[ARCH_INDEX(*q)] != 0x7F)
 				++q;
-			if (*q != '$' || q - p > HASH_LENGTH * 2 || (q - p) % 2)
+			if (*q != '$' || q - p > BINARY_SIZE * 2 || (q - p) % 2)
 				return 0;
 			strncpy(hash, p, q - p);
 			hash[q - p] = 0;

--- a/src/nsec3_fmt_plug.c
+++ b/src/nsec3_fmt_plug.c
@@ -387,6 +387,14 @@ static int cmp_exact(char *source, int index)
 	return 1;
 }
 
+static int get_hash_0(int index) { return crypt_out[index][0] & PH_MASK_0; }
+static int get_hash_1(int index) { return crypt_out[index][0] & PH_MASK_1; }
+static int get_hash_2(int index) { return crypt_out[index][0] & PH_MASK_2; }
+static int get_hash_3(int index) { return crypt_out[index][0] & PH_MASK_3; }
+static int get_hash_4(int index) { return crypt_out[index][0] & PH_MASK_4; }
+static int get_hash_5(int index) { return crypt_out[index][0] & PH_MASK_5; }
+static int get_hash_6(int index) { return crypt_out[index][0] & PH_MASK_6; }
+
 struct fmt_main fmt_nsec3 = {
 	{
 		FORMAT_LABEL,
@@ -402,7 +410,7 @@ struct fmt_main fmt_nsec3 = {
 		SALT_ALIGN,
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
-		FMT_8_BIT | FMT_HUGE_INPUT | FMT_OMP,
+		FMT_8_BIT | FMT_OMP,
 #if FMT_MAIN_VERSION > 11
 		{ NULL },
 #endif
@@ -422,7 +430,13 @@ struct fmt_main fmt_nsec3 = {
 #endif
 		fmt_default_source,
 		{
-			fmt_default_binary_hash
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
 		},
 		salt_hash,
 		NULL,
@@ -432,7 +446,13 @@ struct fmt_main fmt_nsec3 = {
 		fmt_default_clear_keys,
 		crypt_all,
 		{
-			fmt_default_get_hash
+			get_hash_0,
+			get_hash_1,
+			get_hash_2,
+			get_hash_3,
+			get_hash_4,
+			get_hash_5,
+			get_hash_6
 		},
 		cmp_all,
 		cmp_one,


### PR DESCRIPTION
This should significantly speed up NSEC3 cracking, especially at lower iteration counts.

OpenMP support isn't tuned that well yet, but I doubt it's ever going to be great anyway given most zones these days use very low (<= 10) iteration counts (hence I marked it with `FMT_OMP_BAD`).

I wasn't entirely sure about removing `FMT_HUGE_INPUT`, but `formats.h` says it's for ciphertexts longer than 896 bytes, which does not apply here. Please let me know if I missed something.

Let me know if you need me to split these changes into separate PRs, or if you want me to squash the commits.