### PR TITLE
Add "Compiler version" to --list=opencl-devices

### DIFF
--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -3019,7 +3019,10 @@ void opencl_list_devices(void)
 			if (strstr(dname, "OpenCL 1.0")) {
 				printf(" <the minimum REQUIRED is OpenCL 1.1>");
 			}
-			printf("\n    Driver version:         %s\n",
+			clGetDeviceInfo(devices[sequence_nr], CL_DEVICE_OPENCL_C_VERSION,
+			                sizeof(dname), dname, NULL);
+			printf("\n    OpenCL version support: %s\n", dname);
+			printf("    Driver version:         %s\n",
 			       opencl_driver_info(sequence_nr));
 
 			clGetDeviceInfo(devices[sequence_nr],


### PR DESCRIPTION
Example:
```
    (...)
    Device version:         OpenCL 3.0 CUDA
    Compiler version:       OpenCL C 1.2
    Driver version:         470.141.03 [recommended]
    (...)
```
"Device version" corresponds to CL_DEVICE_VERSION while "Compiler version" corresponds to CL_DEVICE_OPENCL_C_VERSION.  The example output is a bit weird with the latter lower than the former - it should mean we can't use OpenCL 2.0 on this device.  Perhaps they are not 100% compliant yet?