### PR TITLE
CI: Add (revised) GitHub Actions from passwdqc

### DIFF
--- a/.ci/install-dependencies.sh
+++ b/.ci/install-dependencies.sh
@@ -1,0 +1,86 @@
+#!/bin/sh -ex
+#
+# Copyright (c) 2018-2020 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+j=-j`nproc` || j=
+type sudo >/dev/null 2>&1 && sudo=sudo || sudo=
+common_packages='make libssl-dev'
+
+retry_if_failed()
+{
+	for i in `seq 0 99`; do
+		"$@" && i= && break || sleep 1
+	done
+	[ -z "$i" ]
+}
+
+updated=
+apt_get_install()
+{
+	[ -n "$updated" ] || {
+		retry_if_failed $sudo apt-get -qq update
+		updated=1
+	}
+	retry_if_failed $sudo \
+		apt-get -qq --no-install-suggests --no-install-recommends \
+		install -y "$@"
+}
+
+git_installed=
+clone_repo()
+{
+	local src dst branch
+	src="$1"; shift
+	dst="$1"; shift
+	branch="${1-}"
+
+	[ -n "$git_installed" ] || {
+		apt_get_install git ca-certificates
+		git_installed=1
+	}
+
+	case "$src" in
+		*://*)	;;
+		*)	local url path
+			url="$(git config remote.origin.url)"
+			path="${url#*://*/}"
+			src="${url%$path}$src"
+			;;
+	esac
+
+	retry_if_failed \
+		git clone --depth=1 ${branch:+--branch $branch} "$src" "$dst"
+}
+
+case "$TARGET" in
+	x32|x86)
+		packages="$common_packages gcc-multilib"
+		;;
+	*)
+		packages="$common_packages gcc"
+		;;
+esac
+
+case "$CC" in
+	gcc-*)
+		retry_if_failed \
+			$sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+		case "$TARGET" in
+			x32|x86)
+				apt_get_install $packages "$CC"-multilib "$CC"
+				;;
+			*)
+				apt_get_install $packages "$CC"
+				;;
+		esac
+		;;
+	clang*)
+		apt_get_install $packages "$CC"
+		;;
+	*)
+		apt_get_install $packages
+		;;
+esac

--- a/.ci/run-build-and-tests.sh
+++ b/.ci/run-build-and-tests.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -ex
+#
+# Copyright (c) 2018-2020 The strace developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+case "${TARGET-}" in
+	x32)
+		CC="$CC -mx32"
+		;;
+	x86)
+		CC="$CC -m32"
+		;;
+esac
+
+echo 'BEGIN OF BUILD ENVIRONMENT INFORMATION'
+uname -a |head -1
+libc="$(ldd /bin/sh |sed -n 's|^[^/]*\(/[^ ]*/libc\.so[^ ]*\).*|\1|p' |head -1)"
+$libc |head -1
+file -L /bin/sh
+$CC --version |head -1
+$CC -print-multi-lib ||:
+make --version |head -1
+kver="$(printf '%s\n%s\n' '#include <linux/version.h>' 'LINUX_VERSION_CODE' | $CC $CPPFLAGS -E -P -)"
+printf 'kernel-headers %s.%s.%s\n' $(($kver/65536)) $(($kver/256%256)) $(($kver%256))
+echo 'END OF BUILD ENVIRONMENT INFORMATION'
+
+nproc="$(nproc)" || nproc=1
+j="-j$nproc"
+
+cd src
+time ./configure
+time make $j
+time make $j check
+
+if git status --porcelain |grep ^.; then
+	echo >&2 'git status reported uncleanness'
+	exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,207 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+#  whitespace-errors:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v3
+#    - name: check
+#      run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+
+  gcc13-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  gcc12-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-12
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  gcc11-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-11
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  gcc10-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-10
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  gcc9-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  gcc8-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc-8
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  clang15-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang-15
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  clang14-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang-14
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  clang13-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  clang12-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: clang-12
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  clang11-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: clang-11
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  clang10-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: clang
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  clang9-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: clang-9
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh
+
+  clang8-x86_64:
+    runs-on: ubuntu-20.04
+    env:
+      CC: clang-8
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh


### PR DESCRIPTION
This is untested. Theoretically, it should give us many build tests via GitHub Actions. It should also fail the trailing whitespace test badly, because we have lots of that.