### PR TITLE
Further argon2-opencl GWS tuning

### DIFF
--- a/run/opencl/argon2_kernel.cl
+++ b/run/opencl/argon2_kernel.cl
@@ -415,9 +415,9 @@ __kernel void KERNEL_NAME(ARGON2_TYPE)(__global struct block_g* memory, uint pas
 	/* select job's memory region: */
 	memory += (size_t)job_id * lanes * lane_blocks;
 
+#if ARGON2_TYPE == ARGON2_I || ARGON2_TYPE == ARGON2_ID
 	uint thread_input = 0;
 
-#if ARGON2_TYPE == ARGON2_I || ARGON2_TYPE == ARGON2_ID
 	switch (thread) {
 	case 0:
 		thread_input = pass;

--- a/run/opencl/argon2_kernel.cl
+++ b/run/opencl/argon2_kernel.cl
@@ -97,6 +97,8 @@ ulong u64_shuffle(ulong v, uint thread_src, uint thread, __local ulong *buf)
 	// TODO: Test on other device types to add support
 #if !gpu_nvidia(DEVICE_INFO) && !gpu_amd(DEVICE_INFO)
 	barrier(CLK_LOCAL_MEM_FENCE);
+#elif gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR < 2500
+	asm("" ::: "memory");
 #endif
 	return buf[thread_src];
 #endif

--- a/src/bench.c
+++ b/src/bench.c
@@ -934,6 +934,7 @@ AGAIN:
 		 * low work sizes, we now need a proper auto-tune for benchmark, with
 		 * internal mask if applicable.
 		 */
+		benchmark_running = 1;
 		format->methods.reset(test_db);
 #endif
 		if ((result = benchmark_format(format, salts, &results_m, test_db))) {


### PR DESCRIPTION
This completes #5402 and while at it improves some messages that the format prints.

There's also a global change to set `benchmark_running` before calling `reset()`, so that formats can know when they're being reset for benchmarking. In here, this is used to disregard `p > 1` seen on some test vectors when choosing optimal GWS, because the test vectors we use for benchmarking are `p = 1`.