### PR TITLE
Update ssh2john.py

### DIFF
--- a/run/ssh2john.py
+++ b/run/ssh2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (C) 2012, Dhiru Kholia <dhiru@openwall.com>
 # Copyright (C) 2015, Dhiru Kholia <dhiru@openwall.com>


### PR DESCRIPTION
## Description
Almost all Linux distributions use Python as the default python3 binary. In the past, when Python 2 was the latest version, the Linux distros used Python as python2. However, in modern times, most Linux distributions simply create a symbolic link of python3 to Python in their OS.

So, in the context of ssh2john, the shebang of ssh2john is still set to `#!/usr/bin/env python`. As a result, the tool does not work on newer versions of Linux distros because it is created using python2.

We can easily fix this error by updating the tools shebang to python2

### Error Message:
```plaintext
Traceback (most recent call last):
  File "/usr/bin/ssh2john", line 193, in <module>
    read_private_key(filename)
  File "/usr/bin/ssh2john", line 103, in read_private_key
    data = base64.decodestring(data)
           ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'base64' has no attribute 'decodestring'