### PR TITLE
Solaris sparc64 portability fixes

### DIFF
--- a/src/DES_bs_b.c
+++ b/src/DES_bs_b.c
@@ -94,7 +94,7 @@ typedef uint32x2_t vtype;
 	(dst) = vshr_n_u32((src), (shift))
 
 #elif defined(__ALTIVEC__) && DES_BS_DEPTH == 128
-#ifdef __linux__
+#ifndef __APPLE__
 #include <altivec.h>
 #endif
 

--- a/src/c3_fmt.c
+++ b/src/c3_fmt.c
@@ -13,20 +13,23 @@
 
 #if AC_BUILT
 #include "autoconfig.h"
-#endif
-
-#if HAVE_CRYPT
-
+#else
 #undef _XOPEN_SOURCE
 #undef _XOPEN_SOURCE_EXTENDED
 #undef _XOPEN_VERSION
 #undef  _XPG4_2
+#undef  _XPG6
 #undef _GNU_SOURCE
 #define _XOPEN_SOURCE 4 /* for crypt(3) */
 #define _XOPEN_SOURCE_EXTENDED 1 /* for OpenBSD */
 #define _XOPEN_VERSION 4
 #define _XPG4_2
+#define _XPG6
 #define _GNU_SOURCE 1 /* for crypt_r(3) */
+#endif
+
+#if HAVE_CRYPT
+
 #include <stdio.h>
 
 #if !AC_BUILT

--- a/src/configure
+++ b/src/configure
@@ -7366,6 +7366,7 @@ $as_echo "\"Not found\"" >&6; };
         fi
 
 
+MAKE=$_cv_gnu_make_command
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${MAKE-make} sets \$(MAKE)" >&5
 $as_echo_n "checking whether ${MAKE-make} sets \$(MAKE)... " >&6; }
 set x ${MAKE-make}

--- a/src/configure
+++ b/src/configure
@@ -7800,20 +7800,23 @@ if test -z "$AR"; then :
 set dummy ${ac_tool_prefix}ar; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_AR+:} false; then :
+if ${ac_cv_path_AR+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  if test -n "$AR"; then
-  ac_cv_prog_AR="$AR" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
+  case $AR in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_AR="$AR" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+as_dummy="$PATH:/usr/ccs/bin"
+for as_dir in $as_dummy
 do
   IFS=$as_save_IFS
   test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_AR="${ac_tool_prefix}ar"
+    ac_cv_path_AR="$as_dir/$ac_word$ac_exec_ext"
     $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -7821,9 +7824,10 @@ done
   done
 IFS=$as_save_IFS
 
+  ;;
+esac
 fi
-fi
-AR=$ac_cv_prog_AR
+AR=$ac_cv_path_AR
 if test -n "$AR"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AR" >&5
 $as_echo "$AR" >&6; }
@@ -7834,26 +7838,29 @@ fi
 
 
 fi
-if test -z "$ac_cv_prog_AR"; then
-  ac_ct_AR=$AR
+if test -z "$ac_cv_path_AR"; then
+  ac_pt_AR=$AR
   # Extract the first word of "ar", so it can be a program name with args.
 set dummy ar; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_ac_ct_AR+:} false; then :
+if ${ac_cv_path_ac_pt_AR+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  if test -n "$ac_ct_AR"; then
-  ac_cv_prog_ac_ct_AR="$ac_ct_AR" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
+  case $ac_pt_AR in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_ac_pt_AR="$ac_pt_AR" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+as_dummy="$PATH:/usr/ccs/bin"
+for as_dir in $as_dummy
 do
   IFS=$as_save_IFS
   test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_ac_ct_AR="ar"
+    ac_cv_path_ac_pt_AR="$as_dir/$ac_word$ac_exec_ext"
     $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -7861,19 +7868,20 @@ done
   done
 IFS=$as_save_IFS
 
+  ;;
+esac
 fi
-fi
-ac_ct_AR=$ac_cv_prog_ac_ct_AR
-if test -n "$ac_ct_AR"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_AR" >&5
-$as_echo "$ac_ct_AR" >&6; }
+ac_pt_AR=$ac_cv_path_ac_pt_AR
+if test -n "$ac_pt_AR"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_AR" >&5
+$as_echo "$ac_pt_AR" >&6; }
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
 
