### PR TITLE
Fuzzer and CI enhancements, format bug fixes

### DIFF
--- a/.ci/install-dependencies.sh
+++ b/.ci/install-dependencies.sh
@@ -7,7 +7,7 @@
 
 j=-j`nproc` || j=
 type sudo >/dev/null 2>&1 && sudo=sudo || sudo=
-common_packages='make libssl-dev'
+common_packages='make libssl-dev libpcap-dev'
 
 retry_if_failed()
 {

--- a/.ci/run-build-and-tests.sh
+++ b/.ci/run-build-and-tests.sh
@@ -29,6 +29,10 @@ echo 'END OF BUILD ENVIRONMENT INFORMATION'
 nproc="$(nproc)" || nproc=1
 j="-j$nproc"
 
+if [ $nproc -gt 2 ]; then
+	export OMP_NUM_THREADS=2
+fi
+
 cd src
 time ./configure $*
 time make $j

--- a/.ci/run-build-and-tests.sh
+++ b/.ci/run-build-and-tests.sh
@@ -30,9 +30,12 @@ nproc="$(nproc)" || nproc=1
 j="-j$nproc"
 
 cd src
-time ./configure
+time ./configure $*
 time make $j
 time make $j check
+if [ "$1" = "--enable-fuzz" ]; then
+	time ../run/john --fuzz=500
+fi
 
 if git status --porcelain |grep ^.; then
 	echo >&2 'git status reported uncleanness'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -33,8 +31,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -47,8 +43,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -61,8 +55,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -75,8 +67,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -89,8 +79,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -103,8 +91,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -117,8 +103,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -131,8 +115,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -145,8 +127,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -159,8 +139,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -173,8 +151,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -187,8 +163,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check
@@ -201,8 +175,6 @@ jobs:
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: install dependencies
       run: .ci/install-dependencies.sh
     - name: build check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
     - name: build check
       run: .ci/run-build-and-tests.sh --enable-fuzz --enable-asan
 
+  asan-disable-all:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --enable-asan --disable-openmp --disable-simd --without-openssl
+
   asan-disable-openmp:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,18 @@ jobs:
     - name: check
       run: git diff-index --check --cached b1b622f691d40196815939e4736a5da71befd206
 
+  asan:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --enable-fuzz --enable-asan
+
   gcc13-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,66 @@ jobs:
     - name: build check
       run: .ci/run-build-and-tests.sh --enable-fuzz --enable-asan
 
+  asan-disable-openmp:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --enable-asan --disable-openmp
+
+  asan-without-openssl:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --enable-asan --without-openssl
+
+  asan-disable-simd:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --enable-asan --disable-simd
+
+  asan-sse2:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --enable-asan --enable-simd=sse2
+
+  asan-avx:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --enable-asan --enable-simd=avx
+
   gcc13-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,30 @@ jobs:
     - name: build check
       run: .ci/run-build-and-tests.sh --enable-asan --enable-simd=avx
 
+  gcc13-x86-without-openssl:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --without-openssl
+
+  gcc13-x86-disable-all:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-13
+      TARGET: x86
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: .ci/install-dependencies.sh
+    - name: build check
+      run: .ci/run-build-and-tests.sh --disable-openmp --disable-simd --without-openssl
+
   gcc13-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/src/blockchain_common_plug.c
+++ b/src/blockchain_common_plug.c
@@ -118,9 +118,9 @@ int blockchain_decrypt(unsigned char *derived_key, unsigned char *data)
 
 	// "guid" will be found in the first block
 	if (memmem(out, 16, "\"guid\"", 6)) {
-		AES_cbc_encrypt(data + 32, out + 16, SAFETY_FACTOR - 16, &akey, iv,
+		AES_cbc_encrypt(data + 32, out + 16, SAFETY_FACTOR - 32, &akey, iv,
 		                AES_DECRYPT);
-		if (memmem(out, SAFETY_FACTOR, "\"sharedKey\"", 11))
+		if (memmem(out, SAFETY_FACTOR - 16, "\"sharedKey\"", 11))
 			// Do not check for "options" string. It is too further
 			// down in the byte stream for v3 wallets.  Note, we
 			// 'could' check that the guid and sharedKey values are

--- a/src/options.c
+++ b/src/options.c
@@ -248,7 +248,7 @@ static struct opt_entry opt_list[] = {
 
 #ifdef HAVE_FUZZ
 #define FUZZ_USAGE \
-"--fuzz[=DICTFILE]          Fuzz formats' prepare(), valid() and split()\n" \
+"--fuzz[=DICTFILE|LIMIT]    Fuzz formats' prepare(), valid() and split()\n" \
 "--fuzz-dump[=FROM,TO]      Dump the fuzzed hashes between FROM and TO to file\n" \
 "                           pwfile.format\n"
 #else

--- a/src/sapB_fmt_plug.c
+++ b/src/sapB_fmt_plug.c
@@ -661,7 +661,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			keyLen[t] = strlen(saved_plain[t]);
 
 			// Back-out of trailing spaces
-			while ( saved_plain[t][keyLen[t] - 1] == ' ' )
+			while ( keyLen[t] && saved_plain[t][keyLen[t] - 1] == ' ' )
 			{
 				if (keyLen[t] == 0) break;
 				saved_plain[t][--keyLen[t]] = 0;

--- a/src/sapG_fmt_plug.c
+++ b/src/sapG_fmt_plug.c
@@ -666,7 +666,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			keyLen[index] = strlen((char*)saved_key[index]);
 
 			// Back-out of trailing spaces
-			while (saved_key[index][keyLen[index] - 1] == ' ') {
+			while (keyLen[index] && saved_key[index][keyLen[index] - 1] == ' ') {
 				saved_key[index][--keyLen[index]] = 0;
 				if (keyLen[index] == 0) break;
 			}

--- a/src/vmx_fmt_plug.c
+++ b/src/vmx_fmt_plug.c
@@ -91,13 +91,13 @@ static char *get_key(int index)
 
 static int vmx_decrypt(struct custom_salt *cur_salt, unsigned char *key, unsigned char *data)
 {
-	unsigned char out[BLOBLEN];
+	unsigned char out[16];
 	unsigned char ivec[16];
 	AES_KEY aes_decrypt_key;
 
 	memcpy(ivec, data, 16);
 	AES_set_decrypt_key(key, 256, &aes_decrypt_key);
-	AES_cbc_encrypt(cur_salt->blob + 16, out, BLOBLEN - 16, &aes_decrypt_key, ivec, AES_DECRYPT);
+	AES_cbc_encrypt(cur_salt->blob + 16, out, 16, &aes_decrypt_key, ivec, AES_DECRYPT);
 
 	return memcmp(out, "type=key:cipher=", 16) == 0;
 }


### PR DESCRIPTION
This adds support for `--fuzz=LIMIT`, where `LIMIT` is a decimal number specifying the maximum number of mangled ciphertexts to try per format. Since we had already supported an argument to that option to specify a "dictionary", I had to add a check for `isdec` and support both features (one at a time). This is a hack, but this whole feature is (and it is not compiled in by default), so it's "fine".

This also adds a number of GitHub Actions, which build with ASan and varying other options. One of them even runs `--fuzz=500`, which takes under a minute and fits 2 GB RAM. All of them use gcc 13. To reduce load on the CI infrastructure and have all of these jobs complete sooner, `OMP_NUM_THREADS` is now capped to 2, which is hopefully enough to have a good chance of catching multithreading-related bugs. Previously, the auto-detected number of threads on GitHub Actions would be 4, and tests were taking significantly longer (I guess those are logical CPUs in 2 cores).

Finally, the `--disable-simd` and `--without-openssl` ASan workers (under my personal GitHub account) identified some bugs in the formats, which are now fixed.