### PR TITLE
ENCDataVault: Increase signature length to reduce fault positive

### DIFF
--- a/run/encdatavault2john.py
+++ b/run/encdatavault2john.py
@@ -58,12 +58,12 @@ def process(vault):
             f.seek(4,1)
             crypto = int.from_bytes(f.read(4),byteorder="little")
             iv = binascii.hexlify(f.read(8))
-            header_enc = binascii.hexlify(f.read(4))
+            header_enc = binascii.hexlify(f.read(8))
         else:
             sys.stderr.write(f"{file_list[0]} : Valid header not found.\n")
             return
 
-        if len(header_enc) != 8:
+        if len(header_enc) != 16:
             sys.stderr.write(f"{file_list[0]} : Problem reading encrypted header.\n")
             return
 

--- a/src/encdatavault_common.h
+++ b/src/encdatavault_common.h
@@ -27,7 +27,7 @@
 #define ENC_BLOCK_SIZE 				16
 #define ENC_KEY_SIZE 				16
 #define ENC_NONCE_SIZE 				8
-#define ENC_SIG_SIZE 				4
+#define ENC_SIG_SIZE 				8
 #define ENC_MAX_KEY_NUM 			8
 #define ENC_KEYCHAIN_SIZE 			128
 
@@ -46,6 +46,7 @@ typedef struct {
 	unsigned char salt[PBKDF2_32_MAX_SALT_SIZE];
 	unsigned int iterations;
 	unsigned char encrypted_data[ENC_BLOCK_SIZE];
+	unsigned int encrypted_data_length;
 	unsigned char keychain[ENC_KEYCHAIN_SIZE];
 } custom_salt;
 

