### PR TITLE
user level john-local.conf

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -4195,8 +4195,12 @@ void init()
 # the new john-local.conf if you so choose.
 .include '$JOHN/john.local.conf'
 
-# include john-local.conf (This file can be created by user, to override defaults in this john.conf file)
+# include john-local.conf (typically /usr/share/john/john-local.conf)
+# This file can be created by administrator, to override defaults in this john.conf file for whole machine
 .include '$JOHN/john-local.conf'
+
+# include john-local.conf (This file can be created by user, to override defaults in this john.conf file)
+.include '~/.john/john-local.conf'
 
 # include john-local.conf in local dir, it can override john.conf, john-local.conf (or any other conf file loaded)
 # This is disabled by default since it's a security risk in case JtR is ever run with untrusted current directory


### PR DESCRIPTION
The current .include '$JOHN/john-local.conf' is actually loading the system-wide file from the john package/installation typically from the /usr/share/john/john-local.conf To allow users to have possibility to load their own local additions to the global john.conf config,  it would be nice to attempt to load one from their home directory. 

```
┌──(kali㉿kali)-[~/exercises/john_the_ripper] 2023-02-17 17:48:59 +0100 
└─$ strace john --incremental=digits --stdout 2>&1  |grep -e 'open.*\.conf' 
openat(AT_FDCWD, "/home/kali/.john/john.conf", O_RDONLY) = 3 
openat(AT_FDCWD, "/usr/share/john/dynamic_disabled.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/unisubst.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/korelogic.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/hybrid.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/dumb16.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/dumb32.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/repeats16.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/repeats32.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/dynamic.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/dynamic_flat_sse_formats.conf", O_RDONLY) = 5
openat(AT_FDCWD, "/usr/share/john/regex_alphabets.conf", O_RDONLY) = 4
openat(AT_FDCWD, "/usr/share/john/john.local.conf", O_RDONLY) = -1 ENOENT (No such file or directory) 
openat(AT_FDCWD, "/usr/share/john/john-local.conf", O_RDONLY) = -1 ENOENT (No such file or directory) 
openat(AT_FDCWD, "/home/kali/.john/john-local.conf", O_RDONLY) = 4
```