-  if test "x$ac_ct_AR" = x; then
-    AR=""
+  if test "x$ac_pt_AR" = x; then
+    AR="ar"
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
@@ -7881,10 +7889,10 @@ yes:)
 $as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
-    AR=$ac_ct_AR
+    AR=$ac_pt_AR
   fi
 else
-  AR="$ac_cv_prog_AR"
+  AR="$ac_cv_path_AR"
 fi
 
 fi
@@ -7967,7 +7975,7 @@ $as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_STRIP" = x; then
-    STRIP=""
+    STRIP="strip"
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
@@ -8061,7 +8069,7 @@ $as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_STRINGS" = x; then
-    STRINGS=""
+    STRINGS="strings"
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -332,6 +332,7 @@ dnl AC_PROG_EGREP Do not trust this one
 AC_PROG_SED
 dnl AC_PROG_CXX
 AX_CHECK_GNU_MAKE()
+MAKE=$_cv_gnu_make_command
 AC_PROG_MAKE_SET
 AC_PROG_CPP
 AC_PROG_MKDIR_P

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -345,9 +345,9 @@ if test "x$PERL" = x ; then
 fi
 AS_IF([test -z "$AS"], [AS="$CC"])
 AS_IF([test -z "$LD"], [LD="$CC"])
-AS_IF([test -z "$AR"], [AC_CHECK_TOOL([AR], [ar])])
-AS_IF([test -z "$STRIP"], [AC_CHECK_TOOL([STRIP], [strip])])
-AS_IF([test -z "$STRINGS"], [AC_CHECK_TOOL([STRINGS], [strings])])
+AS_IF([test -z "$AR"], [AC_PATH_TOOL([AR], [ar], [ar], [$PATH:/usr/ccs/bin])])
+AS_IF([test -z "$STRIP"], [AC_CHECK_TOOL([STRIP], [strip], [strip])])
+AS_IF([test -z "$STRINGS"], [AC_CHECK_TOOL([STRINGS], [strings], [strings])])
 
 dnl Check if we have this at all
 PKG_PROG_PKG_CONFIG

