### PR TITLE
Minimum viable nix-shell with opencl support.

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -305,6 +305,7 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Added krb5tgs-sha1[-opencl] formats for etypes 17 and 18.  [magnum; 2023]
 
+- Added shell.nix with opencl support on AMD and Intel. [lambdajack; 2023]
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,57 @@
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted.
+# 
+# There's ABSOLUTELY NO WARRANTY, express or implied.
+# -------------------------------------------------------------------------------
+# Nix shells are used create development environments which provide the necessary 
+# tools/dependencies to develop/build software. The environment is typically 
+# declared in a shell.nix file in the softwares root directory. 
+# 
+# To create the nix-shell, run: `nix-shell ./shell.nix`.
+# 
+# This will place you in a development shell with the minimum required dependencies 
+# to build openwall/john with opencl support.
+#
+# NOTE: the 'Official OpenCL runtime for Intel CPUs' is unfree software and
+# therefore, when invoking this shell, nix will require the $NIXPKGS_ALLOW_UNFREE=1
+# environment variable to be set. If you wish to create your shell with free software 
+# only, then you can remove 'intel-ocl' entry from 'nativeBuildInputs' below. Please
+# note however if you are running and intel based system and remove intel-ocl then
+# you will not have opencl support when building openwall/john. For the avoidance of 
+# doubt, this file does not contain any unfree software.
+#
+# More information about Nixos: https://nixos.org/
+# More information about nix-shell: https://nixos.org/manual/nix/stable/command-ref/nix-shell.html
+#
+# Copyright Jack Bizzell (lambdajack) 2023
+
+{ pkgs ? import <nixpkgs> {} }:
+let
+	perlEnv = pkgs.perl.withPackages (p: with p; [
+		CompressRawLzma
+		DigestMD4 
+		DigestSHA1 
+		GetoptLong
+		perlldap
+	]);
+	pythonEnv = pkgs.python3.withPackages(p: with p; [
+		dpkt 
+		scapy 
+		lxml
+		wrapPython
+	]);
+in
+pkgs.mkShell {
+	nativeBuildInputs = with pkgs.buildPackages; 
+		[ 
+			openssl libzip rocm-opencl-runtime opencl-headers 
+			bzip2 libpcap libgmpris libxcrypt gmp intel-ocl
+			gcc zlib nss nspr libkrb5 re2 makeWrapper
+			perlEnv pythonEnv
+		];
+	shellHook = ''
+		export AS=$CC
+		export LD=$CC
+	'';
+}
+


### PR DESCRIPTION
Adding minimum viable `nix-shell` configuration for use in [Nix/Nixos](https://nixos.org/) with opencl support. The shell supports both AMD and Intel opencl implementations

NOTE: John is available directly through the nixos repository (https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/tools/security/john/default.nix#L85) however that implementation does not support opencl and limits custom building.

The following optional libraries/features are enabled in this shell:

```
Memory map (share/page large files) ................ yes
Fork support ....................................... yes
OpenMP support ..................................... yes (not for fast formats)
OpenCL support ..................................... yes
Generic crypt(3) format ............................ yes
OpenSSL (many additional formats) .................. yes
libgmp (PRINCE mode and faster SRP formats) ........ yes
128-bit integer (faster PRINCE mode) ............... yes
libz (7z, pkzip and some other formats) ............ yes
libbz2 (7z and gpg2john bz2 support) ............... yes
libpcap (vncpcap2john and SIPdump) ................. yes
Non-free unrar code (complete RAR support) ......... yes
librexgen (regex mode, see doc/README.librexgen) ... no
OpenMPI support (default disabled) ................. no
Experimental code (default disabled) ............... no
ZTEX USB-FPGA module 1.15y support ................. no

```

`./src/configure` and `make` tested in a `--pure` nix-shell, meaning it should be reproducible on any nixos installation. make compiles with no errors.

`./run/john --test` runs with no errors and expected opencl speeds.

This should serve as a 'good-enough' base for most requirements, while being a simple starting point for more advanced configuration when building in a nix environment.

`shell.nix` placed in the root directory as recommended by this nix wiki.