### PR TITLE
Assorted fixes and enhancements

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -419,7 +419,7 @@ AbortTemperature = 95
 SleepOnTemperature = 1
 
 # Enable a workaround for busy-waits, introducing calls to usleep(3).  This
-# currently only applies to nvidia (but not under macOS).
+# currently only applies to some formats on NVIDIA GPUs under Linux.
 AvoidBusyWait = Y
 
 [Options:OpenCL]

--- a/src/c3_fmt.c
+++ b/src/c3_fmt.c
@@ -442,8 +442,9 @@ static void *salt(char *ciphertext)
 		    !strncmp(ciphertext, "$md5,", 5))) {
 			char *p = strrchr(ciphertext + 4, '$');
 			if (p) {
-				strncpy_pad(out, ciphertext,
-				            ++p - ciphertext, 0);
+				/* NUL padding is required */
+				memset(out, 0, sizeof(out));
+				memcpy(out, ciphertext, ++p - ciphertext);
 /*
  * Workaround what looks like a bug in sunmd5.c: crypt_genhash_impl() where it
  * takes a different substring as salt depending on whether the optional

--- a/src/hmacMD5_fmt_plug.c
+++ b/src/hmacMD5_fmt_plug.c
@@ -233,8 +233,8 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 static int valid(char *ciphertext, struct fmt_main *self)
 {
-	int pos, i;
 	char *p;
+	int extra;
 
 	if (!strncmp(ciphertext, "$cram_md5$", 10)) {
 		char *f[10];
@@ -242,25 +242,13 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		ciphertext = prepare(f, self);
 	}
 
-	p = strrchr(ciphertext, '#'); // allow # in salt
+	p = strrchr(ciphertext, '#'); /* search backwards to allow '#' in salt */
 	if (!p)
 		return 0;
-
-	i = (int)(p - ciphertext);
-	if (i > SALT_LENGTH)
+	if (p - ciphertext > SALT_LENGTH)
 		return 0;
-
-	pos = i + 1;
-	if (strlen(ciphertext+pos) != BINARY_SIZE * 2)
+	if (hexlen(++p, &extra) != BINARY_SIZE * 2 || extra)
 		return 0;
-
-	for (i = pos; i < BINARY_SIZE*2+pos; i++) {
-		if (!((('0' <= ciphertext[i])&&(ciphertext[i] <= '9')) ||
-		      (('a' <= ciphertext[i])&&(ciphertext[i] <= 'f'))
-		      || (('A' <= ciphertext[i])&&(ciphertext[i] <= 'F'))))
-			return 0;
-	}
-
 	return 1;
 }
 

--- a/src/hmacSHA1_fmt_plug.c
+++ b/src/hmacSHA1_fmt_plug.c
@@ -162,26 +162,20 @@ static void done(void)
 
 static int valid(char *ciphertext, struct fmt_main *self)
 {
-	int pos, i;
 	char *p;
+	int extra;
 
-	p = strrchr(ciphertext, '#'); // allow # in salt
-	if (!p) return 0;
-	i = (int)(p - ciphertext);
+	p = strrchr(ciphertext, '#'); /* search backwards to allow '#' in salt */
+	if (!p)
+		return 0;
+	if (p - ciphertext > SALT_LENGTH)
+		return 0;
 #if SIMD_COEF_32
-	if (i > 55) return 0;
-#else
-	if (i > SALT_LENGTH) return 0;
+	if (p - ciphertext > 55)
+		return 0;
 #endif
-	pos = i + 1;
-	if (strlen(ciphertext+pos) != BINARY_SIZE * 2) return 0;
-	for (i = pos; i < BINARY_SIZE*2+pos; i++)
-	{
-		if (!((('0' <= ciphertext[i])&&(ciphertext[i] <= '9')) ||
-		        (('a' <= ciphertext[i])&&(ciphertext[i] <= 'f'))
-		        || (('A' <= ciphertext[i])&&(ciphertext[i] <= 'F'))))
-			return 0;
-	}
+	if (hexlen(++p, &extra) != BINARY_SIZE * 2 || extra)
+		return 0;
 	return 1;
 }
 

--- a/src/john.c
+++ b/src/john.c
@@ -1265,24 +1265,21 @@ static void john_load(void)
 		for ( ; i < FMT_TUNABLE_COSTS &&
 			      database.format->methods.tunable_cost_value[i] != NULL; i++) {
 			if (database.min_cost[i] < database.max_cost[i]) {
-				log_event("Loaded hashes with cost %d (%s)"
-				          " varying from %u to %u",
-				          i+1, database.format->params.tunable_cost_name[i],
+				const char *loaded = database.password_count < total ? "Remaining" : "Loaded";
+				log_event("%s hashes with cost %d (%s) varying from %u to %u",
+				          loaded, i+1, database.format->params.tunable_cost_name[i],
 				          database.min_cost[i], database.max_cost[i]);
-					printf("Loaded hashes with cost %d (%s)"
-					       " varying from %u to %u\n",
-					       i+1, database.format->params.tunable_cost_name[i],
-					        database.min_cost[i], database.max_cost[i]);
+				printf("%s hashes with cost %d (%s) varying from %u to %u\n",
+				       loaded, i+1, database.format->params.tunable_cost_name[i],
+				       database.min_cost[i], database.max_cost[i]);
 			}
 			else {	// if (database.min_cost[i] == database.max_cost[i]) {
-				log_event("Cost %d (%s) is %u for all loaded hashes",
-				          i+1, database.format->params.tunable_cost_name[i],
-				          database.min_cost[i]);
+				const char *loaded = database.password_count < total ? "remaining" : "loaded";
+				log_event("Cost %d (%s) is %u for all %s hashes",
+				          i+1, database.format->params.tunable_cost_name[i], database.min_cost[i], loaded);
 				if (options.verbosity >= VERB_DEFAULT)
-				printf("Cost %d (%s) is %u for all loaded "
-				       "hashes\n", i+1,
-				       database.format->params.tunable_cost_name[i],
-				       database.min_cost[i]);
+				printf("Cost %d (%s) is %u for all %s hashes\n",
+				       i+1, database.format->params.tunable_cost_name[i], database.min_cost[i], loaded);
 			}
 		}
 

--- a/src/john.c
+++ b/src/john.c
@@ -1239,12 +1239,14 @@ static void john_load(void)
 		if (database.password_count && options.regen_lost_salts)
 			build_fake_salts_for_regen_lost(&database);
 
-		if (john_main_process && database.password_count < total)
-			printf("Cracked %d password hashes%s%s%s, use \"--show\"\n",
-			    total - database.password_count,
-			    loaded_extra_pots ? "" : " (are in ",
+		if (john_main_process && database.password_count < total) {
+			int count = total - database.password_count;
+			printf("Cracked %d password hash%s%s%s%s, use \"--show\"\n",
+			    count, count != 1 ? "es" : "",
+			    loaded_extra_pots ? "" : (count != 1 ? " (are in " : " (is in "),
 			    loaded_extra_pots ? "" : path_expand(options.activepot),
 			    loaded_extra_pots ? "" : ")");
+		}
 
 		if (!database.password_count) {
 			log_discard();

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -2401,7 +2401,7 @@ int opencl_prepare_dev(int sequential_id)
 		ocl_always_show_ws = cfg_get_bool(SECTION_OPTIONS, SUBSECTION_OPENCL,
 		                                  "AlwaysShowWorksizes", 0);
 
-#ifndef __APPLE__
+#ifdef __linux__
 	if (gpu_nvidia(device_info[sequential_id])) {
 		opencl_avoid_busy_wait[sequential_id] = cfg_get_bool(SECTION_OPTIONS, SUBSECTION_GPU,
 		                                                     "AvoidBusyWait", 1);

--- a/src/yescrypt/CHANGES
+++ b/src/yescrypt/CHANGES
@@ -1,4 +1,11 @@
-	Changes made between 1.0.3 (2018/06/13) and 1.1.x (TBD).
+	Changes made since 1.1.0 (2019/06/30).
+
+Implemented a little-known SHA-2 Maj() optimization proposed by Wei Dai.
+
+Minor code cleanups and documentation updates.
+
+
+	Changes made between 1.0.3 (2018/06/13) and 1.1.0 (2019/06/30).
 
 Merged yescrypt-opt.c and yescrypt-simd.c into one source file, which is
 a closer match to -simd but is called -opt (and -simd is now gone).
@@ -9,6 +16,8 @@ architectures (this shortcoming may be addressed later).  This also
 happens to make SSE prefetch available even in otherwise-scalar builds
 and it paves the way for adding SIMD support on big-endian architectures
 (previously, -simd assumed little-endian).
+
+Added x32 ABI support (x86-64 with 32-bit pointers).
 
 
 	Changes made between 1.0.2 (2018/06/06) and 1.0.3 (2018/06/13).

--- a/src/yescrypt/COMPARISON
+++ b/src/yescrypt/COMPARISON
@@ -82,8 +82,8 @@ yescrypt's drawbacks:
 
  - Not the PHC winner (Argon2 is), but is merely a "special recognition"
 
- - Out of major third-party libraries, yescrypt is currently only
-   included in libxcrypt (part of Fedora 29 and above)
+ - Supported in fewer third-party projects (as of this writing, there's
+   yescrypt support in libxcrypt, Linux-PAM, shadow, and mkpasswd)
 
 Other observations:
 

--- a/src/yescrypt/README
+++ b/src/yescrypt/README
@@ -5,6 +5,11 @@ hashing scheme.  It builds upon Colin Percival's scrypt.  This
 implementation is able to compute native yescrypt hashes as well as
 classic scrypt.
 
+As of this writing, yescrypt is the default password hashing scheme on
+recent ALT Linux, Debian 11, Fedora 35+, Kali Linux 2021.1+, and Ubuntu
+22.04+.  It is also supported in Fedora 29+, RHEL 9+, and Ubuntu 20.04+,
+and is recommended for new passwords in Fedora CoreOS.
+
 
 	Why yescrypt?
 
@@ -87,9 +92,9 @@ yescrypt's advantages:
 yescrypt's drawbacks:
 
  - Complex
- - Cache-timing unsafe
- - Not the PHC winner
- - Not available in third-party libraries yet
+ - Cache-timing unsafe (like scrypt and Argon2d, but unlike Argon2i)
+ - Not the PHC winner (Argon2 is), but is merely a "special recognition"
+ - Supported in fewer third-party projects
 
 Please refer to COMPARISON for a lot more detail and other observations.
 
@@ -102,7 +107,7 @@ a separate project for the PoW use case: yespower.  Thus, rather than
 misuse yescrypt 1.0+ for PoW, those and other projects are advised to
 use yespower 1.0+ instead.  The yespower homepage is:
 
-    http://www.openwall.com/yespower/
+    https://www.openwall.com/yespower/
 
 
 	How to test yescrypt for proper operation.
@@ -183,7 +188,7 @@ yescrypt what it is:
 
 First, please check the yescrypt homepage for new versions, etc.:
 
-    http://www.openwall.com/yescrypt/
+    https://www.openwall.com/yescrypt/
 
 If you have anything valuable to add or a non-trivial question to ask,
 you may join and post to the yescrypt mailing list (referenced on the

--- a/src/yescrypt/insecure_memzero.h
+++ b/src/yescrypt/insecure_memzero.h
@@ -27,9 +27,6 @@
 #ifndef _INSECURE_MEMZERO_H_
 #define _INSECURE_MEMZERO_H_
 
-/* Force SKIP_MEMZERO for use in JtR */
-#define SKIP_MEMZERO
-
 #ifdef SKIP_MEMZERO
 #define insecure_memzero(buf, len) /* empty */
 #else

--- a/src/yescrypt/insecure_memzero.h
+++ b/src/yescrypt/insecure_memzero.h
@@ -27,6 +27,9 @@
 #ifndef _INSECURE_MEMZERO_H_
 #define _INSECURE_MEMZERO_H_
 
+/* Force SKIP_MEMZERO for use in JtR */
+#define SKIP_MEMZERO
+
 #ifdef SKIP_MEMZERO
 #define insecure_memzero(buf, len) /* empty */
 #else

--- a/src/yescrypt/sha256.c
+++ b/src/yescrypt/sha256.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright 2005-2016 Colin Percival
- * Copyright 2016-2018 Alexander Peslyak
+ * Copyright 2016-2018,2021 Alexander Peslyak
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -101,7 +101,11 @@ static const uint32_t Krnd[64] = {
 
 /* Elementary functions used by SHA256 */
 #define Ch(x, y, z)	((x & (y ^ z)) ^ z)
-#define Maj(x, y, z)	((x & (y | z)) | (y & z))
+#if 1 /* Explicit caching/reuse of common subexpression between rounds */
+#define Maj(x, y, z)	(y ^ ((x_xor_y = x ^ y) & y_xor_z))
+#else /* Let the compiler cache/reuse or not */
+#define Maj(x, y, z)	(y ^ ((x ^ y) & (y ^ z)))
+#endif
 #define SHR(x, n)	(x >> n)
 #define ROTR(x, n)	((x >> n) | (x << (32 - n)))
 #define S0(x)		(ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22))
@@ -113,7 +117,8 @@ static const uint32_t Krnd[64] = {
 #define RND(a, b, c, d, e, f, g, h, k)			\
 	h += S1(e) + Ch(e, f, g) + k;			\
 	d += h;						\
-	h += S0(a) + Maj(a, b, c);
+	h += S0(a) + Maj(a, b, c);			\
+	y_xor_z = x_xor_y;
 
 /* Adjusted round function for rotating state */
 #define RNDr(S, W, i, ii)			\
@@ -146,6 +151,7 @@ SHA256_Transform(uint32_t state[static restrict 8],
 
 	/* 3. Mix. */
 	for (i = 0; i < 64; i += 16) {
+		uint32_t x_xor_y, y_xor_z = S[(65 - i) % 8] ^ S[(66 - i) % 8];
 		RNDr(S, W, 0, i);
 		RNDr(S, W, 1, i);
 		RNDr(S, W, 2, i);

--- a/src/yescrypt/tests.c
+++ b/src/yescrypt/tests.c
@@ -314,7 +314,7 @@ int main(void)
 		rom_bytes = (uint64_t)r << (7 + NROM_log2);
 
 		N_log2 = 0;
-		while ((r << (7 + N_log2)) < ram_bytes)
+		while (((uint64_t)r << (7 + N_log2)) < ram_bytes)
 			N_log2++;
 		ram_bytes = (uint64_t)r << (7 + N_log2);
 
@@ -329,7 +329,7 @@ int main(void)
 		yescrypt_params_t rom_params = { YESCRYPT_DEFAULTS,
 		    0, r, YESCRYPT_PROM, 0, 0, (uint64_t)1 << NROM_log2 };
 		if (yescrypt_init_shared(&shared,
-		    (uint8_t *)"local param", 12, &rom_params)) {
+		    (const uint8_t *)"local param", 12, &rom_params)) {
 			puts(" FAILED");
 			return 1;
 		}
@@ -369,7 +369,7 @@ int main(void)
 		fflush(stdout);
 		rom_params.flags |= YESCRYPT_SHARED_PREALLOCATED;
 		if (yescrypt_init_shared(&shared,
-		    (uint8_t *)"local param", 12, &rom_params)) {
+		    (const uint8_t *)"local param", 12, &rom_params)) {
 			puts(" FAILED");
 			return 1;
 		}

--- a/src/yescrypt/yescrypt-common.c
+++ b/src/yescrypt/yescrypt-common.c
@@ -493,7 +493,7 @@ uint8_t *yescrypt_reencrypt(uint8_t *hash,
 	uint8_t *retval = NULL, *saltstart, *hashstart;
 	const uint8_t *hashend;
 	unsigned char saltbin[64], hashbin[32];
-	size_t saltstrlen, saltlen, hashlen;
+	size_t saltstrlen, saltlen = 0, hashlen;
 
 	if (strncmp((char *)hash, "$y$", 3))
 		return NULL;

--- a/src/yescrypt/yescrypt-opt.c
+++ b/src/yescrypt/yescrypt-opt.c
@@ -28,12 +28,16 @@
  * online backup system.
  */
 
+/* JtR hack: don't use OpenMP inside (ye)scrypt */
+#undef _OPENMP
+
 /*
  * AVX and especially XOP speed up Salsa20 a lot, but this mostly matters for
  * classic scrypt and for YESCRYPT_WORM (which use 8 rounds of Salsa20 per
  * sub-block), and much less so for YESCRYPT_RW (which uses 2 rounds of Salsa20
  * per block except during pwxform S-box initialization).
  */
+#if 0 /* JtR hack */
 #ifdef __XOP__
 #warning "Note: XOP is enabled.  That's great."
 #elif defined(__AVX__)
@@ -44,6 +48,7 @@
 #warning "SSE2 not enabled.  Expect poor performance."
 #else
 #warning "Note: building generic code for non-x86.  That's OK."
+#endif
 #endif
 
 /*
@@ -508,7 +513,9 @@ static volatile uint64_t Smask2var = Smask2;
 /* 64-bit without AVX.  This relies on out-of-order execution and register
  * renaming.  It may actually be fastest on CPUs with AVX(2) as well - e.g.,
  * it runs great on Haswell. */
+#if 0 /* JtR hack */
 #warning "Note: using x86-64 inline assembly for YESCRYPT_RW.  That's great."
+#endif
 /* We need a compiler memory barrier between sub-blocks to ensure that none of
  * the writes into what was S2 during processing of the previous sub-block are
  * postponed until after a read from S0 or S1 in the inline asm code below. */

--- a/src/yescrypt/yescrypt-opt.c
+++ b/src/yescrypt/yescrypt-opt.c
@@ -28,16 +28,12 @@
  * online backup system.
  */
 
-/* JtR hack: don't use OpenMP inside (ye)scrypt */
-#undef _OPENMP
-
 /*
  * AVX and especially XOP speed up Salsa20 a lot, but this mostly matters for
  * classic scrypt and for YESCRYPT_WORM (which use 8 rounds of Salsa20 per
  * sub-block), and much less so for YESCRYPT_RW (which uses 2 rounds of Salsa20
  * per block except during pwxform S-box initialization).
  */
-#if 0 /* FIXME */
 #ifdef __XOP__
 #warning "Note: XOP is enabled.  That's great."
 #elif defined(__AVX__)
@@ -49,7 +45,6 @@
 #else
 #warning "Note: building generic code for non-x86.  That's OK."
 #endif
-#endif /* 0 */
 
 /*
  * The SSE4 code version has fewer instructions than the generic SSE2 version,
@@ -513,9 +508,7 @@ static volatile uint64_t Smask2var = Smask2;
 /* 64-bit without AVX.  This relies on out-of-order execution and register
  * renaming.  It may actually be fastest on CPUs with AVX(2) as well - e.g.,
  * it runs great on Haswell. */
-#if 0 /* FIXME */
 #warning "Note: using x86-64 inline assembly for YESCRYPT_RW.  That's great."
-#endif
 /* We need a compiler memory barrier between sub-blocks to ensure that none of
  * the writes into what was S2 during processing of the previous sub-block are
  * postponed until after a read from S0 or S1 in the inline asm code below. */
@@ -1457,7 +1450,7 @@ int yescrypt_init_shared(yescrypt_shared_t *shared,
 	half2.aligned = (uint8_t *)half2.aligned + half1.aligned_size;
 
 	if (yescrypt_kdf(NULL, &half1,
-	    seed, seedlen, (uint8_t *)"yescrypt-ROMhash", 16, &subparams,
+	    seed, seedlen, (const uint8_t *)"yescrypt-ROMhash", 16, &subparams,
 	    salt, sizeof(salt)))
 		goto fail;
 

--- a/src/yescrypt/yescrypt-ref.c
+++ b/src/yescrypt/yescrypt-ref.c
@@ -830,7 +830,7 @@ int yescrypt_init_shared(yescrypt_shared_t *shared,
 	N /= 2;
 
 	if (yescrypt_kdf_body(NULL, &half1,
-	    seed, seedlen, (uint8_t *)"yescrypt-ROMhash", 16,
+	    seed, seedlen, (const uint8_t *)"yescrypt-ROMhash", 16,
 	    flags | YESCRYPT_INIT_SHARED, N, r, p, t, 0,
 	    salt, sizeof(salt)))
 		goto fail;


### PR DESCRIPTION
This improves messages printed by `john`, reduces HMAC-SHA256's false positive detections (#3993), adds explicit scrypt, yescrypt, gost-yescrypt support to the generic crypt(3) format and its uses by loader (#4622), and fixes a few issues with the generic crypt(3) format (I only separated one of those fixes into its own commit).