### PR TITLE
OpenCL formats fixes

### DIFF
--- a/run/opencl/DES_bs_kernel.cl
+++ b/run/opencl/DES_bs_kernel.cl
@@ -1,5 +1,6 @@
 /*
- * This software is Copyright (c) 2012-2015 Sayantan Datta <std2048 at gmail dot com>
+ * This software is Copyright (c) 2012-2015 Sayantan Datta <std2048 at gmail dot com>,
+ * Copyright (c) 2023 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -150,15 +151,15 @@ __kernel void DES_bs_25_b(constant uint *key_map
 	__local DES_bs_vector s_des_bs_key[56 * WORK_GROUP_SIZE];
 	int s_key_offset = lid * 56;
 	for (i = 0; i < 56; i++)
-		s_des_bs_key[lid * 56 + i] = des_bs_key[section + i * gws];
+		s_des_bs_key[s_key_offset + i] = des_bs_key[section + i * gws];
 #endif
 
 #if USE_LOCAL_MEM
 	__local ushort s_key_map[768];
 	int lws = get_local_size(0);
 
-	for (i = 0; i < 768; i += lws)
-		s_key_map[(lid + i) % 768] = key_map[(lid + i) % 768];
+	for (i = lid; i < 768; i += lws)
+		s_key_map[i] = key_map[i];
 #endif
 
 #if USE_LOCAL_MEM || WORK_GROUP_SIZE > 0

--- a/run/opencl/DES_bs_kernel_f.cl
+++ b/run/opencl/DES_bs_kernel_f.cl
@@ -459,7 +459,7 @@ __kernel void DES_bs_25(__global DES_bs_vector *des_bs_key,
 		int s_key_offset = 56 * lid;
 
 		for (i = 0; i < 56; i++)
-			s_des_bs_key[lid * 56 + i] = des_bs_key[section + i * gws];
+			s_des_bs_key[s_key_offset + i] = des_bs_key[section + i * gws];
 		barrier(CLK_LOCAL_MEM_FENCE);
 #endif
 		int iterations;

--- a/run/opencl/DES_bs_kernel_h.cl
+++ b/run/opencl/DES_bs_kernel_h.cl
@@ -143,7 +143,7 @@ __kernel void DES_bs_25( constant uint *key_map
 		int lid = get_local_id(0);
 		int s_key_offset = 56 * lid;
 		for (i = 0; i < 56; i++)
-			s_des_bs_key[lid * 56 + i] = des_bs_key[section + i * gws];
+			s_des_bs_key[s_key_offset + i] = des_bs_key[section + i * gws];
 
 		barrier(CLK_LOCAL_MEM_FENCE);
 #endif

--- a/run/opencl/krb5tgs_kernel.cl
+++ b/run/opencl/krb5tgs_kernel.cl
@@ -186,17 +186,6 @@ __kernel void krb5tgs_init(__global const uchar *password,
 #define GPU_LOC_3 LOC_3
 #endif
 
-#if USE_LOCAL_BITMAPS
-	uint lid = get_local_id(0);
-	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
-
-	for (uint i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
-		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
-
-	barrier(CLK_LOCAL_MEM_FENCE);
-#endif
-
 	/* Prepare base word */
 	prepare_utf16(password, index, &nt_buffer);
 

--- a/run/opencl/lm_kernel_b.cl
+++ b/run/opencl/lm_kernel_b.cl
@@ -1,5 +1,6 @@
 /*
- * This software is Copyright (c) 2015 Sayantan Datta <std2048 at gmail dot com>
+ * This software is Copyright (c) 2015 Sayantan Datta <std2048 at gmail dot com>,
+ * Copyright (c) 2021-2023 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -181,8 +182,8 @@ __kernel void lm_bs_b(__global opencl_lm_transfer *lm_raw_keys,
 #if USE_LOCAL_MEM
 		__local ushort s_key_idx[768];
 		unsigned int lws= get_local_size(0);
-		for (i = 0; i < 768; i += lws)
-			s_key_idx[(lid + i) % 768] = lm_key_idx[(lid + i) % 768];
+		for (i = lid; i < 768; i += lws)
+			s_key_idx[i] = lm_key_idx[i];
 #endif
 #if USE_LOCAL_MEM || WORK_GROUP_SIZE
 		barrier(CLK_LOCAL_MEM_FENCE);

--- a/run/opencl/md4_kernel.cl
+++ b/run/opencl/md4_kernel.cl
@@ -4,7 +4,7 @@
  * This code is in public domain.
  *
  * This software is Copyright (c) 2010, Dhiru Kholia <dhiru.kholia at gmail.com>
- * and Copyright (c) 2012, magnum
+ * and Copyright (c) 2012-2023, magnum
  * and Copyright (c) 2015, Sayantan Datta <std2048@gmail.com>
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
@@ -53,11 +53,8 @@
 	(a) += f((b), (c), (d)) + (x); \
 	(a) = rotate((a), (uint)(s))
 
-#if BITMAP_SIZE_BITS_LESS_ONE < 0xffffffff
-#define BITMAP_SIZE_BITS (BITMAP_SIZE_BITS_LESS_ONE + 1)
-#else
-/*undefined, cause error.*/
-#endif
+/* This handles an input of 0xffffffffU correctly */
+#define BITMAP_SHIFT ((BITMAP_MASK >> 5) + 1)
 
 inline void md4_encrypt(uint *hash, uint *W, uint len)
 {
@@ -189,38 +186,38 @@ inline void cmp(uint gid,
 	hash[3] += 0x10325476;
 
 #if SELECT_CMP_STEPS > 4
-	bitmap_index = hash[0] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[0] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[0] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[1] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 4) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[1] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 3) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[2] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 5 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 6 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[3] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 7 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[0] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[1] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 4 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[2] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 5 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[3] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 6 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[3] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 7 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #elif SELECT_CMP_STEPS > 2
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[1] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 4) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[0] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[0] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #elif SELECT_CMP_STEPS > 1
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #else
-	bitmap_index = hash[3] & BITMAP_SIZE_BITS_LESS_ONE;
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
 #endif
 