--- a/src/encdatavault_md5_fmt_plug.c
+++ b/src/encdatavault_md5_fmt_plug.c
@@ -53,25 +53,25 @@ static const char *const default_salts[] = {
 
 static struct fmt_tests encdatavault_md5_tests[] = {
 	// Sandisk vaults
-	{ "$encdv$1$1$ae07a8354f6fe3ca$a6066363", "bbbb" },
-	{ "$encdv$1$1$7531d98593ea7b1d$d070650d", "openwall" },
+	{ "$encdv$1$1$ae07a8354f6fe3ca$a6066363d7cfc05e", "bbbb" },
+	{ "$encdv$1$1$04738b48de9d25d1$63cb5cd9ab06f1e1", "password" },
 	// Sony vault
-	{ "$encdv$1$2$e8a5d78fa5511fa2$b96a4747", "bbbb" },
-	{ "$encdv$1$2$4e277e5547b88f9c$eb0ed650", "openwallopenwall!" },
+	{ "$encdv$1$2$e8a5d78fa5511fa2$b96a4747332a022d", "bbbb" },
+	{ "$encdv$1$2$adcb666304eaf1bc$181c3ed7f5bb8cc7", "password" },
 	// ENCDataVault v7.1.1 512 bits user password
-	{ "$encdv$1$3$d6209d17c0a87818$77608f04", "123456789ABCDEf" },
-	{ "$encdv$1$3$3563390c4d66944d$2b0470f5", "openwallopenwall" },
+	{ "$encdv$1$3$d6209d17c0a87818$77608f044a4f113a", "123456789ABCDEf" },
+	{ "$encdv$1$3$cc727303f8cec41f$38537aac9d6bc873", "openwallopenwall" },
 	// ENCDataVault v7.1.1 128 bits vault
-	{ "$encdv$3$1$75c97f784cad5027$c58e34a9$6fa3c4085acadda7c94589fe3dd8209d59a79b0ea659c4af51861f659c2d6cc645dab7c821c2cc0e8da97ce66e9be779fcf8fc33c1250aee2cd46e08a3864763a5c7f790c9965376a36fbf3b1c8b944d096e3bbe586a952f9fab5ee2f1c1ca7d2cd06ff357bb397c3eb1da66c5562998411c0b2dff04860e6f6adf818c853941", "128vaultTest" },
-	{ "$encdv$3$1$af9479e81a896dbb$e643f5f6$8e8fd6ccf10cf651efcb561a167fa301849bef0a28718f67d31d53a1e7a8328b3aaa6c642d8a2483e8de5c3751fd0b81604ead7c6412e6197886735bcbd1dd50d23f293bf11856986bd07a7513275dea991968376703a643fc19c373c1d62a7779db88068e24752bb6761f42c8aec9cf7a80ef2b7f6384212ee6b670d8ba17a7", "OpenwallOpenwall" },
+	{ "$encdv$3$1$75c97f784cad5027$c58e34a9a3fcbf33$6fa3c4085acadda7c94589fe3dd8209d59a79b0ea659c4af51861f659c2d6cc645dab7c821c2cc0e8da97ce66e9be779fcf8fc33c1250aee2cd46e08a3864763a5c7f790c9965376a36fbf3b1c8b944d096e3bbe586a952f9fab5ee2f1c1ca7d2cd06ff357bb397c3eb1da66c5562998411c0b2dff04860e6f6adf818c853941", "128vaultTest" },
+	{ "$encdv$3$1$af9479e81a896dbb$e643f5f64c835501$8e8fd6ccf10cf651efcb561a167fa301849bef0a28718f67d31d53a1e7a8328b3aaa6c642d8a2483e8de5c3751fd0b81604ead7c6412e6197886735bcbd1dd50d23f293bf11856986bd07a7513275dea991968376703a643fc19c373c1d62a7779db88068e24752bb6761f42c8aec9cf7a80ef2b7f6384212ee6b670d8ba17a7", "OpenwallOpenwall" },
 	// ENCDataVault v7.1.1 256 bits vault
-	{ "$encdv$3$2$a44a9a62e131023e$d9fe5a04$0bc8c0c937cac8de5a226a9dc7ff5d2542bb8814973afdcc0e593fded8b337cac18acd60c1afea3550fdeabee339a36892eb99f0f502b9f74075e9cb26970e983189be1395ffbec8ebfb765a563db45c3e53d73040e41bcfe58dc211f03f1384c5080c298a5e4bdf7cf23b893b3d2dbe05c472180fdc3f7fd82d97ea0eec1e7e", "OpenwallOpenwall" },
-	{ "$encdv$3$2$85089cdde5cb099b$c3c98127$d96fd1e2709908e08994d1809e516985cf028cd73e2a829dee1ce7473c3c4d0ce35a2652b58ed7ad046641259b9a24a046c89d3251e1036e7117dd8221b07f5a45b6c215b3ad308e5f7b248ea8f1fabaa23da4840797c9052c3f8578187d514a92356b8138455db6424a41db6b0de2817d463f23d44f39537a6c28b2ba075a01", "Verylongbutstillfailpassword" },
+	{ "$encdv$3$2$a44a9a62e131023e$d9fe5a04b7d539c5$0bc8c0c937cac8de5a226a9dc7ff5d2542bb8814973afdcc0e593fded8b337cac18acd60c1afea3550fdeabee339a36892eb99f0f502b9f74075e9cb26970e983189be1395ffbec8ebfb765a563db45c3e53d73040e41bcfe58dc211f03f1384c5080c298a5e4bdf7cf23b893b3d2dbe05c472180fdc3f7fd82d97ea0eec1e7e", "OpenwallOpenwall" },
+	{ "$encdv$3$2$85089cdde5cb099b$c3c98127f85ff387$d96fd1e2709908e08994d1809e516985cf028cd73e2a829dee1ce7473c3c4d0ce35a2652b58ed7ad046641259b9a24a046c89d3251e1036e7117dd8221b07f5a45b6c215b3ad308e5f7b248ea8f1fabaa23da4840797c9052c3f8578187d514a92356b8138455db6424a41db6b0de2817d463f23d44f39537a6c28b2ba075a01", "Verylongbutstillfailpassword" },
 	// ENCDataVault v7.1.1 512 bits vault
-	{ "$encdv$3$3$bd837ac896f26983$15107b99$fb141e6db2cb586b2b445d6a6ca47f17d16947afa32298cc30c6fcdc4bfac7a874d53f2de4bcb196645e59e1c8e5883999875c9951d637e08f78d2bb16003c2abe8bfa1cb8b8d7b627828d61d775937308e7e119dea727da8af12490d50e8b8dc8f24daa7e101576112b52374f3ea4a73f7fa6bfb802bd6dfa845318a2884a9e", "123456789ABCDEf" },
-	{ "$encdv$3$3$ffd2a778b7f1304b$311893a8$5e48500065fc4138b134ce7858ac3b29d9f4b19c5f0d7ee1d07d8dd4dc3d5ae56b18e84d822087849573074a5776dee5309e5cb6bbd0d1470e0717463119bb080c96e24ebd563673060397803aebae5df7c59defcc8fa687b96c9a8245e540be699061c299a69830472e1a6a74ad72086dfac906a49e0ce84fc722da9715d675", "OpenwallOpenwall" },
+	{ "$encdv$3$3$bd837ac896f26983$15107b99273079ee$fb141e6db2cb586b2b445d6a6ca47f17d16947afa32298cc30c6fcdc4bfac7a874d53f2de4bcb196645e59e1c8e5883999875c9951d637e08f78d2bb16003c2abe8bfa1cb8b8d7b627828d61d775937308e7e119dea727da8af12490d50e8b8dc8f24daa7e101576112b52374f3ea4a73f7fa6bfb802bd6dfa845318a2884a9e", "123456789ABCDEf" },
+	{ "$encdv$3$3$ffd2a778b7f1304b$311893a8c058a53c$5e48500065fc4138b134ce7858ac3b29d9f4b19c5f0d7ee1d07d8dd4dc3d5ae56b18e84d822087849573074a5776dee5309e5cb6bbd0d1470e0717463119bb080c96e24ebd563673060397803aebae5df7c59defcc8fa687b96c9a8245e540be699061c299a69830472e1a6a74ad72086dfac906a49e0ce84fc722da9715d675", "OpenwallOpenwall" },
 	// ENCDataVault v7.1.1 1024 bits vault
-	{ "$encdv$3$4$bc93a92cf625e360$fe120bfb$739f9d85964cef2f63b927ff77f3328cc5192014ae21c29954c322f4e808fe5c8abe64cc150dbcb08cb334f3b5c28357f10d8d5c6a103e2c899402136c14633aaf8a5347959b33b80ade2e3f5698864605940dc1423704999e5da859d6584491bbe940f00f162c75d2766b868ef2b4c6bf599a2e8ccea3f7cdfab193744a8d10", "123456789ABCDEf" },
+	{ "$encdv$3$4$bc93a92cf625e360$fe120bfb658d27b6$739f9d85964cef2f63b927ff77f3328cc5192014ae21c29954c322f4e808fe5c8abe64cc150dbcb08cb334f3b5c28357f10d8d5c6a103e2c899402136c14633aaf8a5347959b33b80ade2e3f5698864605940dc1423704999e5da859d6584491bbe940f00f162c75d2766b868ef2b4c6bf599a2e8ccea3f7cdfab193744a8d10", "123456789ABCDEf" },
 	{ "$encdv$3$4$e9786d82101f30ef$d690010a$5748af61f246c1569cc72cbd6c97e0be46b1612842fd3c6284637af5351508a602c731739acb056b845dfa2b5befd40f14136b4336e0c8e98144555a90befbc85abfc4069fbb71709fa39e29f8c6a98d28e14251e50ffdd43d75252de2b0b14c386e72927c62ae39ba18ff8b32a339d882fdd0b15284af246fa50b7c6992f783", "Verylongbutstillfailpassword" },
 	{ NULL }
 };
@@ -172,7 +172,7 @@ static int crypt_all_md5(int *pcount, struct db_salt *salt)
 				// result buffer is used here to hold the decrypted data.
 				enc_aes_ctr_iterated(cur_salt->encrypted_data, result, kdf_out[i][0].u8, ivs, AES_BLOCK_SIZE,
 				                     nb_keys, 1);
-				if (!memcmp(result + 4, "\xd2\xc3\xb4\xa1", ENC_SIG_SIZE)) {
+				if (!memcmp(result + 4, "\xd2\xc3\xb4\xa1\x00\x00", MIN(cur_salt->encrypted_data_length, ENC_SIG_SIZE - 2))) {
 					cracked[index + i] = 1;
 #ifdef _OPENMP
 #pragma omp atomic
@@ -198,7 +198,7 @@ static int crypt_all_md5(int *pcount, struct db_salt *salt)
 				}
 				// result buffer is reused here to hold the decrypted data.
 				enc_aes_ctr_iterated(cur_salt->encrypted_data, result, result, ivs, AES_BLOCK_SIZE, nb_keys, 1);
-				if (!memcmp(result + 4, "\xd2\xc3\xb4\xa1", ENC_SIG_SIZE)) {
+				if (!memcmp(result + 4, "\xd2\xc3\xb4\xa1\x00\x00", MIN(cur_salt->encrypted_data_length, ENC_SIG_SIZE - 2))) {
 					cracked[index + i] = 1;
 #ifdef _OPENMP
 					#pragma omp atomic

--- a/src/encdatavault_pbkdf2_fmt_plug.c
+++ b/src/encdatavault_pbkdf2_fmt_plug.c
@@ -50,13 +50,13 @@ john_register_one(&fmt_encdadatavault_pbkdf2);
 
 static struct fmt_tests encdatavault_pbkdf2_tests[] = {
 	// PrivateAccess
-	{ "$encdv-pbkdf2$1$1$eb012112b3561e6e$01c7dca5$32$9b1c17f7a467cf4d13b73dfd3ce12b3dd51cb980cc1f0ccfad4e47e9c9f3d774$100000", "123456Aa!"},
+	{ "$encdv-pbkdf2$1$1$eb012112b3561e6e$01c7dca58660d6ae$32$9b1c17f7a467cf4d13b73dfd3ce12b3dd51cb980cc1f0ccfad4e47e9c9f3d774$100000", "123456Aa!"},
 	// ENCDataVault v7.2.1 user password
 	//{ "$encdv-pbkdf2$1$3$e84dddc75bc68e3c$789ad76e$32$e89708fb33780d45b975117445c861ed6dfe30142dfdea9afc36ae1a28c552a7$100000", "openwallopenwall"},
 	// ENCDataVault v7.2.1 128 bits vault
- 	//{ "$encdv-pbkdf2$3$1$ae47f1c80b611a1c$bbbcc413$32$da910b0244a6704868b27b72fb0c4558f89b4343ac9716816d63d6ce95cdde6f$100000$f9ce89ee98ed1668cdd25881e0921a30f0a016f3d34055544b082422334f446db6361bbbfa1493ab6bca6c1255b9de6bcd0d1e7fac970fd8d8d21ccf289d224dcb1b5a89bde0c1c04c449155dfe58fa9c383b6856a28ba18d8c5d4efc208a79f05f68491ea98930f5bc7d4dacf56eda4b6277b6b7e88784fa466afba2f8c628a", "123456789ABCDEf"},
+ 	//{ "$encdv-pbkdf2$3$1$ae47f1c80b611a1c$bbbcc4131de92af6$32$da910b0244a6704868b27b72fb0c4558f89b4343ac9716816d63d6ce95cdde6f$100000$f9ce89ee98ed1668cdd25881e0921a30f0a016f3d34055544b082422334f446db6361bbbfa1493ab6bca6c1255b9de6bcd0d1e7fac970fd8d8d21ccf289d224dcb1b5a89bde0c1c04c449155dfe58fa9c383b6856a28ba18d8c5d4efc208a79f05f68491ea98930f5bc7d4dacf56eda4b6277b6b7e88784fa466afba2f8c628a", "123456789ABCDEf"},
 	// ENCDataVault v7.2.1 1024 bits vault
-	{ "$encdv-pbkdf2$3$4$4f1d3889c629968c$e8b68bb8$32$fa79c83e85a41973799522f525e1316ca07ab663def47b816da76205dc1e3e80$100000$0443baa02c7e00870a24f0c16ff0454c56ad079e334bb6fb52bf39de56485dc07f4827d8d83b6f3bf135062e2869d58b8ade04db0716c75d2519797cdbb1d9d75ffe3fc156edfd3bb95747fc0286c149c3c90da8a4b4cdf11838b680b6e9b26da3a0c93f29f8bff6e70f07e6077cda620f7b808793dc127395a11bfc068f1895", "123456789ABCDEf"},
+	{ "$encdv-pbkdf2$3$4$4f1d3889c629968c$e8b68bb804b94a23$32$fa79c83e85a41973799522f525e1316ca07ab663def47b816da76205dc1e3e80$100000$0443baa02c7e00870a24f0c16ff0454c56ad079e334bb6fb52bf39de56485dc07f4827d8d83b6f3bf135062e2869d58b8ade04db0716c75d2519797cdbb1d9d75ffe3fc156edfd3bb95747fc0286c149c3c90da8a4b4cdf11838b680b6e9b26da3a0c93f29f8bff6e70f07e6077cda620f7b808793dc127395a11bfc068f1895", "123456789ABCDEf"},
 	{ NULL }
 };
 
@@ -163,7 +163,7 @@ static int crypt_all_pbkdf2(int *pcount, struct db_salt *salt)
 				// result buffer is used here to hold the decrypted data.
 				enc_aes_ctr_iterated(cur_salt->encrypted_data, result, kdf_out[i][0].u8, ivs, AES_BLOCK_SIZE,
 				                     nb_keys, 1);
-				if (!memcmp(result + 4, "\xd2\xc3\xb4\xa1", ENC_SIG_SIZE)) {
+				if (!memcmp(result + 4, "\xd2\xc3\xb4\xa1\x00\x00", MIN(cur_salt->encrypted_data_length, ENC_SIG_SIZE - 2))) {
 					cracked[index + i] = 1;
 #ifdef _OPENMP
 #pragma omp atomic
@@ -189,7 +189,7 @@ static int crypt_all_pbkdf2(int *pcount, struct db_salt *salt)
 				}
 				// result buffer is reused here to hold the decrypted data.
 				enc_aes_ctr_iterated(cur_salt->encrypted_data, result, result, ivs, AES_BLOCK_SIZE, nb_keys, 1);
-				if (!memcmp(result + 4, "\xd2\xc3\xb4\xa1", ENC_SIG_SIZE)) {
+				if (!memcmp(result + 4, "\xd2\xc3\xb4\xa1\x00\x00", MIN(cur_salt->encrypted_data_length, ENC_SIG_SIZE - 2))) {
 					cracked[index + i] = 1;
 #ifdef _OPENMP
 #pragma omp atomic


### PR DESCRIPTION
As discussed in https://github.com/hashcat/hashcat/issues/3467 the number of fault positive can be reduced by looking at the following 4 bytes which represent the number of vaults which have been created on the machine. Tests have been updated.