### PR TITLE
RAR formats: Reject old archives

### DIFF
--- a/src/rar2john.c
+++ b/src/rar2john.c
@@ -562,6 +562,11 @@ next_file_header:
 			fprintf(stderr, "! not encrypted, skipping\n");
 			jtr_fseek64(fp, file_hdr_pack_size, SEEK_CUR);
 			goto next_file_header;
+		} else if (file_hdr_block[24] < 29) {
+			fprintf(stderr, "! %s: Too old RAR file version (v%u.%u encryption), not supported.\n",
+			        archive_name, file_hdr_block[24] / 10, file_hdr_block[24] % 10);
+			jtr_fseek64(fp, file_hdr_pack_size, SEEK_CUR);
+			goto next_file_header;
 		}
 
 		method = file_hdr_block[25];


### PR DESCRIPTION
These have "unknown" KDF and encryption, and no salt. We could work it out by examining public unrar source code, but such archives are so rare I'm not sure we'll ever bother.

Closes #5271 - see also #5273 