### PR TITLE
Add SNTP-MS "Timeroast" formats

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -294,6 +294,8 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
   improvements to the shared RC4 OpenCL code, and changes to affected formats.
   [magnum; 2023]
 
+- Added support for cracking SNTP-MS "timeroast".  [magnum; 2023]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/run/opencl/timeroast_kernel.cl
+++ b/run/opencl/timeroast_kernel.cl
@@ -1,0 +1,297 @@
+/*
+ * This software is Copyright (c) 2023, magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted.
+ */
+
+#define AMD_PUTCHAR_NOCAST
+#include "opencl_misc.h"
+#include "opencl_md4.h"
+#include "opencl_md5.h"
+#include "opencl_unicode.h"
+#include "opencl_mask.h"
+
+inline void md4_crypt(uint *hash, uint *nt_buffer)
+{
+	md4_single(uint, nt_buffer, hash);
+}
+
+inline void md5_crypt(uint *hash, __constant uint *salt)
+{
+	uint W[16];
+
+	memcpy_macro(W, hash, 4);
+	memcpy_macro(W + 4, salt, 12);
+	md5_single(uint, W, hash);
+
+	W[0] = 0x80;
+	for (uint i = 1; i < 14; i++)
+		W[i] = 0;
+	W[14] = 64 << 3;
+	W[15] = 0;
+	md5_block(uint, W, hash);
+}
+
+#if __OS_X__ && (cpu(DEVICE_INFO) || gpu_nvidia(DEVICE_INFO))
+/* This is a workaround for driver/runtime bugs */
+#define MAYBE_VOLATILE volatile
+#else
+#define MAYBE_VOLATILE
+#endif
+
+#if UTF_8
+
+inline void prepare_key(__global uint *key, uint length,
+                        MAYBE_VOLATILE uint *nt_buffer)
+{
+	const __global UTF8 *source = (const __global uchar*)key;
+	const __global UTF8 *sourceEnd = &source[length];
+	MAYBE_VOLATILE UTF16 *target = (UTF16*)nt_buffer;
+	MAYBE_VOLATILE const UTF16 *targetEnd = &target[PLAINTEXT_LENGTH];
+	UTF32 ch;
+	uint extraBytesToRead;
+
+	/* Input buffer is UTF-8 without zero-termination */
+	while (source < sourceEnd) {
+		if (*source < 0xC0) {
+			*target++ = (UTF16)*source++;
+			if (target >= targetEnd)
+				break;
+			continue;
+		}
+		ch = *source;
+		// This point must not be reached with *source < 0xC0
+		extraBytesToRead =
+			opt_trailingBytesUTF8[ch & 0x3f];
+		if (source + extraBytesToRead >= sourceEnd) {
+			break;
+		}
+		switch (extraBytesToRead) {
+		case 3:
+			ch <<= 6;
+			ch += *++source;
+		case 2:
+			ch <<= 6;
+			ch += *++source;
+		case 1:
+			ch <<= 6;
+			ch += *++source;
+			++source;
+			break;
+		default:
+			*target = UNI_REPLACEMENT_CHAR;
+			break; // from switch
+		}
+		if (*target == UNI_REPLACEMENT_CHAR)
+			break; // from while
+		ch -= offsetsFromUTF8[extraBytesToRead];
+#ifdef UCS_2
+		/* UCS-2 only */
+		*target++ = (UTF16)ch;
+#else
+		/* full UTF-16 with surrogate pairs */
+		if (ch <= UNI_MAX_BMP) {  /* Target is a character <= 0xFFFF */
+			*target++ = (UTF16)ch;
+		} else {  /* target is a character in range 0xFFFF - 0x10FFFF. */
+			if (target + 1 >= targetEnd)
+				break;
+			ch -= halfBase;
+			*target++ = (UTF16)((ch >> halfShift) + UNI_SUR_HIGH_START);
+			*target++ = (UTF16)((ch & halfMask) + UNI_SUR_LOW_START);
+		}
+#endif
+		if (target >= targetEnd)
+			break;
+	}
+
+	*target = 0x80;	// Terminate
+
+	nt_buffer[14] = (uint)(target - (UTF16*)nt_buffer) << 4;
+}
+
+#else
+
+inline void prepare_key(__global uint *key, uint length, uint *nt_buffer)
+{
+	uint i, nt_index, keychars;
+
+	nt_index = 0;
+	for (i = 0; i < (length + 3)/ 4; i++) {
+		keychars = key[i];
+		nt_buffer[nt_index++] = CP_LUT(keychars & 0x000000FF) | (CP_LUT((keychars & 0x0000FF00) >> 8) << 16);
+		nt_buffer[nt_index++] = CP_LUT((keychars & 0x00FF0000) >> 16) | (CP_LUT(keychars >> 24) << 16);
+	}
+	nt_index = length >> 1;
+	nt_buffer[nt_index] = (nt_buffer[nt_index] & 0xFFFF) | (0x80 << ((length & 1) << 4));
+	nt_buffer[nt_index + 1] = 0;
+	nt_buffer[14] = length << 4;
+}
+
+#endif /* UTF_8 */
+
+inline void cmp_final(uint gid,
+		uint iter,
+		uint *hash,
+		__global uint *offset_table,
+		__global uint *hash_table,
+		__constant uint *salt,
+		__global uint *return_hashes,
+		volatile __global uint *output,
+		volatile __global uint *bitmap_dupe) {
+
+	uint t, offset_table_index, hash_table_index;
+	unsigned long LO, HI;
+	unsigned long p;
+
+	HI = ((unsigned long)hash[3] << 32) | (unsigned long)hash[2];
+	LO = ((unsigned long)hash[1] << 32) | (unsigned long)hash[0];
+
+	p = (HI % salt[13]) * salt[15];
+	p += LO % salt[13];
+	p %= salt[13];
+	offset_table_index = (unsigned int)p;
+
+	//error: chances of overflow is extremely low.
+	LO += (unsigned long)offset_table[offset_table_index];
+
+	p = (HI % salt[14]) * salt[16];
+	p += LO % salt[14];
+	p %= salt[14];
+	hash_table_index = (unsigned int)p;
+
+	if (hash_table[hash_table_index] == hash[0])
+	if (hash_table[salt[14] + hash_table_index] == hash[1])
+	{
+/*
+ * Prevent duplicate keys from cracking same hash
+ */
+		if (!(atomic_or(&bitmap_dupe[hash_table_index/32], (1U << (hash_table_index % 32))) & (1U << (hash_table_index % 32)))) {
+			t = atomic_inc(&output[0]);
+			output[1 + 3 * t] = gid;
+			output[2 + 3 * t] = iter;
+			output[3 + 3 * t] = hash_table_index;
+			return_hashes[2 * t] = hash[2];
+			return_hashes[2 * t + 1] = hash[3];
+		}
+	}
+}
+
+inline void cmp(uint gid,
+		uint iter,
+		uint *hash,
+		__global uint *bitmaps,
+		uint bitmap_sz_bits,
+		__global uint *offset_table,
+		__global uint *hash_table,
+		__constant uint *salt,
+		__global uint *return_hashes,
+		volatile __global uint *output,
+		volatile __global uint *bitmap_dupe) {
+	uint bitmap_index, tmp = 1;
+
+	bitmap_index = hash[3] & salt[12];
+	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & salt[12];
+	tmp &= (bitmaps[(bitmap_sz_bits >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+
+	if (tmp)
+		cmp_final(gid, iter, hash, offset_table, hash_table, salt, return_hashes, output, bitmap_dupe);
+}
+
+#define USE_CONST_CACHE \
+	(CONST_CACHE_SIZE >= ((NUM_INT_KEYS + 17) * 4))
+/* some constants used below are passed with -D */
+//#define KEY_LENGTH (MD4_PLAINTEXT_LENGTH + 1)
+
+/* OpenCL kernel entry point. Copy key to be hashed from
+ * global to local (thread) memory. Break the key into 16 32-bit (uint)
+ * words. MD4 hash of a key is 128 bit (uint4). */
+__kernel void timeroast(__global uint *keys,
+                        __global uint *index,
+                        __constant uint *salt
+                        , __global uint *int_key_loc,
+#if USE_CONST_CACHE
+                        __constant
+#else
+                        __global
+#endif
+                        uint *int_keys
+                        , __global uint *bitmaps,
+                        __global uint *offset_table,
+                        __global uint *hash_table,
+                        __global uint *return_hashes,
+                        volatile __global uint *out_hash_ids,
+                        volatile __global uint *bitmap_dupe)
+{
+	uint i;
+	uint gid = get_global_id(0);
+	uint base = index[gid];
+	uint nt_buffer[16] = { 0 };
+	uint len = base & 127;
+	uint hash[4] = {0};
+	uint bitmap_sz_bits = salt[12] + 1;
+
+#if NUM_INT_KEYS > 1 && !IS_STATIC_GPU_MASK
+	uint ikl = int_key_loc[gid];
+	uint loc0 = ikl & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+	uint loc1 = (ikl & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+	uint loc2 = (ikl & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+	uint loc3 = (ikl & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+#if !IS_STATIC_GPU_MASK
+#define GPU_LOC_0 loc0
+#define GPU_LOC_1 loc1
+#define GPU_LOC_2 loc2
+#define GPU_LOC_3 loc3
+#else
+#define GPU_LOC_0 LOC_0
+#define GPU_LOC_1 LOC_1
+#define GPU_LOC_2 LOC_2
+#define GPU_LOC_3 LOC_3
+#endif
+
+	keys += base >> 7;
+	prepare_key(keys, len, nt_buffer);
+
+	for (i = 0; i < NUM_INT_KEYS; i++) {
+#if NUM_INT_KEYS > 1
+		PUTSHORT(nt_buffer, GPU_LOC_0, CP_LUT(int_keys[i] & 0xff));
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+		PUTSHORT(nt_buffer, GPU_LOC_1, CP_LUT((int_keys[i] & 0xff00) >> 8));
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+		PUTSHORT(nt_buffer, GPU_LOC_2, CP_LUT((int_keys[i] & 0xff0000) >> 16));
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+		PUTSHORT(nt_buffer, GPU_LOC_3, CP_LUT((int_keys[i] & 0xff000000) >> 24));
+#endif
+#endif
+#endif
+		md4_crypt(hash, nt_buffer);
+		md5_crypt(hash, salt);
+
+		cmp(gid, i, hash, bitmaps, bitmap_sz_bits, offset_table, hash_table,
+		    salt, return_hashes, out_hash_ids, bitmap_dupe);
+
+	}
+}

--- a/src/opencl_timeroast_fmt_plug.c
+++ b/src/opencl_timeroast_fmt_plug.c
@@ -1,0 +1,781 @@
+/*
+ * This software is Copyright (c) 2023, magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#ifdef HAVE_OPENCL
+#define FMT_STRUCT fmt_opencl_timeroast
+
+#if FMT_EXTERNS_H
+extern struct fmt_main FMT_STRUCT;
+#elif FMT_REGISTERS_H
+john_register_one(&FMT_STRUCT);
+#else
+
+#include <string.h>
+#include <sys/time.h>
+
+#include "arch.h"
+#include "params.h"
+#include "path.h"
+#include "common.h"
+#include "formats.h"
+#include "opencl_common.h"
+#include "config.h"
+#include "options.h"
+#include "unicode.h"
+#include "mask_ext.h"
+#include "bt_interface.h"
+#include "timeroast_common.h"
+
+#define PLAINTEXT_LENGTH    27 /* Max. is 55 with current kernel */
+#define UTF8_MAX_LENGTH     (3 * PLAINTEXT_LENGTH)
+#define BUFSIZE             ((UTF8_MAX_LENGTH + 3) / 4 * 4)
+#define AUTOTUNE_LENGTH     8
+#define FORMAT_LABEL        "timeroast-opencl"
+#define FORMAT_NAME         "SNTP-MS"
+#define ALGORITHM_NAME      "MD4+MD5 OpenCL"
+
+static cl_mem pinned_saved_keys, pinned_saved_idx, pinned_int_key_loc;
+static cl_mem buffer_keys, buffer_idx, buffer_int_keys, buffer_int_key_loc;
+static cl_uint *saved_plain, *saved_idx, *saved_int_key_loc;
+static int static_gpu_locations[MASK_FMT_INT_PLHDR];
+
+static cl_mem buffer_return_hashes, buffer_hash_ids, buffer_bitmap_dupe;
+static cl_mem *buffer_offset_tables, *buffer_hash_tables, *buffer_bitmaps, *buffer_salts;
+static OFFSET_TABLE_WORD *offset_table;
+static unsigned int **hash_tables;
+static unsigned int current_salt;
+static cl_uint *loaded_hashes, max_num_loaded_hashes, *hash_ids, *bitmaps, max_hash_table_size;
+static cl_ulong bitmap_size_bits;
+
+static unsigned int key_idx;
+static unsigned int new_keys;
+static struct fmt_main *self;
+static cl_uint *zero_buffer;
+
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+
+#define STEP                    0
+#define SEED                    1024
+
+static const char *warn[] = {
+	"key xfer: ",  ", idx xfer: ",  ", crypt: ",  ", res xfer: "
+};
+
+//This file contains auto-tuning routine(s). Has to be included after formats definitions.
+#include "opencl_autotune.h"
+
+/* ------- Helper functions ------- */
+static size_t get_task_max_work_group_size()
+{
+	return autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel);
+}
+
+struct fmt_main FMT_STRUCT;
+
+static void set_kernel_args_kpc()
+{
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 0, sizeof(buffer_keys), (void *) &buffer_keys), "Error setting argument 1.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 1, sizeof(buffer_idx), (void *) &buffer_idx), "Error setting argument 2.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 3, sizeof(buffer_int_key_loc), (void *) &buffer_int_key_loc), "Error setting argument 4.");
+}
+
+static void set_kernel_args()
+{
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 4, sizeof(buffer_int_keys), (void *) &buffer_int_keys), "Error setting argument 5.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 8, sizeof(buffer_return_hashes), (void *) &buffer_return_hashes), "Error setting argument 9.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 9, sizeof(buffer_hash_ids), (void *) &buffer_hash_ids), "Error setting argument 10.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 10, sizeof(buffer_bitmap_dupe), (void *) &buffer_bitmap_dupe), "Error setting argument 11.");
+}
+
+static void release_clobj(void);
+
+static void create_clobj(size_t kpc, struct fmt_main *self)
+{
+	release_clobj();
+
+	pinned_saved_keys = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR, BUFSIZE * kpc, NULL, &ret_code);
+	if (ret_code != CL_SUCCESS) {
+		saved_plain = (cl_uint *) mem_alloc(BUFSIZE * kpc);
+		if (saved_plain == NULL)
+			HANDLE_CLERROR(ret_code, "Error creating page-locked memory pinned_saved_keys.");
+	}
+	else {
+		saved_plain = (cl_uint *) clEnqueueMapBuffer(queue[gpu_id], pinned_saved_keys, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFSIZE * kpc, 0, NULL, NULL, &ret_code);
+		HANDLE_CLERROR(ret_code, "Error mapping page-locked memory saved_plain.");
+	}
+
+	pinned_saved_idx = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR, sizeof(cl_uint) * kpc, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating page-locked memory pinned_saved_idx.");
+	saved_idx = (cl_uint *) clEnqueueMapBuffer(queue[gpu_id], pinned_saved_idx, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, sizeof(cl_uint) * kpc, 0, NULL, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error mapping page-locked memory saved_idx.");
+
+	pinned_int_key_loc = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR, sizeof(cl_uint) * kpc, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating page-locked memory pinned_int_key_loc.");
+	saved_int_key_loc = (cl_uint *) clEnqueueMapBuffer(queue[gpu_id], pinned_int_key_loc, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, sizeof(cl_uint) * kpc, 0, NULL, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error mapping page-locked memory saved_int_key_loc.");
+
+	// create and set arguments
+	buffer_keys = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, BUFSIZE * kpc, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_keys.");
+
+	buffer_idx = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, 4 * kpc, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_idx.");
+
+	buffer_int_key_loc = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, sizeof(cl_uint) * kpc, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_int_key_loc.");
+
+	set_kernel_args_kpc();
+}
+
+static void create_base_clobj()
+{
+	unsigned int dummy = 0;
+
+	zero_buffer = (cl_uint *) mem_calloc(max_hash_table_size/32 + 1, sizeof(cl_uint));
+
+	buffer_return_hashes = clCreateBuffer(context[gpu_id], CL_MEM_WRITE_ONLY, 2 * sizeof(cl_uint) * max_num_loaded_hashes, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_return_hashes.");
+
+	buffer_hash_ids = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE, (3 * max_num_loaded_hashes + 1) * sizeof(cl_uint), NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_buffer_hash_ids.");
+
+	buffer_bitmap_dupe = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR, (max_hash_table_size/32 + 1) * sizeof(cl_uint), zero_buffer, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_bitmap_dupe.");
+
+	//ref_ctr is used as dummy parameter
+	buffer_int_keys = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, 4 * mask_int_cand.num_int_cand, mask_int_cand.int_cand ? mask_int_cand.int_cand : (void *)&dummy, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_int_keys.");
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, sizeof(cl_uint), zero_buffer, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_hash_ids.");
+
+	set_kernel_args();
+}
+
+static void release_clobj(void)
+{
+	if (buffer_keys) {
+		if (pinned_saved_keys) {
+			HANDLE_CLERROR(clEnqueueUnmapMemObject(queue[gpu_id], pinned_saved_keys, saved_plain, 0, NULL, NULL), "Error Unmapping saved_plain.");
+			HANDLE_CLERROR(clReleaseMemObject(pinned_saved_keys), "Error Releasing pinned_saved_keys.");
+		}
+		else
+			MEM_FREE(saved_plain);
+
+		HANDLE_CLERROR(clEnqueueUnmapMemObject(queue[gpu_id], pinned_saved_idx, saved_idx, 0, NULL, NULL), "Error Unmapping saved_idx.");
+		HANDLE_CLERROR(clEnqueueUnmapMemObject(queue[gpu_id], pinned_int_key_loc, saved_int_key_loc, 0, NULL, NULL), "Error Unmapping saved_int_key_loc.");
+		HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error releasing mappings.");
+		HANDLE_CLERROR(clReleaseMemObject(pinned_saved_idx), "Error Releasing pinned_saved_idx.");
+		HANDLE_CLERROR(clReleaseMemObject(pinned_int_key_loc), "Error Releasing pinned_int_key_loc.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_keys), "Error Releasing buffer_keys.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_idx), "Error Releasing buffer_idx.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_int_key_loc), "Error Releasing buffer_int_key_loc.");
+		buffer_keys = 0;
+	}
+}
+
+static void release_base_clobj(void)
+{
+	if (buffer_int_keys) {
+		HANDLE_CLERROR(clReleaseMemObject(buffer_int_keys), "Error Releasing buffer_int_keys.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_return_hashes), "Error Releasing buffer_return_hashes.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_bitmap_dupe), "Error Releasing buffer_bitmap_dupe.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_hash_ids), "Error Releasing buffer_hash_ids.");
+		MEM_FREE(zero_buffer);
+		buffer_int_keys = 0;
+	}
+}
+
+static void release_salt_buffers()
+{
+	unsigned int k;
+	if (hash_tables) {
+		k = 0;
+		while (hash_tables[k]) {
+			MEM_FREE(hash_tables[k]);
+			k++;
+		}
+		MEM_FREE(hash_tables);
+	}
+	if (buffer_offset_tables) {
+		k = 0;
+		while (buffer_offset_tables[k]) {
+			clReleaseMemObject(buffer_offset_tables[k]);
+			buffer_offset_tables[k] = 0;
+			k++;
+		}
+		MEM_FREE(buffer_offset_tables);
+	}
+	if (buffer_hash_tables) {
+		k = 0;
+		while (buffer_hash_tables[k]) {
+			clReleaseMemObject(buffer_hash_tables[k]);
+			buffer_hash_tables[k] = 0;
+			k++;
+		}
+		MEM_FREE(buffer_hash_tables);
+	}
+	if (buffer_bitmaps) {
+		k = 0;
+		while (buffer_bitmaps[k]) {
+			clReleaseMemObject(buffer_bitmaps[k]);
+			buffer_bitmaps[k] = 0;
+			k++;
+		}
+		MEM_FREE(buffer_bitmaps);
+	}
+	if (buffer_salts) {
+		k = 0;
+		while (buffer_salts[k]) {
+			clReleaseMemObject(buffer_salts[k]);
+			buffer_salts[k] = 0;
+			k++;
+		}
+		MEM_FREE(buffer_salts);
+	}
+}
+
+static void done(void)
+{
+	release_clobj();
+	release_base_clobj();
+
+	if (crypt_kernel) {
+		HANDLE_CLERROR(clReleaseKernel(crypt_kernel), "Release kernel.");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program.");
+		crypt_kernel = NULL;
+	}
+
+	if (loaded_hashes)
+		MEM_FREE(loaded_hashes);
+	if (hash_ids)
+		MEM_FREE(hash_ids);
+	release_salt_buffers();
+}
+
+static void init_kernel(void)
+{
+	char build_opts[5000];
+	int i;
+
+	if (crypt_kernel) {
+		HANDLE_CLERROR(clReleaseKernel(crypt_kernel), "Release kernel.");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program.");
+		crypt_kernel = NULL;
+	}
+
+	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
+			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
+				ranges[mask_skip_ranges[i]].pos;
+		else
+			static_gpu_locations[i] = -1;
+
+	sprintf(build_opts, "-D NUM_INT_KEYS=%u -D IS_STATIC_GPU_MASK=%d"
+#if !NT_FULL_UNICODE
+		" -DUCS_2"
+#endif
+		" -D%s -D%s -DPLAINTEXT_LENGTH=%d -D LOC_0=%d"
+#if MASK_FMT_INT_PLHDR > 1
+	" -D LOC_1=%d "
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+	"-D LOC_2=%d "
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+	"-D LOC_3=%d"
+#endif
+	, mask_int_cand.num_int_cand, mask_gpu_is_static,
+	cp_id2macro(options.target_enc),
+	options.internal_cp == UTF_8 ? cp_id2macro(ENC_RAW) :
+	cp_id2macro(options.internal_cp), PLAINTEXT_LENGTH,
+	static_gpu_locations[0]
+#if MASK_FMT_INT_PLHDR > 1
+	, static_gpu_locations[1]
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+	, static_gpu_locations[2]
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+	, static_gpu_locations[3]
+#endif
+	);
+
+	opencl_build_kernel("$JOHN/opencl/timeroast_kernel.cl", gpu_id, build_opts, 0);
+	crypt_kernel = clCreateKernel(program[gpu_id], "timeroast", &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating kernel. Double-check kernel name?");
+}
+
+static void set_key(char *_key, int index);
+
+static void init(struct fmt_main *_self)
+{
+	self = _self;
+	max_num_loaded_hashes = 0;
+
+	opencl_prepare_dev(gpu_id);
+	mask_int_cand_target = opencl_speed_index(gpu_id) / 300;
+}
+
+static int get_hash_0(int index) { return hash_tables[current_salt][hash_ids[3 + 3 * index]] & PH_MASK_0; }
+static int get_hash_1(int index) { return hash_tables[current_salt][hash_ids[3 + 3 * index]] & PH_MASK_1; }
+static int get_hash_2(int index) { return hash_tables[current_salt][hash_ids[3 + 3 * index]] & PH_MASK_2; }
+static int get_hash_3(int index) { return hash_tables[current_salt][hash_ids[3 + 3 * index]] & PH_MASK_3; }
+static int get_hash_4(int index) { return hash_tables[current_salt][hash_ids[3 + 3 * index]] & PH_MASK_4; }
+static int get_hash_5(int index) { return hash_tables[current_salt][hash_ids[3 + 3 * index]] & PH_MASK_5; }
+static int get_hash_6(int index) { return hash_tables[current_salt][hash_ids[3 + 3 * index]] & PH_MASK_6; }
+
+static void clear_keys(void)
+{
+	key_idx = 0;
+}
+
+static void set_key(char *_key, int index)
+{
+	const uint32_t *key = (uint32_t*)_key;
+	int len = strlen(_key);
+
+	if (mask_int_cand.num_int_cand > 1 && !mask_gpu_is_static) {
+		int i;
+		saved_int_key_loc[index] = 0;
+		for (i = 0; i < MASK_FMT_INT_PLHDR; i++) {
+			if (mask_skip_ranges[i] != -1)  {
+				saved_int_key_loc[index] |= ((mask_int_cand.
+				int_cpu_mask_ctx->ranges[mask_skip_ranges[i]].offset +
+				mask_int_cand.int_cpu_mask_ctx->
+				ranges[mask_skip_ranges[i]].pos) & 0xff) << (i << 3);
+			}
+			else
+				saved_int_key_loc[index] |= 0x80 << (i << 3);
+		}
+	}
+
+	saved_idx[index] = (key_idx << 7) | len;
+
+	while (len > 4) {
+		saved_plain[key_idx++] = *key++;
+		len -= 4;
+	}
+	if (len)
+		saved_plain[key_idx++] = *key & (0xffffffffU >> (32 - (len << 3)));
+	new_keys = 1;
+}
+
+static char *get_key(int index)
+{
+	static char out[UTF8_MAX_LENGTH + 1];
+	int i, len, int_index, t;
+	char *key;
+
+	if (hash_ids == NULL || hash_ids[0] == 0 ||
+	    index >= hash_ids[0] || hash_ids[0] > max_num_loaded_hashes) {
+		t = index;
+		int_index = 0;
+	}
+	else  {
+		t = hash_ids[1 + 3 * index];
+		int_index = hash_ids[2 + 3 * index];
+
+	}
+
+	if (t >= global_work_size) {
+		//fprintf(stderr, "Get key error! %d %d\n", t, index);
+		t = 0;
+	}
+
+	len = saved_idx[t] & 127;
+	key = (char*)&saved_plain[saved_idx[t] >> 7];
+
+	for (i = 0; i < len; i++)
+		out[i] = *key++;
+	out[i] = 0;
+
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
+			if (mask_gpu_is_static)
+				out[static_gpu_locations[i]] =
+				mask_int_cand.int_cand[int_index].x[i];
+			else
+				out[(saved_int_key_loc[t]& (0xff << (i * 8))) >> (i * 8)] =
+				mask_int_cand.int_cand[int_index].x[i];
+	}
+
+	/* Ensure truncation due to over-length or invalid UTF-8 is made like in GPU code. */
+	if (options.target_enc == UTF_8)
+		truncate_utf8((UTF8*)out, PLAINTEXT_LENGTH);
+
+	return out;
+}
+
+/* Use only for smaller bitmaps < 16MB */
+static void prepare_bitmap_4(cl_ulong bmp_sz, cl_uint **bitmap_ptr, uint32_t num_loaded_hashes)
+{
+	unsigned int i;
+	MEM_FREE(*bitmap_ptr);
+	*bitmap_ptr = (cl_uint*) mem_calloc((bmp_sz >> 3), sizeof(cl_uint));
+
+	for (i = 0; i < num_loaded_hashes; i++) {
+		unsigned int bmp_idx = loaded_hashes[4 * i + 3] & (bmp_sz - 1);
+		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
+
+		bmp_idx = loaded_hashes[4 * i + 2] & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |=
+			(1U << (bmp_idx & 31));
+
+		bmp_idx = loaded_hashes[4 * i + 1] & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 4) + (bmp_idx >> 5)] |=
+			(1U << (bmp_idx & 31));
+
+		bmp_idx = loaded_hashes[4 * i] & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) * 3 + (bmp_idx >> 5)] |=
+			(1U << (bmp_idx & 31));
+	}
+}
+/*
+static void prepare_bitmap_1(cl_ulong bmp_sz, cl_uint **bitmap_ptr, uint32_t num_loaded_hashes)
+{
+	unsigned int i;
+	MEM_FREE(*bitmap_ptr);
+	*bitmap_ptr = (cl_uint*) mem_calloc((bmp_sz >> 5), sizeof(cl_uint));
+
+	for (i = 0; i < num_loaded_hashes; i++) {
+		unsigned int bmp_idx = loaded_hashes[4 * i + 3] & (bmp_sz - 1);
+		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
+	}
+}*/
+
+static void select_bitmap(unsigned int num_loaded_hashes)
+{
+	cl_ulong max_local_mem_sz_bytes = 0;
+
+	HANDLE_CLERROR(clGetDeviceInfo(devices[gpu_id], CL_DEVICE_LOCAL_MEM_SIZE,
+		sizeof(cl_ulong), &max_local_mem_sz_bytes, 0),
+		"failed to get CL_DEVICE_LOCAL_MEM_SIZE.");
+
+	if (num_loaded_hashes <= 5100) {
+		if (amd_gcn_10(device_info[gpu_id]) ||
+			amd_vliw4(device_info[gpu_id]))
+			bitmap_size_bits = 512 * 1024;
+
+		else
+			bitmap_size_bits = 256 * 1024;
+	}
+
+	else if (num_loaded_hashes <= 10100) {
+		if (amd_gcn_10(device_info[gpu_id]) ||
+			amd_vliw4(device_info[gpu_id]))
+			bitmap_size_bits = 512 * 1024;
+
+		else
+			bitmap_size_bits = 256 * 1024;
+
+	}
+
+	else if (num_loaded_hashes <= 20100) {
+		if (amd_gcn_10(device_info[gpu_id]) ||
+			amd_vliw4(device_info[gpu_id]))
+			bitmap_size_bits = 1024 * 1024;
+
+		else
+			bitmap_size_bits = 512 * 1024;
+
+	}
+
+	else if (num_loaded_hashes <= 250100)
+		bitmap_size_bits = 2048 * 1024;
+
+	else if (num_loaded_hashes <= 1100100) {
+		if (!amd_gcn_11(device_info[gpu_id]))
+			bitmap_size_bits = 4096 * 1024;
+
+		else
+			bitmap_size_bits = 2048 * 1024;
+	}
+	else {
+		fprintf(stderr, "Too many hashes (%d), max is 1100100\n",
+		        num_loaded_hashes);
+		error();
+	}
+
+	prepare_bitmap_4(bitmap_size_bits, &bitmaps, num_loaded_hashes);
+}
+
+static void prepare_table(struct db_main *db)
+{
+	struct db_salt *salt;
+	int seq_ids = 0;
+
+	max_num_loaded_hashes = 0;
+	max_hash_table_size = 1;
+
+	salt = db->salts;
+	do {
+		if (salt->count > max_num_loaded_hashes)
+			max_num_loaded_hashes = salt->count;
+	} while ((salt = salt->next));
+
+	MEM_FREE(loaded_hashes);
+	MEM_FREE(hash_ids);
+	release_salt_buffers();
+
+	loaded_hashes = (cl_uint*) mem_alloc(4 * max_num_loaded_hashes * sizeof(cl_uint));
+	hash_ids = (cl_uint*) mem_calloc((3 * max_num_loaded_hashes + 1), sizeof(cl_uint));
+
+	hash_tables = (unsigned int **)mem_calloc(sizeof(unsigned int*), db->salt_count + 1);
+	buffer_offset_tables = (cl_mem *)mem_calloc(sizeof(cl_mem), db->salt_count + 1);
+	buffer_hash_tables = (cl_mem *)mem_calloc(sizeof(cl_mem), db->salt_count + 1);
+	buffer_bitmaps = (cl_mem *)mem_calloc(sizeof(cl_mem), db->salt_count + 1);
+	buffer_salts = (cl_mem *)mem_calloc(sizeof(cl_mem), db->salt_count + 1);
+
+	hash_tables[db->salt_count] = NULL;
+	buffer_offset_tables[db->salt_count] = NULL;
+	buffer_hash_tables[db->salt_count] = NULL;
+	buffer_bitmaps[db->salt_count] = NULL;
+	buffer_salts[db->salt_count] = NULL;
+
+	salt = db->salts;
+	do {
+		unsigned int i = 0;
+		unsigned int num_loaded_hashes, salt_params[SALT_SIZE / sizeof(unsigned int) + 5];
+		unsigned int hash_table_size, offset_table_size, shift64_ht_sz, shift64_ot_sz;
+		struct db_password *pw, *last;
+
+		last = pw = salt->list;
+		do {
+			unsigned int *bin = (unsigned int *)pw->binary;
+			if (bin == NULL) {
+				if (last == pw)
+					salt->list = pw->next;
+				else
+					last->next = pw->next;
+			} else {
+				last = pw;
+				loaded_hashes[4 * i] = bin[0];
+				loaded_hashes[4 * i + 1] = bin[1];
+				loaded_hashes[4 * i + 2] = bin[2];
+				loaded_hashes[4 * i + 3] = bin[3];
+				i++;
+			}
+		} while ((pw = pw->next));
+
+		if (i != salt->count) {
+			fprintf(stderr,
+				"Something went wrong while preparing hashes..Exiting..\n");
+			error();
+		}
+		num_loaded_hashes = salt->count;
+		salt->sequential_id = seq_ids++;
+
+		num_loaded_hashes = create_perfect_hash_table(128, (void*)loaded_hashes,
+		                                              num_loaded_hashes,
+		                                              &offset_table,
+		                                              &offset_table_size,
+		                                              &hash_table_size, 0);
+
+		if (!num_loaded_hashes) {
+			MEM_FREE(hash_table_128);
+			fprintf(stderr, "Failed to create Hash Table for cracking.\n");
+			error();
+		}
+
+		hash_tables[salt->sequential_id] = hash_table_128;
+
+		buffer_offset_tables[salt->sequential_id] = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, offset_table_size * sizeof(OFFSET_TABLE_WORD), offset_table, &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_offset_tables[].");
+
+		buffer_hash_tables[salt->sequential_id] = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, hash_table_size * sizeof(unsigned int) * 2, hash_table_128, &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_hash_tables[].");
+
+		if (max_hash_table_size < hash_table_size)
+			max_hash_table_size = hash_table_size;
+
+		shift64_ht_sz = (((1ULL << 63) % hash_table_size) * 2) % hash_table_size;
+		shift64_ot_sz = (((1ULL << 63) % offset_table_size) * 2) % offset_table_size;
+
+		select_bitmap(num_loaded_hashes);
+
+		memcpy(salt_params, salt->salt, SALT_SIZE);
+		salt_params[12] = bitmap_size_bits - 1;
+		salt_params[13] = offset_table_size;
+		salt_params[14] = hash_table_size;
+		salt_params[15] = shift64_ot_sz;
+		salt_params[16] = shift64_ht_sz;
+
+		buffer_bitmaps[salt->sequential_id] = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, (size_t)(bitmap_size_bits >> 3) * 2, bitmaps, &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_bitmaps[].");
+
+		buffer_salts[salt->sequential_id] = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, (SALT_SIZE / sizeof(unsigned int) + 5) * sizeof(unsigned int), salt_params, &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_salts[].");
+
+		MEM_FREE(bitmaps);
+		MEM_FREE(offset_table);
+
+	} while ((salt = salt->next));
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+
+	size_t *lws = local_work_size ? &local_work_size : NULL;
+	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
+
+	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand %d\n", __FUNCTION__, count, local_work_size, gws, key_idx, mask_int_cand.num_int_cand);
+
+	// copy keys to the device
+	if (new_keys) {
+		if (key_idx)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_FALSE, 0, 4 * key_idx, saved_plain, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer buffer_keys.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_FALSE, 0, 4 * gws, saved_idx, 0, NULL, multi_profilingEvent[1]), "failed in clEnqueueWriteBuffer buffer_idx.");
+		if (!mask_gpu_is_static)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_FALSE, 0, 4 * gws, saved_int_key_loc, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
+		new_keys = 0;
+	}
+
+	current_salt = salt->sequential_id;
+	BENCH_CLERROR(clSetKernelArg(crypt_kernel, 2, sizeof(buffer_salts[current_salt]), (void *) &buffer_salts[current_salt]), "Error setting argument 3.");
+	BENCH_CLERROR(clSetKernelArg(crypt_kernel, 5, sizeof(buffer_bitmaps[current_salt]), (void *) &buffer_bitmaps[current_salt]), "Error setting argument 6.");
+	BENCH_CLERROR(clSetKernelArg(crypt_kernel, 6, sizeof(buffer_offset_tables[current_salt]), (void *) &buffer_offset_tables[current_salt]), "Error setting argument 7.");
+	BENCH_CLERROR(clSetKernelArg(crypt_kernel, 7, sizeof(buffer_hash_tables[current_salt]), (void *) &buffer_hash_tables[current_salt]), "Error setting argument 8.");
+
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "failed in clEnqueueNDRangeKernel");
+
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, sizeof(cl_uint), hash_ids, 0, NULL, multi_profilingEvent[3]), "failed in reading back num cracked hashes.");
+
+	if (hash_ids[0] > max_num_loaded_hashes) {
+		fprintf(stderr, "Error, crypt_all kernel.\n");
+		error();
+	}
+
+	if (hash_ids[0]) {
+		BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_return_hashes, CL_FALSE, 0, 2 * sizeof(cl_uint) * hash_ids[0], loaded_hashes, 0, NULL, NULL), "failed in reading back return_hashes.");
+		BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, (3 * hash_ids[0] + 1) * sizeof(cl_uint), hash_ids, 0, NULL, NULL), "failed in reading data back hash_ids.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_bitmap_dupe, CL_FALSE, 0, (max_hash_table_size/32 + 1) * sizeof(cl_uint), zero_buffer, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_bitmap_dupe.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0, sizeof(cl_uint), zero_buffer, 0, NULL, NULL), "failed in clEnqueueWriteBuffer buffer_hash_ids.");
+	}
+
+	*pcount *=  mask_int_cand.num_int_cand;
+	return hash_ids[0];
+}
+
+static int cmp_all(void *binary, int count)
+{
+	if (count) return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return (((unsigned int*)binary)[0] ==
+		hash_tables[current_salt][hash_ids[3 + 3 * index]]);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	unsigned int *t = (unsigned int *) timeroast_binary(source);
+
+	if (t[2] != loaded_hashes[2 * index])
+		return 0;
+	if (t[3] != loaded_hashes[2 * index + 1])
+		return 0;
+	return 1;
+}
+
+static void reset(struct db_main *db)
+{
+	release_base_clobj();
+	release_clobj();
+
+	prepare_table(db);
+	init_kernel();
+
+	create_base_clobj();
+
+	current_salt = 0;
+	hash_ids[0] = 0;
+
+	size_t gws_limit = MIN((0xf << 21) * 4 / BUFSIZE,
+	                       get_max_mem_alloc_size(gpu_id) / BUFSIZE);
+	get_power_of_two(gws_limit);
+	if (gws_limit > MIN((0xf << 21) * 4 / BUFSIZE,
+	                    get_max_mem_alloc_size(gpu_id) / BUFSIZE))
+		gws_limit >>= 1;
+
+	// Initialize openCL tuning (library) for this format.
+	opencl_init_auto_setup(SEED, 1, NULL, warn, 2, self,
+	                       create_clobj, release_clobj,
+	                       2 * BUFSIZE, gws_limit, db);
+
+	// Auto tune execution from shared/included code.
+	autotune_run_extra(self, 1, gws_limit, 200, CL_TRUE);
+}
+
+struct fmt_main FMT_STRUCT = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_UNICODE | FMT_ENC | FMT_REMOVE | FMT_MASK,
+		{ NULL },
+		{ FORMAT_TAG },
+		timeroast_tests
+	}, {
+		init,
+		done,
+		reset,
+		fmt_default_prepare,
+		timeroast_valid,
+		fmt_default_split,
+		timeroast_binary,
+		timeroast_salt,
+		{ NULL },
+		fmt_default_source,
+		{
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
+		},
+		fmt_default_salt_hash,
+		NULL,
+		fmt_default_set_salt,
+		set_key,
+		get_key,
+		clear_keys,
+		crypt_all,
+		{
+			get_hash_0,
+			get_hash_1,
+			get_hash_2,
+			get_hash_3,
+			get_hash_4,
+			get_hash_5,
+			get_hash_6
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */
+
+#endif /* HAVE_OPENCL */

--- a/src/timeroast_common.h
+++ b/src/timeroast_common.h
@@ -1,0 +1,25 @@
+/*
+ * SNTP-MS "Timeroast" patch for john
+ *
+ * This software is Copyright (c) 2023 magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#define PLAINTEXT_LENGTH    27
+#define BENCHMARK_COMMENT   ""
+#define BENCHMARK_LENGTH    7
+#define FORMAT_TAG          "$sntp-ms$"
+#define FORMAT_TAG_LEN      (sizeof(FORMAT_TAG) - 1)
+#define BINARY_SIZE         16
+#define BINARY_ALIGN        sizeof(uint32_t)
+#define SALT_SIZE           48
+#define SALT_ALIGN          sizeof(uint32_t)
+
+extern struct fmt_tests timeroast_tests[];
+
+extern int   timeroast_valid(char *ciphertext, struct fmt_main *self);
+extern void *timeroast_binary(char *ciphertext);
+extern void *timeroast_salt(char *ciphertext);

--- a/src/timeroast_common_plug.c
+++ b/src/timeroast_common_plug.c
@@ -1,0 +1,98 @@
+/*
+ * SNTP-MS "Timeroast" patch for john
+ *
+ * This software is Copyright (c) 2023 magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#include <stdio.h>
+
+#include "formats.h"
+#include "memory.h"
+#include "common.h"
+#include "unicode.h"
+#include "johnswap.h"
+#include "timeroast_common.h"
+
+struct fmt_tests timeroast_tests[] = {
+	{"$sntp-ms$55265c2d9510284b3ad62ab7d5cae532$1c0111e900000000000a24124c4f434ce6e13d4de4200050e1b8428bffbfcd0ae6e16cdc7817804fe6e16cdc7817f412", "legacycomp1"},
+	{NULL}
+};
+
+int timeroast_valid(char *ciphertext, struct fmt_main *self)
+{
+	int i;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+		return 0;
+
+	ciphertext += FORMAT_TAG_LEN;
+
+	for (i = 0; i < 2 * BINARY_SIZE; i++)
+		if (atoi16[ARCH_INDEX(ciphertext[i])] == 0x7F)
+			return 0;
+	if (ciphertext[i] != '$')
+		return 0;
+
+	ciphertext += i + 1;
+	for (i = 0; i < 2 * SALT_SIZE; i++)
+		if (atoi16[ARCH_INDEX(ciphertext[i])] == 0x7F)
+			return 0;
+	if (ciphertext[i] != 0)
+		return 0;
+
+	return 1;
+}
+
+void *timeroast_binary(char *ciphertext)
+{
+	static uint32_t binary[BINARY_SIZE / sizeof(uint32_t)];
+	char *hash = ciphertext + FORMAT_TAG_LEN;
+	uint32_t i, v;
+
+	for (i = 0; i < BINARY_SIZE / sizeof(uint32_t); i++) {
+		v  = ((unsigned int)(atoi16[ARCH_INDEX(hash[0])])) << 4;
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[1])]));
+
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[2])])) << 12;
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[3])])) << 8;
+
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[4])])) << 20;
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[5])])) << 16;
+
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[6])])) << 28;
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[7])])) << 24;
+		hash += 8;
+
+		binary[i] = v;
+	}
+	return binary;
+}
+
+void *timeroast_salt(char *ciphertext)
+{
+	static uint32_t salt[SALT_SIZE / sizeof(uint32_t)];
+	char *hash = ciphertext + FORMAT_TAG_LEN + 2 * BINARY_SIZE + 1;
+	uint32_t i, v;
+
+	for (i = 0; i < SALT_SIZE / sizeof(uint32_t); i++) {
+		v  = ((unsigned int)(atoi16[ARCH_INDEX(hash[0])])) << 4;
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[1])]));
+
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[2])])) << 12;
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[3])])) << 8;
+
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[4])])) << 20;
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[5])])) << 16;
+
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[6])])) << 28;
+		v |= ((unsigned int)(atoi16[ARCH_INDEX(hash[7])])) << 24;
+		hash += 8;
+
+		salt[i] = v;
+	}
+	return salt;
+}

--- a/src/timeroast_fmt_plug.c
+++ b/src/timeroast_fmt_plug.c
@@ -1,0 +1,586 @@
+/*
+ * SNTP-MS "Timeroast" patch for john
+ *
+ * This software is Copyright (c) 2023 magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_timeroast;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_timeroast);
+#else
+
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "arch.h"
+#include "misc.h"
+#include "memory.h"
+#include "common.h"
+#include "formats.h"
+#include "unicode.h"
+#include "options.h"
+#include "loader.h"
+#include "johnswap.h"
+#include "timeroast_common.h"
+#include "md5.h"
+
+#define FORMAT_LABEL        "timeroast"
+#define FORMAT_NAME         "SNTP-MS"
+#define ALGORITHM_NAME      "MD4+MD5 32/" ARCH_BITS_STR
+
+#ifndef OMP_SCALE
+#define OMP_SCALE           32
+#endif
+
+#define MIN_KEYS_PER_CRYPT  1
+#define MAX_KEYS_PER_CRYPT  128
+
+static unsigned int *ms_buffer1x;
+static unsigned int *output1x;
+static unsigned int *crypt_out;
+static unsigned int *last;
+static unsigned int *last_i;
+
+static unsigned int *salt_buffer;
+static unsigned int new_key;
+
+// MD4 Init values
+#define INIT_A 0x67452301
+#define INIT_B 0xefcdab89
+#define INIT_C 0x98badcfe
+#define INIT_D 0x10325476
+
+#define SQRT_2 0x5a827999
+#define SQRT_3 0x6ed9eba1
+
+static void set_key_utf8(char *_key, int index);
+static void set_key_encoding(char *_key, int index);
+struct fmt_main fmt_timeroast;
+
+#if !ARCH_LITTLE_ENDIAN
+inline static void swap(unsigned int *x, int count)
+{
+	while (count--) {
+		*x = JOHNSWAP(*x);
+		x++;
+	}
+}
+#endif
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+
+	ms_buffer1x = mem_calloc(sizeof(ms_buffer1x[0]), 16 * self->params.max_keys_per_crypt);
+	output1x    = mem_calloc(sizeof(output1x[0])   ,  4 * self->params.max_keys_per_crypt);
+	crypt_out   = mem_calloc(sizeof(crypt_out[0])  ,  4 * self->params.max_keys_per_crypt);
+	last        = mem_calloc(sizeof(last[0])       ,  4 * self->params.max_keys_per_crypt);
+	last_i      = mem_calloc(sizeof(last_i[0])     ,      self->params.max_keys_per_crypt);
+
+	if (options.target_enc == UTF_8)
+		self->methods.set_key = set_key_utf8;
+	else if (!(options.target_enc == ENC_RAW || options.target_enc == ISO_8859_1))
+		self->methods.set_key = set_key_encoding;
+}
+
+static void done(void)
+{
+	MEM_FREE(last_i);
+	MEM_FREE(last);
+	MEM_FREE(crypt_out);
+	MEM_FREE(output1x);
+	MEM_FREE(ms_buffer1x);
+}
+
+static void set_salt(void *salt)
+{
+	salt_buffer = salt;
+}
+
+static int binary_hash_0(void *binary) { return ((unsigned int*)binary)[0] & PH_MASK_0; }
+static int binary_hash_1(void *binary) { return ((unsigned int*)binary)[0] & PH_MASK_1; }
+static int binary_hash_2(void *binary) { return ((unsigned int*)binary)[0] & PH_MASK_2; }
+static int binary_hash_3(void *binary) { return ((unsigned int*)binary)[0] & PH_MASK_3; }
+static int binary_hash_4(void *binary) { return ((unsigned int*)binary)[0] & PH_MASK_4; }
+static int binary_hash_5(void *binary) { return ((unsigned int*)binary)[0] & PH_MASK_5; }
+static int binary_hash_6(void *binary) { return ((unsigned int*)binary)[0] & PH_MASK_6; }
+
+static int get_hash_0(int index) { return output1x[4 * index] & PH_MASK_0; }
+static int get_hash_1(int index) { return output1x[4 * index] & PH_MASK_1; }
+static int get_hash_2(int index) { return output1x[4 * index] & PH_MASK_2; }
+static int get_hash_3(int index) { return output1x[4 * index] & PH_MASK_3; }
+static int get_hash_4(int index) { return output1x[4 * index] & PH_MASK_4; }
+static int get_hash_5(int index) { return output1x[4 * index] & PH_MASK_5; }
+static int get_hash_6(int index) { return output1x[4 * index] & PH_MASK_6; }
+
+static void nt_hash(int count)
+{
+	int i;
+
+#if defined(_OPENMP)
+#pragma omp parallel for default(none) private(i) shared(count, ms_buffer1x, crypt_out, last)
+#endif
+	for (i = 0; i < count; i++) {
+		unsigned int a;
+		unsigned int b;
+		unsigned int c;
+		unsigned int d;
+
+		/* Round 1 */
+		a = 		0xFFFFFFFF 		  + ms_buffer1x[16 * i + 0];a = (a << 3 ) | (a >> 29);
+		d = INIT_D + (INIT_C ^ (a & 0x77777777))  + ms_buffer1x[16 * i + 1];d = (d << 7 ) | (d >> 25);
+		c = INIT_C + (INIT_B ^ (d & (a ^ INIT_B)))+ ms_buffer1x[16 * i + 2];c = (c << 11) | (c >> 21);
+		b =    INIT_B + (a ^ (c & (d ^ a))) 	  + ms_buffer1x[16 * i + 3];b = (b << 19) | (b >> 13);
+
+		a += (d ^ (b & (c ^ d))) + ms_buffer1x[16 * i + 4]  ;a = (a << 3 ) | (a >> 29);
+		d += (c ^ (a & (b ^ c))) + ms_buffer1x[16 * i + 5]  ;d = (d << 7 ) | (d >> 25);
+		c += (b ^ (d & (a ^ b))) + ms_buffer1x[16 * i + 6]  ;c = (c << 11) | (c >> 21);
+		b += (a ^ (c & (d ^ a))) + ms_buffer1x[16 * i + 7]  ;b = (b << 19) | (b >> 13);
+
+		a += (d ^ (b & (c ^ d))) + ms_buffer1x[16 * i + 8]  ;a = (a << 3 ) | (a >> 29);
+		d += (c ^ (a & (b ^ c))) + ms_buffer1x[16 * i + 9]  ;d = (d << 7 ) | (d >> 25);
+		c += (b ^ (d & (a ^ b))) + ms_buffer1x[16 * i + 10] ;c = (c << 11) | (c >> 21);
+		b += (a ^ (c & (d ^ a))) + ms_buffer1x[16 * i + 11] ;b = (b << 19) | (b >> 13);
+
+		a += (d ^ (b & (c ^ d))) + ms_buffer1x[16 * i + 12] ;a = (a << 3 ) | (a >> 29);
+		d += (c ^ (a & (b ^ c))) + ms_buffer1x[16 * i + 13] ;d = (d << 7 ) | (d >> 25);
+		c += (b ^ (d & (a ^ b))) + ms_buffer1x[16 * i + 14] ;c = (c << 11) | (c >> 21);
+		b += (a ^ (c & (d ^ a)))/*+ms_buffer1x[16 * i + 15]*/;b = (b << 19) | (b >> 13);
+
+		/* Round 2 */
+		a += ((b & (c | d)) | (c & d)) + ms_buffer1x[16 * i + 0]  + SQRT_2; a = (a << 3 ) | (a >> 29);
+		d += ((a & (b | c)) | (b & c)) + ms_buffer1x[16 * i + 4]  + SQRT_2; d = (d << 5 ) | (d >> 27);
+		c += ((d & (a | b)) | (a & b)) + ms_buffer1x[16 * i + 8]  + SQRT_2; c = (c << 9 ) | (c >> 23);
+		b += ((c & (d | a)) | (d & a)) + ms_buffer1x[16 * i + 12] + SQRT_2; b = (b << 13) | (b >> 19);
+
+		a += ((b & (c | d)) | (c & d)) + ms_buffer1x[16 * i + 1]  + SQRT_2; a = (a << 3 ) | (a >> 29);
+		d += ((a & (b | c)) | (b & c)) + ms_buffer1x[16 * i + 5]  + SQRT_2; d = (d << 5 ) | (d >> 27);
+		c += ((d & (a | b)) | (a & b)) + ms_buffer1x[16 * i + 9]  + SQRT_2; c = (c << 9 ) | (c >> 23);
+		b += ((c & (d | a)) | (d & a)) + ms_buffer1x[16 * i + 13] + SQRT_2; b = (b << 13) | (b >> 19);
+
+		a += ((b & (c | d)) | (c & d)) + ms_buffer1x[16 * i + 2]  + SQRT_2; a = (a << 3 ) | (a >> 29);
+		d += ((a & (b | c)) | (b & c)) + ms_buffer1x[16 * i + 6]  + SQRT_2; d = (d << 5 ) | (d >> 27);
+		c += ((d & (a | b)) | (a & b)) + ms_buffer1x[16 * i + 10] + SQRT_2; c = (c << 9 ) | (c >> 23);
+		b += ((c & (d | a)) | (d & a)) + ms_buffer1x[16 * i + 14] + SQRT_2; b = (b << 13) | (b >> 19);
+
+		a += ((b & (c | d)) | (c & d)) + ms_buffer1x[16 * i + 3]  + SQRT_2; a = (a << 3 ) | (a >> 29);
+		d += ((a & (b | c)) | (b & c)) + ms_buffer1x[16 * i + 7]  + SQRT_2; d = (d << 5 ) | (d >> 27);
+		c += ((d & (a | b)) | (a & b)) + ms_buffer1x[16 * i + 11] + SQRT_2; c = (c << 9 ) | (c >> 23);
+		b += ((c & (d | a)) | (d & a))/*+ms_buffer1x[16 * i + 15]*/+SQRT_2; b = (b << 13) | (b >> 19);
+
+		/* Round 3 */
+		a += (b ^ c ^ d) + ms_buffer1x[16 * i + 0]  + SQRT_3; a = (a << 3 ) | (a >> 29);
+		d += (a ^ b ^ c) + ms_buffer1x[16 * i + 8]  + SQRT_3; d = (d << 9 ) | (d >> 23);
+		c += (d ^ a ^ b) + ms_buffer1x[16 * i + 4]  + SQRT_3; c = (c << 11) | (c >> 21);
+		b += (c ^ d ^ a) + ms_buffer1x[16 * i + 12] + SQRT_3; b = (b << 15) | (b >> 17);
+
+		a += (b ^ c ^ d) + ms_buffer1x[16 * i + 2]  + SQRT_3; a = (a << 3 ) | (a >> 29);
+		d += (a ^ b ^ c) + ms_buffer1x[16 * i + 10] + SQRT_3; d = (d << 9 ) | (d >> 23);
+		c += (d ^ a ^ b) + ms_buffer1x[16 * i + 6]  + SQRT_3; c = (c << 11) | (c >> 21);
+		b += (c ^ d ^ a) + ms_buffer1x[16 * i + 14] + SQRT_3; b = (b << 15) | (b >> 17);
+
+		a += (b ^ c ^ d) + ms_buffer1x[16 * i + 1]  + SQRT_3; a = (a << 3 ) | (a >> 29);
+		d += (a ^ b ^ c) + ms_buffer1x[16 * i + 9]  + SQRT_3; d = (d << 9 ) | (d >> 23);
+		c += (d ^ a ^ b) + ms_buffer1x[16 * i + 5]  + SQRT_3; c = (c << 11) | (c >> 21);
+		b += (c ^ d ^ a) + ms_buffer1x[16 * i + 13] + SQRT_3; b = (b << 15) | (b >> 17);
+
+		a += (b ^ c ^ d) + ms_buffer1x[16 * i + 3]  + SQRT_3; a = (a << 3 ) | (a >> 29);
+		d += (a ^ b ^ c) + ms_buffer1x[16 * i + 11] + SQRT_3; d = (d << 9 ) | (d >> 23);
+		c += (d ^ a ^ b) + ms_buffer1x[16 * i + 7]  + SQRT_3; c = (c << 11) | (c >> 21);
+		b += (c ^ d ^ a) /*+ ms_buffer1x[16 * i + 15] */+ SQRT_3; b = (b << 15) | (b >> 17);
+
+		last[4 * i + 0] = a + INIT_A;
+		last[4 * i + 1] = b + INIT_B;
+		last[4 * i + 2] = c + INIT_C;
+		last[4 * i + 3] = d + INIT_D;
+	}
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	int count = *pcount;
+	int i;
+
+	if (new_key)
+	{
+		nt_hash(count);
+		new_key = 0;
+	}
+
+#if defined(_OPENMP)
+#pragma omp parallel for
+#endif
+	for (i = 0; i < count; i++) {
+		MD5_CTX ctx;
+
+		MD5_Init(&ctx);
+		MD5_Update(&ctx, &((unsigned char*)last)[16 * i], 16);
+		MD5_Update(&ctx, salt_buffer, SALT_SIZE);
+		MD5_Final(&((unsigned char*)output1x)[16 * i], &ctx);
+	}
+	return count;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	unsigned int i;
+	unsigned int a = ((unsigned int*)binary)[0];
+
+	for (i = 0; i < count; i++)
+		if (a == output1x[i * 4 + 0])
+			return 1;
+
+	return 0;
+}
+
+static int cmp_one(void * binary, int index)
+{
+	return !memcmp(binary, &output1x[4 * index], BINARY_SIZE);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+// This is common code for the SSE/MMX/generic variants of non-UTF8 set_key
+inline static void set_key_helper(unsigned int * keybuffer,
+                                  unsigned int xBuf,
+                                  const unsigned char * key,
+                                  unsigned int lenStoreOffset,
+                                  unsigned int *last_length)
+{
+	unsigned int i=0;
+	unsigned int md4_size=0;
+	for (; key[md4_size] && md4_size < PLAINTEXT_LENGTH; i += xBuf, md4_size++)
+	{
+		unsigned int temp;
+		if ((temp = key[++md4_size]))
+		{
+			keybuffer[i] = key[md4_size-1] | (temp << 16);
+		}
+		else
+		{
+			keybuffer[i] = key[md4_size-1] | 0x800000;
+			goto key_cleaning;
+		}
+	}
+	keybuffer[i] = 0x80;
+
+key_cleaning:
+	i += xBuf;
+	for (;i <= *last_length; i += xBuf)
+		keybuffer[i] = 0;
+
+	*last_length = (md4_size >> 1)+1;
+
+	keybuffer[lenStoreOffset] = md4_size << 4;
+}
+
+static void set_key(char *_key, int index)
+{
+	set_key_helper(&ms_buffer1x[index << 4], 1, (unsigned char*)_key, 14,
+	               &last_i[index]);
+	//new password_candidate
+	new_key=1;
+}
+
+// UTF-8 conversion right into key buffer
+// This is common code for the SSE/MMX/generic variants
+inline static void set_key_helper_utf8(unsigned int * keybuffer, unsigned int xBuf,
+    const UTF8 * source, unsigned int lenStoreOffset, unsigned int *lastlen)
+{
+	unsigned int *target = keybuffer;
+	UTF32 chl, chh = 0x80;
+	unsigned int outlen = 0;
+
+	while (*source) {
+		chl = *source;
+		if (chl >= 0xC0) {
+			unsigned int extraBytesToRead = opt_trailingBytesUTF8[chl & 0x3f];
+			switch (extraBytesToRead) {
+			case 3:
+				++source;
+				if (*source) {
+					chl <<= 6;
+					chl += *source;
+				} else {
+					*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+					return;
+				}
+			case 2:
+				++source;
+				if (*source) {
+					chl <<= 6;
+					chl += *source;
+				} else {
+					*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+					return;
+				}
+			case 1:
+				++source;
+				if (*source) {
+					chl <<= 6;
+					chl += *source;
+				} else {
+					*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+					return;
+				}
+			case 0:
+				break;
+			default:
+				*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+				return;
+			}
+			chl -= offsetsFromUTF8[extraBytesToRead];
+		}
+		source++;
+		outlen++;
+		if (chl > UNI_MAX_BMP) {
+			if (outlen == PLAINTEXT_LENGTH) {
+				chh = 0x80;
+				*target = (chh << 16) | chl;
+				target += xBuf;
+				*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+				break;
+			}
+			#define halfBase 0x0010000UL
+			#define halfShift 10
+			#define halfMask 0x3FFUL
+			#define UNI_SUR_HIGH_START  (UTF32)0xD800
+			#define UNI_SUR_LOW_START   (UTF32)0xDC00
+			chl -= halfBase;
+			chh = (UTF16)((chl & halfMask) + UNI_SUR_LOW_START);;
+			chl = (UTF16)((chl >> halfShift) + UNI_SUR_HIGH_START);
+			outlen++;
+		} else if (*source && outlen < PLAINTEXT_LENGTH) {
+			chh = *source;
+			if (chh >= 0xC0) {
+				unsigned int extraBytesToRead =
+					opt_trailingBytesUTF8[chh & 0x3f];
+				switch (extraBytesToRead) {
+				case 3:
+					++source;
+					if (*source) {
+						chl <<= 6;
+						chl += *source;
+					} else {
+						*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+						return;
+					}
+				case 2:
+					++source;
+					if (*source) {
+						chh <<= 6;
+						chh += *source;
+					} else {
+						*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+						return;
+					}
+				case 1:
+					++source;
+					if (*source) {
+						chh <<= 6;
+						chh += *source;
+					} else {
+						*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+						return;
+					}
+				case 0:
+					break;
+				default:
+					*lastlen = ((PLAINTEXT_LENGTH >> 1) + 1) * xBuf;
+					return;
+				}
+				chh -= offsetsFromUTF8[extraBytesToRead];
+			}
+			source++;
+			outlen++;
+		} else {
+			chh = 0x80;
+			*target = chh << 16 | chl;
+			target += xBuf;
+			break;
+		}
+		*target = chh << 16 | chl;
+		target += xBuf;
+	}
+	if (chh != 0x80 || outlen == 0) {
+		*target = 0x80;
+		target += xBuf;
+	}
+
+	while(target < &keybuffer[*lastlen]) {
+		*target = 0;
+		target += xBuf;
+	}
+
+	*lastlen = ((outlen >> 1) + 1) * xBuf;
+	keybuffer[lenStoreOffset] = outlen << 4;
+}
+
+static void set_key_utf8(char *_key, int index)
+{
+	set_key_helper_utf8(&ms_buffer1x[index << 4], 1, (UTF8*)_key, 14,
+	                &last_i[index]);
+	//new password_candidate
+	new_key=1;
+}
+
+// This is common code for the SSE/MMX/generic variants of non-UTF8 non-ISO-8859-1 set_key
+inline static void set_key_helper_encoding(unsigned int * keybuffer,
+                                  unsigned int xBuf,
+                                  const unsigned char * key,
+                                  unsigned int lenStoreOffset,
+                                  unsigned int *last_length)
+{
+	unsigned int i=0;
+	int md4_size;
+	md4_size = enc_to_utf16( (UTF16*)keybuffer, PLAINTEXT_LENGTH, (UTF8*) key, strlen((char*)key));
+	if (md4_size < 0)
+		md4_size = strlen16((UTF16*)keybuffer);
+
+#if ARCH_LITTLE_ENDIAN
+	((UTF16*)keybuffer)[md4_size] = 0x80;
+#else
+	((UTF16*)keybuffer)[md4_size] = 0x8000;
+#endif
+	((UTF16*)keybuffer)[md4_size+1] = 0;
+#if !ARCH_LITTLE_ENDIAN
+	((UTF16*)keybuffer)[md4_size+2] = 0;
+#endif
+	i = md4_size>>1;
+
+	i += xBuf;
+	for (;i <= *last_length; i += xBuf)
+		keybuffer[i] = 0;
+
+#if !ARCH_LITTLE_ENDIAN
+	swap(keybuffer, (md4_size>>1)+1);
+#endif
+
+	*last_length = (md4_size >> 1) + 1;
+
+	keybuffer[lenStoreOffset] = md4_size << 4;
+}
+
+static void set_key_encoding(char *_key, int index)
+{
+	set_key_helper_encoding(&ms_buffer1x[index << 4], 1, (unsigned char*)_key, 14,
+	               &last_i[index]);
+	//new password_candidate
+	new_key=1;
+}
+
+
+// Get the key back from the key buffer, from UCS-2 LE
+static char *get_key(int index)
+{
+	static union {
+		UTF16 u16[PLAINTEXT_LENGTH + 1];
+		unsigned int u32[(PLAINTEXT_LENGTH + 1 + 1) / 2];
+	} key;
+	unsigned int * keybuffer = &ms_buffer1x[index << 4];
+	unsigned int md4_size;
+	unsigned int i=0;
+	int len = keybuffer[14] >> 4;
+
+	for (md4_size = 0; md4_size < len; i++, md4_size += 2)
+	{
+#if ARCH_LITTLE_ENDIAN
+		key.u16[md4_size] = keybuffer[i];
+		key.u16[md4_size+1] = keybuffer[i] >> 16;
+#else
+		key.u16[md4_size] = keybuffer[i] >> 16;
+		key.u16[md4_size+1] = keybuffer[i];
+#endif
+	}
+#if !ARCH_LITTLE_ENDIAN
+	swap(key.u32, md4_size >> 1);
+#endif
+	key.u16[len] = 0x00;
+
+	return (char*)utf16_to_enc(key.u16);
+}
+
+// Public domain hash function by DJ Bernstein (salt is a username)
+static int salt_hash(void *salt)
+{
+	unsigned int *s = salt, hash = 5381, len = SALT_SIZE / sizeof(unsigned int);
+
+	while (len--)
+		hash = ((hash << 5) + hash) ^ *s++;
+
+	return hash & (SALT_HASH_SIZE - 1);
+}
+
+struct fmt_main fmt_timeroast = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_UNICODE | FMT_ENC,
+		{ NULL },
+		{ FORMAT_TAG },
+		timeroast_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		timeroast_valid,
+		fmt_default_split,
+		timeroast_binary,
+		timeroast_salt,
+		{ NULL },
+		fmt_default_source,
+		{
+			binary_hash_0,
+			binary_hash_1,
+			binary_hash_2,
+			binary_hash_3,
+			binary_hash_4,
+			binary_hash_5,
+			binary_hash_6
+		},
+		salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+			get_hash_0,
+			get_hash_1,
+			get_hash_2,
+			get_hash_3,
+			get_hash_4,
+			get_hash_5,
+			get_hash_6
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */


### PR DESCRIPTION
They are very similar to 'mscash' so based on them. That unfortunately means the CPU format isn't SIMD capable for whatever reason (I never noticed that before).

Closes #5238