### PR TITLE
Subsets bugfix

### DIFF
--- a/src/subsets.c
+++ b/src/subsets.c
@@ -364,6 +364,7 @@ static int submit(UTF32 *subset)
 		/* Nearly as quick conversion, from UTF-8-32[tm] to UTF-8 */
 		subset[word_len] = 0;
 		utf8_32_to_utf8(out, subset);
+		out[maxlength] = 0;
 	} else {
 		/* Slowest conversion, from real UTF-32 to some legacy codepage */
 		subset[word_len] = 0;


### PR DESCRIPTION
Fix a bug where plaintext buffer could be overran when a format report support for a "too long" password length in bytes (such as NT: length 81 but only for ASCII).