### PR TITLE
 Updated office2john.py for Python 3.10+ 

### DIFF
--- a/run/office2john.py
+++ b/run/office2john.py
@@ -2952,14 +2952,14 @@ def xml_metadata_parser(data, filename):
         if PY3:
             encryptedVerifierHashValue = binascii.hexlify(base64.decodebytes(encryptedVerifierHashValue.encode()))
         else:
-            encryptedVerifierHashValue = binascii.hexlify(base64.decodestring(encryptedVerifierHashValue.encode()))
+            encryptedVerifierHashValue = binascii.hexlify(base64.decodebytes(encryptedVerifierHashValue.encode()))
 
         if PY3:
             saltAscii = binascii.hexlify(base64.decodebytes(saltValue.encode())).decode("ascii")
             encryptedVerifierHashAscii = binascii.hexlify(base64.decodebytes(encryptedVerifierHashInput.encode())).decode("ascii")
         else:
-            saltAscii = binascii.hexlify(base64.decodestring(saltValue.encode())).decode("ascii")
-            encryptedVerifierHashAscii = binascii.hexlify(base64.decodestring(encryptedVerifierHashInput.encode())).decode("ascii")
+            saltAscii = binascii.hexlify(base64.decodebytes(saltValue.encode())).decode("ascii")
+            encryptedVerifierHashAscii = binascii.hexlify(base64.decodebytes(encryptedVerifierHashInput.encode())).decode("ascii")
 
         sys.stdout.write("%s:$office$*%d*%d*%d*%d*%s*%s*%s\n" % \
             (os.path.basename(filename), version,

--- a/run/office2john.py
+++ b/run/office2john.py
@@ -2921,7 +2921,7 @@ def xml_metadata_parser(data, filename):
     tree = ElementTree()
     tree.parse(data)
 
-    tree_iter = tree.iter if hasattr(ElementTree, 'iter') else tree.getiterator
+    tree_iter = tree.iter if hasattr(ElementTree, 'iter') else tree.iter
     for node in tree_iter('{http://schemas.microsoft.com/office/2006/keyEncryptor/password}encryptedKey'):
         spinCount = node.attrib.get("spinCount")
         assert(spinCount)


### PR DESCRIPTION
methods `getiterator` and `base64.decodestring` are depreciated and must be replaced. The suggested methods work on Python 3.9 , 3.10 and 3.11. Haven't tested other versions.

Closes #5371 