### PR TITLE
argon2-opencl fix for macOS

### DIFF
--- a/run/opencl/argon2_kernel.cl
+++ b/run/opencl/argon2_kernel.cl
@@ -68,7 +68,7 @@ ulong u64_shuffle_warp(ulong v, uint thread_src)
 ulong u64_shuffle(ulong v, uint thread_src, uint thread, __local ulong *buf)
 #endif
 {
-#if USE_WARP_SHUFFLE && gpu_nvidia(DEVICE_INFO) && SM_MAJOR >= 3
+#if USE_WARP_SHUFFLE && !__OS_X__ && gpu_nvidia(DEVICE_INFO) && SM_MAJOR >= 3
 	ulong result;
 
 	asm("{\n\t"
@@ -97,7 +97,7 @@ ulong u64_shuffle(ulong v, uint thread_src, uint thread, __local ulong *buf)
 	// TODO: Test on other device types to add support
 #if !gpu_nvidia(DEVICE_INFO) && !gpu_amd(DEVICE_INFO)
 	barrier(CLK_LOCAL_MEM_FENCE);
-#elif gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR < 2500
+#elif !__OS_X__ && gpu_amd(DEVICE_INFO) && DEV_VER_MAJOR < 2500
 	asm("" ::: "memory");
 #endif
 	return buf[thread_src];


### PR DESCRIPTION
The Apple driver doesn't let us use inline assembler.

With this patch:
```
Device 3: AMD Radeon Pro Vega 20 Compute Engine
Benchmarking: argon2-opencl [Blake2 OpenCL]... |
Trying to compute 62 hashes at a time using 992 of 4080 MiB device memory
LWS=[64-192] GWS=[1984-5952] ([10-93] blocks) => Mode: LOCAL_MEMORY
DONE
Speed for cost 1 (t) of 3, cost 2 (m) of 4096, cost 3 (p) of 1, cost 4 (type [0:Argon2d 1:Argon2i 2:Argon2id]) of 0 and 1
Raw:	1099 c/s real, 15942 c/s virtual
```

There are other problems I haven't looked into yet, with other devices:
```
Device 1: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Testing: argon2-opencl [Blake2 OpenCL]... 0: OpenCL CL_INVALID_BUFFER_SIZE (-61) error in opencl_argon2_fmt_plug.c:608 - Error creating memory buffer
```
```
Device 2: Intel(R) UHD Graphics 630
Testing: argon2-opencl [Blake2 OpenCL]... Binary Build log: <program source>:68:7: warning: no previous prototype for function 'u64_shuffle'
ulong u64_shuffle(ulong v, uint thread_src, uint thread, __local ulong *buf)
      ^
<program source>:115:7: warning: no previous prototype for function 'block_th_get'
ulong block_th_get(const struct block_th *b, uint idx)
      ^
<program source>:125:6: warning: no previous prototype for function 'block_th_set'
void block_th_set(struct block_th *b, uint idx, ulong v)
     ^
<program source>:133:7: warning: no previous prototype for function 'mul_wide_u32'
ulong mul_wide_u32(ulong a, ulong b)
      ^
<program source>:149:6: warning: no previous prototype for function 'g'
void g(struct block_th *block)
     ^
<program source>:171:6: warning: no previous prototype for function 'apply_shuffle_shift2'
uint apply_shuffle_shift2(uint thread, uint idx)
     ^
<program source>:182:6: warning: no previous prototype for function 'shuffle_block'
void shuffle_block(struct block_th *block, uint thread, __local ulong *buf)
     ^
<program source>:260:6: warning: no previous prototype for function 'next_addresses'
void next_addresses(struct block_th *addr, uint thread_input, uint thread, __local ulong *buf)
     ^
<program source>:295:6: warning: no previous prototype for function 'blake2b_block'
void blake2b_block(ulong m[16], ulong out_len, ulong message_size)
     ^

FAILED (cmp_one(10))
```