### PR TITLE
loader.c bugfix: Be more picky about detecting pwdump format.

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -603,7 +603,8 @@ static int ldr_split_line(char **login, char **ciphertext,
 	if (SPLFLEN(1) > MAX_CIPHERTEXT_SIZE) {
 		huge_line = 1;
 	}
-	else if (SPLFLEN(2) == 32 || SPLFLEN(3) == 32) {
+	else if ((SPLFLEN(3) == 32 && strspn(fields[3], HEXCHARS_all) == 32) ||
+	         (SPLFLEN(2) == 32 && strspn(fields[2], HEXCHARS_all) == 32)) {
 		/* PWDUMP */
 		/* user:uid:LMhash:NThash:comment:homedir: */
 		*uid = fields[1];


### PR DESCRIPTION
Any uid or gid field of length 32 in an input file would result in --show=types outputting incorrect information because the line was then erroneously parsed as pwdump.

Not sure if there were other problems than just --show=types. The canonical hash field would still be correct, so perhaps not.