### PR TITLE
aem2john.py: add ability to parse+print user names

### DIFF
--- a/run/aem2john.py
+++ b/run/aem2john.py
@@ -23,13 +23,13 @@ if not PY3:
 
 # Input,
 #   {SHA-256}a9d4b340cb43807b-1000-33b8875ff3f9619e6ae984add262fb6b6f043e8ff9b065f4fb0863021aada275
-#   {SHA-256}fe90d85cdcd7e79c-1000-ef182cdc47e60b472784e42a6e167d26242648c6b2e063dfd9e27eec9aa38912
-#   {SHA-512}fe90d85cdcd7e79c-1000-4c29a0ac964e7bbc5380797f294d15928288cbcde3d501eb8746296de8d6c06b2b5ff27b56ae174744fe69ee157614ad126c1315ee3b67c891e42753e01a3e37
+#   jsmith:{SHA-256}fe90d85cdcd7e79c-1000-ef182cdc47e60b472784e42a6e167d26242648c6b2e063dfd9e27eec9aa38912
+#   admin:{SHA-512}fe90d85cdcd7e79c-1000-4c29a0ac964e7bbc5380797f294d15928288cbcde3d501eb8746296de8d6c06b2b5ff27b56ae174744fe69ee157614ad126c1315ee3b67c891e42753e01a3e37
 #
 # Output,
 #   $sspr$3$1000$a9d4b340cb43807b$33b8875ff3f9619e6ae984add262fb6b6f043e8ff9b065f4fb0863021aada275
-#   $sspr$3$1000$fe90d85cdcd7e79c$ef182cdc47e60b472784e42a6e167d26242648c6b2e063dfd9e27eec9aa38912
-#   $sspr$4$1000$fe90d85cdcd7e79c$4c29a0ac964e7bbc5380797f294d15928288cbcde3d501eb8746296de8d6c06b2b5ff27b56ae174744fe69ee157614ad126c1315ee3b67c891e42753e01a3e37
+#   jsmith:$sspr$3$1000$fe90d85cdcd7e79c$ef182cdc47e60b472784e42a6e167d26242648c6b2e063dfd9e27eec9aa38912
+#   admin:$sspr$4$1000$fe90d85cdcd7e79c$4c29a0ac964e7bbc5380797f294d15928288cbcde3d501eb8746296de8d6c06b2b5ff27b56ae174744fe69ee157614ad126c1315ee3b67c891e42753e01a3e37
 #
 # Passwords -> admin, Aa12345678!@
 
@@ -47,6 +47,13 @@ def process_file(filename):
             else:
                 sys.stderr.write("[!] Unknown hash format -> %s\n" % line[0:8])
                 continue
+            # Parse username
+            user = ''
+            if ':' in line:
+                parts = line.split(':')
+                user = parts[0] + ':'
+                line = parts[1]
+            # Split up hashing algo, salt, iterations, digest values
             line = line[tag_length:]
             data = line.split('-')
             try:
@@ -55,8 +62,8 @@ def process_file(filename):
                 import traceback
                 traceback.print_exc()
                 continue
-
-            sys.stdout.write("$sspr$%s$%s$%s$%s\n" % (algo, iterations, salt, h))
+            # Print out results $$$
+            sys.stdout.write("%s$sspr$%s$%s$%s$%s\n" % (user, algo, iterations, salt, h))
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:


### PR DESCRIPTION
added helpful functionality that now allows us to associate a user name with a hash. in both the input AEM hash, and the output John-formatted hash. validated, working fine, allows both types of aem hash input lines (user or no user). hacktheplanet