### PR TITLE
Perfect hash tables' bitmap bugfixes

### DIFF
--- a/src/opencl_hash_check_128_plug.c
+++ b/src/opencl_hash_check_128_plug.c
@@ -94,15 +94,14 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 	*bitmap_ptr = (cl_uint*) mem_calloc((bmp_sz >> 2), sizeof(cl_uint));
 
 	for (i = 0; i < ocl_hc_num_loaded_hashes; i++) {
-		unsigned int bmp_idx =
-			(loaded_hashes[4 * i] & 0x0000ffff) & (bmp_sz - 1);
+		unsigned int bmp_idx = (loaded_hashes[4 * i]) & (bmp_sz - 1);
 		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
 
 		bmp_idx = (loaded_hashes[4 * i] >> 16) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[4 * i + 1] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[4 * i + 1]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 4) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -110,7 +109,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 3 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[4 * i + 2] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[4 * i + 2]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 3) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -118,7 +117,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 5 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[4 * i + 3] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[4 * i + 3]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) * 6 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 

--- a/src/opencl_hash_check_64_plug.c
+++ b/src/opencl_hash_check_64_plug.c
@@ -139,13 +139,13 @@ static void prepare_bitmap_4(uint64_t bmp_sz, cl_uint **bitmap_ptr)
 		unsigned int a = loaded_hashes[2 * i];
 		unsigned int b = loaded_hashes[2 * i + 1];
 
-		bmp_idx = (b & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = b & (bmp_sz - 1);
 		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
 
 		bmp_idx = (b >> 16) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |= (1U << (bmp_idx & 31));
 
-		bmp_idx = (a & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = a & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) * 2 + (bmp_idx >> 5)] |= (1U << (bmp_idx & 31));
 
 		bmp_idx = (a >> 16) & (bmp_sz - 1);

--- a/src/opencl_mysqlsha1_fmt_plug.c
+++ b/src/opencl_mysqlsha1_fmt_plug.c
@@ -519,20 +519,15 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 	MEM_FREE(*bitmap_ptr);
 	*bitmap_ptr = (cl_uint*) mem_calloc((bmp_sz >> 2), sizeof(cl_uint));
 
-	if ((bmp_sz - 1) > 0xffff)
-		fprintf(stderr, "Warning, %s() used with too large bitmap (0x%x) %s:%u\n",
-		        __FUNCTION__, (uint)bmp_sz - 1, __FILE__, __LINE__);
-
 	for (i = 0; i < num_loaded_hashes; i++) {
-		unsigned int bmp_idx =
-			(loaded_hashes[6 * i] & 0x0000ffff) & (bmp_sz - 1);
+		unsigned int bmp_idx = (loaded_hashes[6 * i]) & (bmp_sz - 1);
 		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
 
 		bmp_idx = (loaded_hashes[6 * i] >> 16) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 1] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 1]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 4) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -540,7 +535,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 3 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 2] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 2]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 3) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -548,7 +543,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 5 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 3] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 3]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) * 6 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 

--- a/src/opencl_rawsha1_fmt_plug.c
+++ b/src/opencl_rawsha1_fmt_plug.c
@@ -472,20 +472,15 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 	MEM_FREE(*bitmap_ptr);
 	*bitmap_ptr = (cl_uint*) mem_calloc((bmp_sz >> 2), sizeof(cl_uint));
 
-	if ((bmp_sz - 1) > 0xffff)
-		fprintf(stderr, "Warning, %s() used with too large bitmap (0x%x) %s:%u\n",
-		        __FUNCTION__, (uint)bmp_sz - 1, __FILE__, __LINE__);
-
 	for (i = 0; i < num_loaded_hashes; i++) {
-		unsigned int bmp_idx =
-			(loaded_hashes[6 * i] & 0x0000ffff) & (bmp_sz - 1);
+		unsigned int bmp_idx = (loaded_hashes[6 * i]) & (bmp_sz - 1);
 		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
 
 		bmp_idx = (loaded_hashes[6 * i] >> 16) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 1] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 1]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 4) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -493,7 +488,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 3 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 2] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 2]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 3) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -501,7 +496,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 5 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 3] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 3]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) * 6 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 

--- a/src/opencl_salted_sha_fmt_plug.c
+++ b/src/opencl_salted_sha_fmt_plug.c
@@ -525,20 +525,15 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 	MEM_FREE(*bitmap_ptr);
 	*bitmap_ptr = (cl_uint*) mem_calloc((bmp_sz >> 2), sizeof(cl_uint));
 
-	if ((bmp_sz - 1) > 0xffff)
-		fprintf(stderr, "Warning, %s() used with too large bitmap (0x%x) %s:%u\n",
-		        __FUNCTION__, (uint)bmp_sz - 1, __FILE__, __LINE__);
-
 	for (i = 0; i < num_loaded_hashes; i++) {
-		unsigned int bmp_idx =
-			(loaded_hashes[6 * i] & 0x0000ffff) & (bmp_sz - 1);
+		unsigned int bmp_idx = (loaded_hashes[6 * i]) & (bmp_sz - 1);
 		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
 
 		bmp_idx = (loaded_hashes[6 * i] >> 16) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 1] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 1]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 4) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -546,7 +541,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 3 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 2] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 2]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 3) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -554,7 +549,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 5 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 3] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 3]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) * 6 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 

--- a/src/opencl_sl3_fmt_plug.c
+++ b/src/opencl_sl3_fmt_plug.c
@@ -482,20 +482,15 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 	MEM_FREE(*bitmap_ptr);
 	*bitmap_ptr = (cl_uint*)mem_calloc((bmp_sz >> 2), sizeof(cl_uint));
 
-	if ((bmp_sz - 1) > 0xffff)
-		fprintf(stderr, "Warning, %s() used with too large bitmap (0x%x) %s:%u\n",
-		        __FUNCTION__, (uint)bmp_sz - 1, __FILE__, __LINE__);
-
 	for (i = 0; i < num_loaded_hashes; i++) {
-		unsigned int bmp_idx =
-			(loaded_hashes[6 * i] & 0x0000ffff) & (bmp_sz - 1);
+		unsigned int bmp_idx = (loaded_hashes[6 * i]) & (bmp_sz - 1);
 		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
 
 		bmp_idx = (loaded_hashes[6 * i] >> 16) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 1] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 1]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 4) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -503,7 +498,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 3 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 2] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 2]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 3) + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
@@ -511,7 +506,7 @@ static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
 		(*bitmap_ptr)[(bmp_sz >> 5) * 5 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 
-		bmp_idx = (loaded_hashes[6 * i + 3] & 0x0000ffff) & (bmp_sz - 1);
+		bmp_idx = (loaded_hashes[6 * i + 3]) & (bmp_sz - 1);
 		(*bitmap_ptr)[(bmp_sz >> 5) * 6 + (bmp_idx >> 5)] |=
 			(1U << (bmp_idx & 31));
 


### PR DESCRIPTION
The bitmap host code for 4/8-level bitmaps (only 8-level in 128-bit code) differed from GPU side's: If we mask stuff off we have to do it on GPU as well or we'll get false negatives.  Never doing it at all yields better characteristics for "oversized" masks, so that's what we go with.

This bug never surfaced until recent 6ed33a7f, and even then it would only trigger for NT-opencl, and when having between 10101 and 20100 hashes loaded AND running on either AMD VLIW4 GPU devices, or CPU OpenCL devices.