--- a/src/eapmd5tojohn.c
+++ b/src/eapmd5tojohn.c
@@ -61,18 +61,18 @@
 
 /* The radio capture header precedes the 802.11 header. */
 struct ieee80211_radiotap_header {
-	u_int8_t	it_version;	/* Version 0. Only increases
+	uint8_t	       it_version;	/* Version 0. Only increases
 					 * for drastic changes,
 					 * introduction of compatible
 					 * new fields does not count.
 					 */
-	u_int8_t	it_pad;
-	u_int16_t       it_len;         /* length of the whole
+	uint8_t        it_pad;
+	uint16_t       it_len;          /* length of the whole
 					 * header in bytes, including
 					 * int_version, it_pad,
 					 * it_len, and data fields.
 					 */
-	u_int32_t       it_present;     /* A bitmap telling which
+	uint32_t       it_present;      /* A bitmap telling which
 					 * fields are present. Set bit 31
 					 * (0x80000000) to extend the
 					 * bitmap by another 32 bits.
@@ -354,7 +354,7 @@ struct eapmd5pass_data {
 static void cleanexit(int signum);
 void usage();
 int radiotap_offset(pcap_t *p, struct pcap_pkthdr *h);
-void assess_packet(char *user, struct pcap_pkthdr *h, u_int8_t *pkt);
+void assess_packet(char *user, struct pcap_pkthdr *h, uint8_t *pkt);
 void eapmd5_nexttarget(struct eapmd5pass_data *em);
 int extract_eapusername(uint8_t *eap, int eaplen, struct eapmd5pass_data *em);
 int extract_eapchallenge(uint8_t *eap, int eaplen, struct eapmd5pass_data *em);
@@ -650,7 +650,7 @@ static void print_hex(unsigned char *str, int len)
                 printf("%02x", str[i]);
 }
 
-void assess_packet(char *user, struct pcap_pkthdr *h, u_int8_t *pkt)
+void assess_packet(char *user, struct pcap_pkthdr *h, uint8_t *pkt)
 {
 	struct dot11hdr *dot11;
 	struct ieee8021x *dot1xhdr;

--- a/src/idle.c
+++ b/src/idle.c
@@ -10,8 +10,9 @@
  * There's ABSOLUTELY NO WARRANTY, express or implied.
  */
 
-#ifndef _XOPEN_SOURCE
+#if !AC_BUILT && !defined(_XOPEN_SOURCE)
 #define _XOPEN_SOURCE /* for nice(2) */
+#define _XPG6
 #endif
 
 #include "os.h"

--- a/src/int-util.h
+++ b/src/int-util.h
@@ -10,16 +10,14 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "arch.h"
+
 #if !AC_BUILT || HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
 
 #if defined(_MSC_VER)
 #include <stdlib.h>
-// VC has no sys/parm.h   These defines were taken from defines found on cygwin
-#define LITTLE_ENDIAN 4321
-#define BIG_ENDIAN 1234
-#define BYTE_ORDER LITTLE_ENDIAN
 
 static inline uint32_t rol32(uint32_t x, int r) {
   static_assert(sizeof(uint32_t) == sizeof(unsigned int), "this code assumes 32-bit integers");
@@ -175,11 +173,7 @@ static inline void memcpy_swap64(void *dst, const void *src, size_t n) {
   }
 }
 
-#if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN) || !defined(BIG_ENDIAN)
-static_assert(false, "BYTE_ORDER is undefined. Perhaps, GNU extensions are not enabled");
-#endif
-
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if ARCH_LITTLE_ENDIAN
 #define SWAP32LE IDENT32
 #define SWAP32BE SWAP32
 #define swap32le ident32
@@ -196,9 +190,7 @@ static_assert(false, "BYTE_ORDER is undefined. Perhaps, GNU extensions are not e
 #define mem_inplace_swap64be mem_inplace_swap64
 #define memcpy_swap64le memcpy_ident64
 #define memcpy_swap64be memcpy_swap64
-#endif
-
-#if BYTE_ORDER == BIG_ENDIAN
+#else
 #define SWAP32BE IDENT32
 #define SWAP32LE SWAP32
 #define swap32be ident32

--- a/src/logger.c
+++ b/src/logger.c
@@ -10,8 +10,9 @@
  * There's ABSOLUTELY NO WARRANTY, express or implied.
  */
 
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE /* for fileno(3) and fsync(2) */
+#if !AC_BUILT && !defined(_XOPEN_SOURCE)
+#define _XOPEN_SOURCE 500 /* for fileno(3) and fsync(2) */
+#define _XPG6
 #endif
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE /* for strcasestr */
@@ -35,6 +36,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <sys/time.h> /* for struct timeval */
 #include <time.h>
 #include <stdarg.h>
 #include <string.h>

--- a/src/os.h
+++ b/src/os.h
@@ -28,6 +28,7 @@
 #else
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 500 /* for ITIMER_REAL */
+#define _XPG6
 #endif
 #include <sys/time.h>
 #ifdef ITIMER_REAL

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -13,9 +13,10 @@
 #if !(__FreeBSD__ || __APPLE__)
 /* On FreeBSD, defining this precludes the declaration of u_int, which
  * FreeBSD's own <sys/file.h> needs. */
-#if _XOPEN_SOURCE < 500
+#if !AC_BUILT && _XOPEN_SOURCE < 500
 #undef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 500 /* for fdopen(3), fileno(3), fsync(2), ftruncate(2) */
+#define _XPG6
 #endif
 #endif
 

--- a/src/signals.c
+++ b/src/signals.c
@@ -10,9 +10,10 @@
  * There's ABSOLUTELY NO WARRANTY, express or implied.
  */
 
-#if _XOPEN_SOURCE < 500
+#if !AC_BUILT && _XOPEN_SOURCE < 500
 #undef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 500 /* for setitimer(2) and siginterrupt(3) */
+#define _XPG6
 #endif
 
 #define NEED_OS_TIMER

--- a/src/unique.c
+++ b/src/unique.c
@@ -14,6 +14,7 @@
 #include "autoconfig.h"
 #else
 #define _POSIX_SOURCE /* for fdopen(3) */
+#define _XPG6
 #endif
 
 #include <stdio.h>

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -15,6 +15,7 @@
 #else
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE /* for fileno(3) and stat(2) */
+#define _XPG6
 #endif
 #endif
 


### PR DESCRIPTION
Tested on Solaris 10, 11, 32-bit OpenMP configure, 64-bit non-OpenMP legacy (four combinations). Hopefully, these improve portability elsewhere more than they break anything. Let's see what CI says.