@@ -295,10 +292,10 @@ __kernel void md4(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	__local uint s_bitmaps[BITMAP_SHIFT * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
-		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
+	for (i = lid; i < BITMAP_SHIFT * SELECT_CMP_STEPS; i+= lws)
+		s_bitmaps[i] = bitmaps[i];
 
 	barrier(CLK_LOCAL_MEM_FENCE);
 #endif

--- a/run/opencl/md5_kernel.cl
+++ b/run/opencl/md5_kernel.cl
@@ -3,7 +3,7 @@
  * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
  *
  * This software is Copyright (c) 2010, Dhiru Kholia <dhiru.kholia at gmail.com>
- * and Copyright (c) 2012, magnum
+ * and Copyright (c) 2012-2023, magnum
  * and Copyright (c) 2015, Sayantan Datta <std2048@gmail.com>
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
@@ -59,11 +59,8 @@
 	    (a) = rotate((a), (uint)(s)); \
 	    (a) += (b)
 
-#if BITMAP_SIZE_BITS_LESS_ONE < 0xffffffff
-#define BITMAP_SIZE_BITS (BITMAP_SIZE_BITS_LESS_ONE + 1)
-#else
-/*undefined, cause error.*/
-#endif
+/* This handles an input of 0xffffffffU correctly */
+#define BITMAP_SHIFT ((BITMAP_MASK >> 5) + 1)
 
 inline void md5_encrypt(uint *hash, uint *W, uint len)
 {
@@ -213,38 +210,38 @@ inline void cmp(uint gid,
 	hash[3] += 0x10325476;
 
 #if SELECT_CMP_STEPS > 4
-	bitmap_index = hash[0] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[0] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[0] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[1] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 4) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[1] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 3) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[2] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 5 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 6 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[3] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 7 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[0] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[1] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 4 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[2] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 5 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[3] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 6 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[3] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 7 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #elif SELECT_CMP_STEPS > 2
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[1] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 4) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[0] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[0] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #elif SELECT_CMP_STEPS > 1
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #else
-	bitmap_index = hash[3] & BITMAP_SIZE_BITS_LESS_ONE;
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
 #endif
 
@@ -319,10 +316,10 @@ __kernel void md5(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	__local uint s_bitmaps[BITMAP_SHIFT * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
-		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
+	for (i = lid; i < BITMAP_SHIFT * SELECT_CMP_STEPS; i+= lws)
+		s_bitmaps[i] = bitmaps[i];
 
 	barrier(CLK_LOCAL_MEM_FENCE);
 #endif

--- a/run/opencl/opencl_lm_kernel_params.h
+++ b/run/opencl/opencl_lm_kernel_params.h
@@ -68,11 +68,8 @@ typedef unsigned WORD vtype;
 	lm_clear_block_8(48); 			\
 	lm_clear_block_8(56);
 
-#if BITMAP_SIZE_BITS_LESS_ONE < 0xffffffff
-#define BITMAP_SIZE_BITS (BITMAP_SIZE_BITS_LESS_ONE + 1)
-#else
-/*undefined, cause error.*/
-#endif
+/* This handles an input of 0xffffffffU correctly */
+#define BITMAP_SHIFT ((BITMAP_MASK >> 5) + 1)
 
 #define GET_HASH_0(hash, x, k, bits)			\
 	for (bit = bits; bit < k; bit++)		\
@@ -134,14 +131,14 @@ inline void cmp( unsigned lm_vector *B,
 	value[1] = 0;
 	GET_HASH_0(value[0], i, REQ_BITMAP_BITS, 0);
 	GET_HASH_1(value[1], i, REQ_BITMAP_BITS, 0);
-	bitmap_index = value[1] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = value[1] & BITMAP_MASK;
 	bit = (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = value[0] & (BITMAP_SIZE_BITS - 1);
-	bit &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = value[0] & BITMAP_MASK;
+	bit &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #else
 	value[1] = 0;
 	GET_HASH_1(value[1], i, REQ_BITMAP_BITS, 0);
-	bitmap_index = value[1] & BITMAP_SIZE_BITS_LESS_ONE;
+	bitmap_index = value[1] & BITMAP_MASK;
 	bit = (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
 #endif
 	if (bit)

--- a/run/opencl/salted_sha_kernel.cl
+++ b/run/opencl/salted_sha_kernel.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, magnum
+ * Copyright (c) 2014-2023, magnum
  * Copyright (c) 2015, Sayantan Datta <sdatta@openwall.com>
  * This software is hereby released to the general public under
  * the following terms: Redistribution and use in source and binary
@@ -12,11 +12,8 @@
 #include "opencl_mask.h"
 #include "opencl_sha1.h"
 
-#if BITMAP_SIZE_BITS_LESS_ONE < 0xffffffff
-#define BITMAP_SIZE_BITS (BITMAP_SIZE_BITS_LESS_ONE + 1)
-#else
-#error BITMAP_SIZE_BITS is not defined
-#endif
+/* This handles an input of 0xffffffffU correctly */
+#define BITMAP_SHIFT ((BITMAP_MASK >> 5) + 1)
 
 #if SL3
 #define SL3CONV - '0'
@@ -96,38 +93,38 @@ inline void cmp(uint gid,
 	hash[4] = SWAP32(hash[4]);
 
 #if SELECT_CMP_STEPS > 4
-	bitmap_index = hash[0] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[0] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[0] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[1] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 4) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[1] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 3) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[2] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 5 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 6 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[3] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 7 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[0] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[1] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 4 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[2] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 5 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[3] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 6 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[3] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 7 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #elif SELECT_CMP_STEPS > 2
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[1] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 4) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[0] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[0] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #elif SELECT_CMP_STEPS > 1
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #else
-	bitmap_index = hash[3] & BITMAP_SIZE_BITS_LESS_ONE;
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
 #endif
 
@@ -208,10 +205,10 @@ void sha1(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	__local uint s_bitmaps[BITMAP_SHIFT * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
-		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
+	for (i = lid; i < BITMAP_SHIFT * SELECT_CMP_STEPS; i+= lws)
+		s_bitmaps[i] = bitmaps[i];
 
 	barrier(CLK_LOCAL_MEM_FENCE);
 #endif

--- a/run/opencl/sha1_kernel.cl
+++ b/run/opencl/sha1_kernel.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2016, magnum
+ * Copyright (c) 2012-2023, magnum
  * and Copyright (c) 2015, Sayantan Datta <sdatta@openwall.com>
  * This software is hereby released to the general public under
  * the following terms: Redistribution and use in source and binary
@@ -12,11 +12,8 @@
 #include "opencl_sha1.h"
 #include "opencl_mask.h"
 
-#if BITMAP_SIZE_BITS_LESS_ONE < 0xffffffff
-#define BITMAP_SIZE_BITS (BITMAP_SIZE_BITS_LESS_ONE + 1)
-#else
-/*undefined, cause error.*/
-#endif
+/* This handles an input of 0xffffffffU correctly */
+#define BITMAP_SHIFT ((BITMAP_MASK >> 5) + 1)
 
 inline void cmp_final(uint gid,
 		uint iter,
@@ -84,38 +81,38 @@ inline void cmp(uint gid,
 	uint bitmap_index, tmp = 1;
 
 #if SELECT_CMP_STEPS > 4
-	bitmap_index = hash[0] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[0] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[0] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[1] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 4) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[1] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 3) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[2] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 5 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 6 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = (hash[3] >> 16) & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 7 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[0] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[1] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 4 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[2] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 5 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[3] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 6 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[3] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 7 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #elif SELECT_CMP_STEPS > 2
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[1] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 4) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[0] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[0] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #elif SELECT_CMP_STEPS > 1
-	bitmap_index = hash[3] & (BITMAP_SIZE_BITS - 1);
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
-	bitmap_index = hash[2] & (BITMAP_SIZE_BITS - 1);
-	tmp &= (bitmaps[(BITMAP_SIZE_BITS >> 5) + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) & 1U;
 #else
-	bitmap_index = hash[3] & BITMAP_SIZE_BITS_LESS_ONE;
+	bitmap_index = hash[3] & BITMAP_MASK;
 	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
 #endif
 
@@ -186,10 +183,10 @@ __kernel void sha1(__global uint *keys,
 #if USE_LOCAL_BITMAPS
 	uint lid = get_local_id(0);
 	uint lws = get_local_size(0);
-	uint __local s_bitmaps[(BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS];
+	__local uint s_bitmaps[BITMAP_SHIFT * SELECT_CMP_STEPS];
 
-	for (i = 0; i < (((BITMAP_SIZE_BITS >> 5) * SELECT_CMP_STEPS) / lws); i++)
-		s_bitmaps[i*lws + lid] = bitmaps[i*lws + lid];
+	for (i = lid; i < BITMAP_SHIFT * SELECT_CMP_STEPS; i+= lws)
+		s_bitmaps[i] = bitmaps[i];
 
 	barrier(CLK_LOCAL_MEM_FENCE);
 #endif

--- a/src/md4.c
+++ b/src/md4.c
@@ -22,6 +22,7 @@
  */
 
 #include "md4.h"
+
 #if !HAVE_LIBCRYPTO
 #include <string.h>
 
@@ -258,4 +259,39 @@ void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 #endif
 }
 
-#endif
+#endif /* !HAVE_LIBCRYPTO */
+
+#undef INIT_A
+#undef INIT_B
+#undef INIT_C
+#undef INIT_D
+#undef SQRT_3
+#define INIT_A 0x67452301
+#define INIT_B 0xefcdab89
+#define INIT_C 0x98badcfe
+#define INIT_D 0x10325476
+#define SQRT_3 0x6ed9eba1
+
+void md4_reverse(uint32_t *hash)
+{
+	hash[0] -= INIT_A;
+	hash[1] -= INIT_B;
+	hash[2] -= INIT_C;
+	hash[3] -= INIT_D;
+	hash[1]  = (hash[1] >> 15) | (hash[1] << 17);
+	hash[1] -= SQRT_3 + (hash[2] ^ hash[3] ^ hash[0]);
+	hash[1]  = (hash[1] >> 15) | (hash[1] << 17);
+	hash[1] -= SQRT_3;
+}
+
+void md4_unreverse(uint32_t *hash)
+{
+	hash[1] += SQRT_3;
+	hash[1]  = (hash[1] >> 17) | (hash[1] << 15);
+	hash[1] += SQRT_3 + (hash[2] ^ hash[3] ^ hash[0]);
+	hash[1]  = (hash[1] >> 17) | (hash[1] << 15);
+	hash[3] += INIT_D;
+	hash[2] += INIT_C;
+	hash[1] += INIT_B;
+	hash[0] += INIT_A;
+}

--- a/src/md4.h
+++ b/src/md4.h
@@ -8,12 +8,17 @@
  * See md4.c for more information.
  */
 
+#if !defined(_MD4_H)
+#define _MD4_H
+
+#include <stdint.h>
+
 #include "arch.h" /* also includes autoconfig.h for HAVE_LIBCRYPTO */
 
 #if HAVE_LIBCRYPTO
 #include <openssl/md4.h>
-#elif !defined(_MD4_H)
-#define _MD4_H
+
+#else
 
 #define MD4_Init john_MD4_Init
 #define MD4_Update john_MD4_Update
@@ -34,5 +39,10 @@ typedef struct {
 extern void MD4_Init(MD4_CTX *ctx);
 extern void MD4_Update(MD4_CTX *ctx, const void *data, unsigned long size);
 extern void MD4_Final(unsigned char *result, MD4_CTX *ctx);
+
+#endif /* HAVE_LIBCRYPTO */
+
+extern void md4_reverse(uint32_t *hash);
+extern void md4_unreverse(uint32_t *hash);
 
 #endif /* _MD4_H */

--- a/src/md5.c
+++ b/src/md5.c
@@ -23,6 +23,7 @@
  */
 
 #include "md5.h"
+
 #if !HAVE_LIBCRYPTO
 #include <string.h>
 
@@ -285,4 +286,17 @@ void MD5_Final(unsigned char *result, MD5_CTX *ctx)
 #endif
 }
 
-#endif
+#endif /* !HAVE_LIBCRYPTO */
+
+#undef INIT_A
+#define INIT_A 0x67452301
+
+void md5_reverse(uint32_t *hash)
+{
+	hash[0] -= INIT_A;
+}
+
+void md5_unreverse(uint32_t *hash)
+{
+	hash[0] += INIT_A;
+}

--- a/src/md5.h
+++ b/src/md5.h
@@ -15,6 +15,8 @@
 #if !defined(_MD5_H)
 #define _MD5_H
 
+#include <stdint.h>
+
 /* Any 32-bit or wider unsigned integer data type will do */
 /* this needs to be defined no matter if building with HAVE_LIBCRYPTO or not */
 typedef unsigned int MD5_u32plus;
@@ -45,4 +47,8 @@ extern void MD5_PreFinal(MD5_CTX *ctx);
 extern void MD5_Final(unsigned char *result, MD5_CTX *ctx);
 
 #endif /* HAVE_LIBCRYPTO */
+
+extern void md5_reverse(uint32_t *hash);
+extern void md5_unreverse(uint32_t *hash);
+
 #endif /* _MD5_H */

--- a/src/opencl_hash_check_64_plug.c
+++ b/src/opencl_hash_check_64_plug.c
@@ -312,24 +312,22 @@ char* ocl_hc_64_select_bitmap(unsigned int num_ld_hashes)
 		uint128_t step_mask = pow128i(num_ld_hashes, cmp_steps);
 		uint128_t expected_fp = pow128i(bitmap_size_bits, cmp_steps) / step_mask;
 		uint32_t bits = expected_fp ? log2_128(expected_fp) : 64;
+		uint128_t mask = ((uint128_t)1 << bits) - 1;
 
 #define print_stats	  \
 			"%u hashes: bitmap %ux%"PRIu64" bits, mask 0x%x, effectively %s%u%s bits (0x%.x%"PRIx64"), %sB%s", \
 				(uint32_t)num_ld_hashes, cmp_steps, bitmap_size_bits, (uint32_t)(bitmap_size_bits - 1), \
 				(expected_fp & (expected_fp - 1)) ? "~" : "", bits, expected_fp ? "" : "+", \
-				bits ? (uint32_t)((expected_fp - 1ULL) >> 64ULL) : 0, bits ? (uint64_t)(expected_fp - 1) : 0, \
+				bits ? (uint32_t)(mask >> 64ULL) : 0, bits ? (uint64_t)mask : 0, \
 				human_prefix((bitmap_size_bits >> 3) * cmp_steps), use_local ? " (local)": ""
 
-		if (options.verbosity > VERB_DEFAULT) {
+		if (options.verbosity >= VERB_DEBUG) {
 			if (bits > 33)
 				fprintf(stderr, "Expecting \"no\" false positives\n");
 			else if (bits == 0)
 				fprintf(stderr, "Expecting all false positives\n");
 			else
 				fprintf(stderr, "Expecting 1/%"PRIu64" false positives\n", (uint64_t)expected_fp);
-
-			if (expected_fp & (expected_fp - 1))
-				expected_fp = (uint128_t)1 << bits;
 
 			fprintf(stderr, print_stats);
 			fputc('\n', stderr);

--- a/src/opencl_lm_b_plug.c
+++ b/src/opencl_lm_b_plug.c
@@ -1,5 +1,6 @@
 /*
- * This software is Copyright (c) 2015 Sayantan Datta <std2048 at gmail dot com>
+ * This software is Copyright (c) 2015 Sayantan Datta <std2048 at gmail dot com>,
+ * Copyright (c) 2015-2023 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification, are permitted.
  * Based on Solar Designer implementation of DES_bs_b.c in jtr-v1.7.9
@@ -1066,9 +1067,8 @@ static char* select_bitmap(unsigned int num_ld_hashes, int *loaded_hashes, unsig
 	get_num_bits(bits_req, (*bitmap_size_bits));
 
 	sprintf(kernel_params,
-		"-D SELECT_CMP_STEPS=%u"
-		" -D BITMAP_SIZE_BITS_LESS_ONE="LLu" -D REQ_BITMAP_BITS=%u",
-		cmp_steps, (unsigned long long)(*bitmap_size_bits) - 1, bits_req);
+	        "-D SELECT_CMP_STEPS=%u -D BITMAP_MASK=0x%xU -D REQ_BITMAP_BITS=%u",
+	        cmp_steps, (uint32_t)((*bitmap_size_bits) - 1), bits_req);
 
 	*bitmap_size_bits *= cmp_steps;
 

--- a/src/opencl_mysqlsha1_fmt_plug.c
+++ b/src/opencl_mysqlsha1_fmt_plug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2016, magnum
+ * Copyright (c) 2012-2023, magnum
  * and Copyright (c) 2015, Sayantan Datta <sdatta@openwall.com>
  * This software is hereby released to the general public under
  * the following terms: Redistribution and use in source and binary
@@ -707,9 +707,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		prepare_bitmap_8(bitmap_size_bits, &bitmaps);
 
 	sprintf(kernel_params,
-		"-DSELECT_CMP_STEPS=%u"
-		" -DBITMAP_SIZE_BITS_LESS_ONE="LLu" -DUSE_LOCAL_BITMAPS=%u",
-		cmp_steps, (unsigned long long)bitmap_size_bits - 1, use_local);
+	        "-DSELECT_CMP_STEPS=%u -DBITMAP_MASK=0x%xU -DUSE_LOCAL_BITMAPS=%u",
+	        cmp_steps, (uint32_t)(bitmap_size_bits - 1), use_local);
 
 	bitmap_size_bits *= cmp_steps;
 

--- a/src/opencl_rawsha1_fmt_plug.c
+++ b/src/opencl_rawsha1_fmt_plug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2016, magnum
+ * Copyright (c) 2012-2023, magnum
  * and Copyright (c) 2015, Sayantan Datta <sdatta@openwall.com>
  * This software is hereby released to the general public under
  * the following terms: Redistribution and use in source and binary
@@ -660,9 +660,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		prepare_bitmap_8(bitmap_size_bits, &bitmaps);
 
 	sprintf(kernel_params,
-		"-D SELECT_CMP_STEPS=%u"
-		" -D BITMAP_SIZE_BITS_LESS_ONE="LLu" -D USE_LOCAL_BITMAPS=%u",
-		cmp_steps, (unsigned long long)bitmap_size_bits - 1, use_local);
+	        "-D SELECT_CMP_STEPS=%u -D BITMAP_MASK=0x%xU -D USE_LOCAL_BITMAPS=%u",
+	        cmp_steps, (uint32_t)(bitmap_size_bits - 1), use_local);
 
 	bitmap_size_bits *= cmp_steps;
 

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2016, magnum
+ * Copyright (c) 2012-2023, magnum
  * and Copyright (c) 2015, Sayantan Datta <sdatta@openwall.com>
  * This software is hereby released to the general public under
  * the following terms: Redistribution and use in source and binary
@@ -713,9 +713,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		prepare_bitmap_8(bitmap_size_bits, &bitmaps);
 
 	sprintf(kernel_params,
-		"-D SELECT_CMP_STEPS=%u"
-		" -D BITMAP_SIZE_BITS_LESS_ONE="LLu" -D USE_LOCAL_BITMAPS=%u",
-		cmp_steps, (unsigned long long)bitmap_size_bits - 1, use_local);
+		"-D SELECT_CMP_STEPS=%u -D BITMAP_MASK=0x%xU -D USE_LOCAL_BITMAPS=%u",
+		cmp_steps, (uint32_t)bitmap_size_bits - 1, use_local);
 
 	bitmap_size_bits *= cmp_steps;
 

--- a/src/opencl_sl3_fmt_plug.c
+++ b/src/opencl_sl3_fmt_plug.c
@@ -7,7 +7,7 @@
  * IMEI is 14 or 15 digits 0-9 (only 14 are used)
  * hash is hex lowercase (0-9, a-f)
  *
- * Copyright (c) 2017 magnum.
+ * Copyright (c) 2017-2023 magnum.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  */
@@ -670,9 +670,8 @@ static char* select_bitmap(unsigned int num_ld_hashes)
 		prepare_bitmap_8(bitmap_size_bits, &bitmaps);
 
 	sprintf(kernel_params,
-		"-D SELECT_CMP_STEPS=%u"
-		" -D BITMAP_SIZE_BITS_LESS_ONE="LLu" -D USE_LOCAL_BITMAPS=%u",
-		cmp_steps, (unsigned long long)bitmap_size_bits - 1, use_local);
+		"-D SELECT_CMP_STEPS=%u -D BITMAP_MASK=0x%xU -D USE_LOCAL_BITMAPS=%u",
+		cmp_steps, (uint32_t)bitmap_size_bits - 1, use_local);
 
 	bitmap_size_bits *= cmp_steps;
 

--- a/src/pseudo_intrinsics.h
+++ b/src/pseudo_intrinsics.h
@@ -1,7 +1,7 @@
 /*
  * Minimalistic pseudo-instrinsics for width-agnostic x86 SIMD code.
  *
- * This software is Copyright (c) 2015-2018 magnum,
+ * This software is Copyright (c) 2015-2021 magnum,
  * Copyright (c) 2015 JimF,
  * Copyright (c) 2015 Lei Zhang,
  * and it is hereby released to the general public under the following terms:

--- a/src/sha.h
+++ b/src/sha.h
@@ -1,6 +1,8 @@
 #ifndef JOHN_SHA_H
 #define JOHN_SHA_H
 
+#include <stdint.h>
+
 #if AC_BUILT
 #include "autoconfig.h"
 #endif
@@ -30,10 +32,16 @@
 #define SHA_H2 val[2]
 #define SHA_H3 val[3]
 #define SHA_H4 val[4]
-#endif
+
+#endif /* HAVE_LIBCRYPTO */
 
 #ifndef SHA_DIGEST_LENGTH
 #define SHA_DIGEST_LENGTH 20
 #endif
 
-#endif
+extern void sha1_reverse(uint32_t *hash);
+extern void sha1_unreverse(uint32_t *hash);
+extern void sha1_reverse3(uint32_t *hash);
+extern void sha1_unreverse3(uint32_t *hash);
+
+#endif /* JOHN_SHA_H */

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -5,7 +5,7 @@
  * ==========================(LICENSE BEGIN)============================
  *
  * Copyright (c) 2007-2010  Projet RNRT SAPHIR
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -13,10 +13,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -29,6 +29,8 @@
  *
  * @author   Thomas Pornin <thomas.pornin@cryptolog.com>
  */
+
+#include "sha.h"
 
 #if !HAVE_LIBCRYPTO
 
@@ -384,3 +386,32 @@ sph_sha1_comp(const sph_u32 msg[16], sph_u32 val[5])
 #endif /* dead code */
 
 #endif /* HAVE_LIBCRYPTO */
+
+#undef INIT_D
+#undef INIT_E
+#define INIT_D 0x10325476
+#define INIT_E 0xC3D2E1F0
+
+void sha1_reverse(uint32_t *hash)
+{
+	hash[4] -= INIT_E;
+	hash[4]  = (hash[4] << 2) | (hash[4] >> 30);
+}
+
+void sha1_unreverse(uint32_t *hash)
+{
+	hash[4]  = (hash[4] << 30) | (hash[4] >> 2);
+	hash[4] += INIT_E;
+}
+
+void sha1_reverse3(uint32_t *hash)
+{
+	hash[3] -= INIT_D;
+	hash[3]  = (hash[3] << 2) | (hash[3] >> 30);
+}
+
+void sha1_unreverse3(uint32_t *hash)
+{
+	hash[3]  = (hash[3] << 30) | (hash[3] >> 2);
+	hash[3] += INIT_D;
+}

--- a/src/sha2.c
+++ b/src/sha2.c
@@ -1,19 +1,11 @@
 /*
+ * This software is
+ * Copyright (c) 2012 JimF,
+ * Copyright (c) 2012-2023 magnum,
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  *
- * This software was written by JimF jfoug AT cox dot net
- * in 2012. No copyright is claimed, and the software is hereby
- * placed in the public domain. In case this attempt to disclaim
- * copyright and place the software in the public domain is deemed
- * null and void, then the software is Copyright (c) 2012 JimF
- * and it is hereby released to the general public under the following
- * terms:
- *
- * This software may be modified, redistributed, and used for any
- * purpose, in source and binary forms, with or without modification.
- */
-
-
-/*
  *  FIPS-180-2 compliant SHA-256 implementation
  *  The SHA-256 Secure Hash Standard was published by NIST in 2002.
  *
@@ -289,11 +281,89 @@ void jtr_sha256_final(void *_output, jtr_sha256_ctx *ctx)
 #endif
 }
 
-/*********************************************************************/
-/*********************************************************************/
-/*** Here is code for SHA386 and SHA512                            ***/
-/*********************************************************************/
-/*********************************************************************/
+#define INIT_D 0xf70e5939
+
+void sha224_reverse(uint32_t *hash)
+{
+	hash[3] -= INIT_D;
+}
+
+void sha224_unreverse(uint32_t *hash)
+{
+	hash[3] += INIT_D;
+}
+
+#undef INIT_D
+
+#define INIT_A 0x6a09e667
+#define INIT_B 0xbb67ae85
+#define INIT_C 0x3c6ef372
+#define INIT_D 0xa54ff53a
+#define INIT_E 0x510e527f
+#define INIT_F 0x9b05688c
+#define INIT_G 0x1f83d9ab
+#define INIT_H 0x5be0cd19
+
+#define ror(x, n)       ((x >> n) | (x << (32 - n)))
+
+void sha256_reverse(uint32_t *hash)
+{
+	uint32_t a, b, c, d, e, f, g, h, s0, maj, tmp;
+
+	a = hash[0] - INIT_A;
+	b = hash[1] - INIT_B;
+	c = hash[2] - INIT_C;
+	d = hash[3] - INIT_D;
+	e = hash[4] - INIT_E;
+	f = hash[5] - INIT_F;
+	g = hash[6] - INIT_G;
+	h = hash[7] - INIT_H;
+
+	s0 = ror(b, 2) ^ ror(b, 13) ^ ror(b, 22);
+	maj = (b & c) ^ (b & d) ^ (c & d);
+	tmp = d;
+	d = e - (a - (s0 + maj));
+	e = f;
+	f = g;
+	g = h;
+	a = b;
+	b = c;
+	c = tmp;
+
+	s0 = ror(b, 2) ^ ror(b, 13) ^ ror(b, 22);
+	maj = (b & c) ^ (b & d) ^ (c & d);
+	tmp = d;
+	d = e - (a - (s0 + maj));
+	e = f;
+	f = g;
+	a = b;
+	b = c;
+	c = tmp;
+
+	s0 = ror(b, 2) ^ ror(b, 13) ^ ror(b, 22);
+	maj = (b & c) ^ (b & d) ^ (c & d);
+	tmp = d;
+	d = e - (a - (s0 + maj));
+	e = f;
+	a = b;
+	b = c;
+	c = tmp;
+
+	s0 = ror(b, 2) ^ ror(b, 13) ^ ror(b, 22);
+	maj = (b & c) ^ (b & d) ^ (c & d);
+
+	hash[0] = e - (a - (s0 + maj));
+}
+
+#undef ror
+#undef INIT_H
+#undef INIT_G
+#undef INIT_F
+#undef INIT_E
+#undef INIT_D
+#undef INIT_C
+#undef INIT_B
+#undef INIT_A
 #undef S0
 #undef S1
 #undef R0
@@ -301,6 +371,12 @@ void jtr_sha256_final(void *_output, jtr_sha256_ctx *ctx)
 #undef F0
 #undef F1
 #undef R
+
+/*********************************************************************/
+/*********************************************************************/
+/*** Here is code for SHA386 and SHA512                            ***/
+/*********************************************************************/
+/*********************************************************************/
 
 #define INIT_A 0x6a09e667f3bcc908ULL
 #define INIT_B 0xbb67ae8584caa73bULL
@@ -310,7 +386,6 @@ void jtr_sha256_final(void *_output, jtr_sha256_ctx *ctx)
 #define INIT_F 0x9b05688c2b3e6c1fULL
 #define INIT_G 0x1f83d9abfb41bd6bULL
 #define INIT_H 0x5be0cd19137e2179ULL
-
 
 #define S0(x) (ROR64(x,28) ^ ROR64(x,34) ^ ROR64(x,39))
 #define S1(x) (ROR64(x,14) ^ ROR64(x,18) ^ ROR64(x,41))
@@ -648,13 +723,6 @@ void jtr_sha512_final(void *_output, jtr_sha512_ctx *ctx)
 #endif
 }
 
-/*********************************************************************/
-/*********************************************************************/
-/*** Reverse SHA512 rounds. The function can be used on OpenCL.    ***/
-/*** - It must be available for a SIMD or non-SIMD build.          ***/
-/*********************************************************************/
-/*********************************************************************/
-#if defined(SIMD_COEF_64) || defined(HAVE_OPENCL)
 void sha512_reverse(uint64_t *hash)
 {
 	uint64_t a, b, c, d, e, f, g, h, s0, maj, tmp;
@@ -703,4 +771,3 @@ void sha512_reverse(uint64_t *hash)
 
 	hash[0] = e - (a - (s0 + maj));
 }
-#endif

--- a/src/sha2.h
+++ b/src/sha2.h
@@ -1,18 +1,11 @@
 /*
+ * This software is
+ * Copyright (c) 2012-2013 JimF,
+ * Copyright (c) 2012-2023 magnum,
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  *
- * This software was written by JimF jfoug AT cox dot net in
- * 2012-2013. No copyright is claimed, and the software is hereby
- * placed in the public domain. In case this attempt to disclaim
- * copyright and place the software in the public domain is deemed
- * null and void, then the software is Copyright (c) 2012-2013 JimF
- * and it is hereby released to the general public under the following
- * terms:
- *
- * This software may be modified, redistributed, and used for any
- * purpose, in source and binary forms, with or without modification.
- */
-
-/*
  * SHA-224 and SHA-256 hash function.
  * Will use Openssl if the openssl version is great enough.
  * otherwise, we use C code, in ssh2.c, and some #defines
@@ -34,18 +27,19 @@
 #include <stdint.h>
 #include "arch.h"
 #include "aligned.h"
+
 #if HAVE_LIBCRYPTO
 #include <openssl/opensslv.h>
 #elif !defined(FORCE_GENERIC_SHA2)
 #define FORCE_GENERIC_SHA2 1
 #endif
+
 #include "openssl_local_overrides.h"
 
 #if (AC_BUILT && HAVE_SHA256 && !FORCE_GENERIC_SHA2) ||	  \
     (!AC_BUILT && OPENSSL_VERSION_NUMBER >= 0x00908000 && !FORCE_GENERIC_SHA2)
 
 #include <openssl/sha.h>
-
 #undef GENERIC_SHA2
 
 #else	// OPENSSL_VERSION_NUMBER ! >= 0x00908000
@@ -54,19 +48,9 @@
 #include <openssl/sha.h>
 #endif
 #include "jtr_sha2.h"
-
 #define GENERIC_SHA2
 
-
-#endif
-
-#if defined(SIMD_COEF_64) || defined(HAVE_OPENCL)
-/*
- * Reverse SHA512 rounds. The function can be used on OpenCL.
- * - It must be available for a SIMD or non-SIMD build.
- */
-void sha512_reverse(uint64_t *hash);
-#endif
+#endif	// OPENSSL_VERSION_NUMBER ! >= 0x00908000
 
 #ifndef SHA224_DIGEST_LENGTH
 #define SHA224_DIGEST_LENGTH 28
@@ -83,5 +67,12 @@ void sha512_reverse(uint64_t *hash);
 #ifndef SHA512_DIGEST_LENGTH
 #define SHA512_DIGEST_LENGTH 64
 #endif
+
+extern void sha224_reverse(uint32_t *hash);
+extern void sha224_unreverse(uint32_t *hash);
+extern void sha256_reverse(uint32_t *hash);
+extern void sha384_reverse(uint64_t *hash);
+extern void sha384_unreverse(uint64_t *hash);
+extern void sha512_reverse(uint64_t *hash);
 
 #endif /* _JOHN_SHA2_h */

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2010 bartavelle, <bartavelle at bandecon.com>,
  * Copyright (c) 2012 Solar Designer,
  * Copyright (c) 2011-2015 JimF,
- * Copyright (c) 2011-2021 magnum,
+ * Copyright (c) 2011-2023 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -100,20 +100,6 @@
         a[i] = vroti16_epi32( a[i], (s) );          \
         a[i] = vadd_epi32( a[i], b[i] );            \
     }
-
-#define INIT_A 0x67452301
-
-void md5_reverse(uint32_t *hash)
-{
-	hash[0] -= INIT_A;
-}
-
-void md5_unreverse(uint32_t *hash)
-{
-	hash[0] += INIT_A;
-}
-
-#undef INIT_A
 
 void SIMDmd5body(vtype* _data, unsigned int *out,
                 uint32_t *reload_state, unsigned SSEi_flags)
@@ -774,42 +760,6 @@ void md5cryptsse(unsigned char pwd[MD5_SSE_NUM_KEYS][16], unsigned char *salt,
         a[i] = vadd_epi32( a[i], data[i*16+x] );    \
     }
 
-#define INIT_A 0x67452301
-#define INIT_B 0xefcdab89
-#define INIT_C 0x98badcfe
-#define INIT_D 0x10325476
-#define SQRT_3 0x6ed9eba1
-
-void md4_reverse(uint32_t *hash)
-{
-	hash[0] -= INIT_A;
-	hash[1] -= INIT_B;
-	hash[2] -= INIT_C;
-	hash[3] -= INIT_D;
-	hash[1]  = (hash[1] >> 15) | (hash[1] << 17);
-	hash[1] -= SQRT_3 + (hash[2] ^ hash[3] ^ hash[0]);
-	hash[1]  = (hash[1] >> 15) | (hash[1] << 17);
-	hash[1] -= SQRT_3;
-}
-
-void md4_unreverse(uint32_t *hash)
-{
-	hash[1] += SQRT_3;
-	hash[1]  = (hash[1] >> 17) | (hash[1] << 15);
-	hash[1] += SQRT_3 + (hash[2] ^ hash[3] ^ hash[0]);
-	hash[1]  = (hash[1] >> 17) | (hash[1] << 15);
-	hash[3] += INIT_D;
-	hash[2] += INIT_C;
-	hash[1] += INIT_B;
-	hash[0] += INIT_A;
-}
-
-#undef SQRT_3
-#undef INIT_D
-#undef INIT_C
-#undef INIT_B
-#undef INIT_A
-
 void SIMDmd4body(vtype* _data, unsigned int *out, uint32_t *reload_state,
                 unsigned SSEi_flags)
 {
@@ -1282,35 +1232,6 @@ void SIMDmd4body(vtype* _data, unsigned int *out, uint32_t *reload_state,
         e[i] = vadd_epi32( e[i], w[i*16+(t&0xF)] ); \
         b[i] = vroti_epi32(b[i], 30);               \
     }
-#define INIT_D 0x10325476
-#define INIT_E 0xC3D2E1F0
-
-void sha1_reverse(uint32_t *hash)
-{
-	hash[4] -= INIT_E;
-	hash[4]  = (hash[4] << 2) | (hash[4] >> 30);
-}
-
-void sha1_unreverse(uint32_t *hash)
-{
-	hash[4]  = (hash[4] << 30) | (hash[4] >> 2);
-	hash[4] += INIT_E;
-}
-
-void sha1_reverse3(uint32_t *hash)
-{
-	hash[3] -= INIT_D;
-	hash[3]  = (hash[3] << 2) | (hash[3] >> 30);
-}
-
-void sha1_unreverse3(uint32_t *hash)
-{
-	hash[3]  = (hash[3] << 30) | (hash[3] >> 2);
-	hash[3] += INIT_D;
-}
-
-#undef INIT_D
-#undef INIT_E
 
 void SIMDSHA1body(vtype* _data, uint32_t *out, uint32_t *reload_state,
                  unsigned SSEi_flags)
@@ -1817,97 +1738,6 @@ void SIMDSHA1body(vtype* _data, uint32_t *out, uint32_t *reload_state,
         if (x < 48) R(x);                                   \
     }                                                       \
 }
-
-#define INIT_A 0x6a09e667
-#define INIT_B 0xbb67ae85
-#define INIT_C 0x3c6ef372
-#define INIT_D 0xa54ff53a
-#define INIT_E 0x510e527f
-#define INIT_F 0x9b05688c
-#define INIT_G 0x1f83d9ab
-#define INIT_H 0x5be0cd19
-
-#define ror(x, n)       ((x >> n) | (x << (32 - n)))
-
-void sha256_reverse(uint32_t *hash)
-{
-	uint32_t a, b, c, d, e, f, g, h, s0, maj, tmp;
-
-	a = hash[0] - INIT_A;
-	b = hash[1] - INIT_B;
-	c = hash[2] - INIT_C;
-	d = hash[3] - INIT_D;
-	e = hash[4] - INIT_E;
-	f = hash[5] - INIT_F;
-	g = hash[6] - INIT_G;
-	h = hash[7] - INIT_H;
-
-	s0 = ror(b, 2) ^ ror(b, 13) ^ ror(b, 22);
-	maj = (b & c) ^ (b & d) ^ (c & d);
-	tmp = d;
-	d = e - (a - (s0 + maj));
-	e = f;
-	f = g;
-	g = h;
-	a = b;
-	b = c;
-	c = tmp;
-
-	s0 = ror(b, 2) ^ ror(b, 13) ^ ror(b, 22);
-	maj = (b & c) ^ (b & d) ^ (c & d);
-	tmp = d;
-	d = e - (a - (s0 + maj));
-	e = f;
-	f = g;
-	a = b;
-	b = c;
-	c = tmp;
-
-	s0 = ror(b, 2) ^ ror(b, 13) ^ ror(b, 22);
-	maj = (b & c) ^ (b & d) ^ (c & d);
-	tmp = d;
-	d = e - (a - (s0 + maj));
-	e = f;
-	a = b;
-	b = c;
-	c = tmp;
-
-	s0 = ror(b, 2) ^ ror(b, 13) ^ ror(b, 22);
-	maj = (b & c) ^ (b & d) ^ (c & d);
-
-	hash[0] = e - (a - (s0 + maj));
-}
-
-void sha256_unreverse(uint32_t *hash)
-{
-	fprintf(stderr, "sha256_unreverse() not implemented\n");
-	error();
-}
-
-#undef ror
-
-#undef INIT_H
-#undef INIT_G
-#undef INIT_F
-#undef INIT_E
-#undef INIT_D
-#undef INIT_C
-#undef INIT_B
-#undef INIT_A
-
-#define INIT_D 0xf70e5939
-
-void sha224_reverse(uint32_t *hash)
-{
-	hash[3] -= INIT_D;
-}
-
-void sha224_unreverse(uint32_t *hash)
-{
-	hash[3] += INIT_D;
-}
-
-#undef INIT_D
 
 void SIMDSHA256body(vtype *data, uint32_t *out, uint32_t *reload_state, unsigned SSEi_flags)
 {

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -1,8 +1,11 @@
 /*
- * This software is Copyright (c) 2010 bartavelle, <bartavelle at bandecon.com>, and it is hereby released to the general public under the following terms:
- * Redistribution and use in source and binary forms, with or without modification, are permitted.
- *
- * Some modifications, Jim Fougeron, 2013.  Licensing rights listed in accompanying simd-intrinsics.c file.
+ * This software is
+ * Copyright (c) 2010 bartavelle, <bartavelle at bandecon.com>,
+ * Copyright (c) 2013 JimF,
+ * Copyright (c) 2013-2023 magnum,
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  */
 
 #if !defined (__JTR_SSE_INTRINSICS_H__)
@@ -78,8 +81,6 @@
 #ifdef SIMD_PARA_MD5
 void md5cryptsse(unsigned char *buf, unsigned char *salt, char *out, unsigned int md5_type);
 void SIMDmd5body(vtype* data, uint32_t *out, uint32_t *reload_state, unsigned SSEi_flags);
-void md5_reverse(uint32_t *hash);
-void md5_unreverse(uint32_t *hash);
 #define MD5_ALGORITHM_NAME		BITS " " SIMD_TYPE " " MD5_N_STR
 #else
 #define MD5_ALGORITHM_NAME		"32/" ARCH_BITS_STR
@@ -88,8 +89,6 @@ void md5_unreverse(uint32_t *hash);
 #ifdef SIMD_PARA_MD4
 //void SIMDmd4body(__m128i* data, unsigned int *out, int init);
 void SIMDmd4body(vtype* data, uint32_t *out, uint32_t *reload_state, unsigned SSEi_flags);
-void md4_reverse(uint32_t *hash);
-void md4_unreverse(uint32_t *hash);
 #define MD4_ALGORITHM_NAME		BITS " " SIMD_TYPE " " MD4_N_STR
 #else
 #define MD4_ALGORITHM_NAME		"32/" ARCH_BITS_STR
@@ -97,10 +96,6 @@ void md4_unreverse(uint32_t *hash);
 
 #ifdef SIMD_PARA_SHA1
 void SIMDSHA1body(vtype* data, uint32_t *out, uint32_t *reload_state, unsigned SSEi_flags);
-void sha1_reverse(uint32_t *hash);
-void sha1_unreverse(uint32_t *hash);
-void sha1_reverse3(uint32_t *hash);
-void sha1_unreverse3(uint32_t *hash);
 #define SHA1_ALGORITHM_NAME		BITS " " SIMD_TYPE " " SHA1_N_STR
 #else
 #define SHA1_ALGORITHM_NAME		"32/" ARCH_BITS_STR
@@ -112,18 +107,11 @@ void sha1_unreverse3(uint32_t *hash);
 #ifdef SIMD_COEF_32
 #define SHA256_ALGORITHM_NAME	BITS " " SIMD_TYPE " " SHA256_N_STR
 void SIMDSHA256body(vtype* data, uint32_t *out, uint32_t *reload_state, unsigned SSEi_flags);
-void sha224_reverse(uint32_t *hash);
-void sha224_unreverse(uint32_t *hash);
-void sha256_reverse(uint32_t *hash);
-void sha256_unreverse(uint32_t *hash);
 #endif
 
 #ifdef SIMD_COEF_64
 #define SHA512_ALGORITHM_NAME	BITS " " SIMD_TYPE " " SHA512_N_STR
 void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
-void sha384_reverse(uint64_t *hash);
-void sha384_unreverse(uint64_t *hash);
-// sha512_reverse is defined in sha2.h. It can be used for a non-SIMD build.
 #endif
 
 #else


### PR DESCRIPTION
NT-opencl: Minor bugfix for logging of bitmap parameters.
Move reversing/unreversing hash functions from SIMD-code to common code. Closes #5264.
Support largest bitmaps (0xffffffff) without failing kernel build (formats using perfect hash tables).
Fix a bug where some workgroup sizes would fail to properly copy bitmap to local memory (formats using perfect hash tables).
While at it, for DES/LM OpenCL formats fix a similar copy to local to avoid modulo arithmetic.