### PR TITLE
Specialize SIMD SHA-512 for half-length input, iterated hashing

### DIFF
--- a/run/relbench
+++ b/run/relbench
@@ -42,19 +42,18 @@ sub parse
 		return;
 	}
 
-	if (/^(All|\d+ out of) \d+ (tests|formats)( have)? (passed self-tests|FAILED)/) {
-		($total) = /^All (\d+) (tests|formats)( have)? passed self-tests/;
-		if (!defined($total)) {
+	if (/^(|All |\d+ out of )\d+ (tests|formats)( have)? (benchmarked|passed self-tests|FAILED)/) {
+		($total) = /^(|All )(\d+) (tests|formats)( have)? (benchmarked|passed self-tests)/;
+		if (defined($total)) {
+			$failed = 0;
+		} else {
 			($failed, $total) =
 			    /^(\d+) out of (\d+) (tests|formats)( have)? FAILED/;
 		}
 		return;
 	}
-	return if /Benchmarking: .*\.\.\. FAILED/;
+	return if /Benchmarking: .*\.\.\. FAILED|^Speed for cost |^Warning: /;
 
-	if (/^Speed for cost /) {
-		return;
-	}
 	my $ok = 0;
 	if (defined($name)) {
 		($kind, $real, $reals, $virtual, $virtuals) =
@@ -71,9 +70,12 @@ sub parse
 			$id = $name . ':' . $kind;
 			$real *= 1000 if ($reals eq 'K');
 			$real *= 1000000 if ($reals eq 'M');
+			$real *= 1000000000 if ($reals eq 'G');
+			$real = 0.001 if ($real eq "0.0" || $real eq "0.00");
 			$virtual *= 1000 if ($virtuals eq 'K');
 			$virtual *= 1000000 if ($virtuals eq 'M');
-			$virtual = 0.001 if $virtual eq "0.0";
+			$virtual *= 1000000000 if ($virtuals eq 'G');
+			$virtual = 0.001 if ($virtual eq "0.0" || $virtual eq "0.00");
 			return;
 		}
 	} else {

--- a/src/armory_fmt_plug.c
+++ b/src/armory_fmt_plug.c
@@ -276,7 +276,7 @@ static int derive_keys(region_t *memory, int index, derived_key *dk)
 #define DO8 DO(0) DO(1) DO(2) DO(3) DO(4) DO(5) DO(6) DO(7)
 
 #ifdef SIMD_COEF_64
-		JTR_ALIGN(64) uint64_t x[16][MIN_KEYS_PER_CRYPT];
+		JTR_ALIGN(64) uint64_t x[8][MIN_KEYS_PER_CRYPT];
 		for (subindex = 0; subindex < MIN_KEYS_PER_CRYPT; subindex++) {
 			uint32_t k;
 			for (k = 0; k < 8; k++)

--- a/src/armory_fmt_plug.c
+++ b/src/armory_fmt_plug.c
@@ -311,7 +311,7 @@ static int derive_keys(region_t *memory, int index, derived_key *dk)
 			if (++p >= &lut[n])
 				break;
 
-			SIMDSHA512body(x, x[0], NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+			SIMDSHA512body(x, x[0], NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
 		} while (1);
 
 		uint32_t j = n >> 1;
@@ -326,7 +326,7 @@ static int derive_keys(region_t *memory, int index, derived_key *dk)
 #undef DO
 			}
 
-			SIMDSHA512body(x, x[0], NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+			SIMDSHA512body(x, x[0], NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
 		} while (--j);
 
 		for (subindex = 0; subindex < MIN_KEYS_PER_CRYPT; subindex++) {

--- a/src/armory_fmt_plug.c
+++ b/src/armory_fmt_plug.c
@@ -41,9 +41,10 @@ john_register_one(&fmt_armory);
 #define FORMAT_TAG_LEN			(sizeof(FORMAT_TAG) - 1)
 #define FORMAT_NAME			"Armory wallet"
 
-#ifdef SIMD_COEF_64
+#if defined(SIMD_COEF_64) && SIMD_PARA_SHA512 == 1
 #define ALGORITHM_NAME			"SHA512/AES/secp256k1/SHA256/RIPEMD160 " SHA512_ALGORITHM_NAME
 #else
+#undef SIMD_COEF_64
 #define ALGORITHM_NAME			"SHA512/AES/secp256k1/SHA256/RIPEMD160 " ARCH_BITS_STR "/" ARCH_BITS_STR
 #endif
 
@@ -297,7 +298,7 @@ static int derive_keys(region_t *memory, int index, derived_key *dk)
 #undef DO
 			}
 
-			SIMDSHA512body(x, x[0], NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
+			SIMDSHA512body(x, x[0], NULL, SSEi_HALF_IN);
 		} while (--j);
 
 		for (subindex = 0; subindex < MIN_KEYS_PER_CRYPT; subindex++) {

--- a/src/bench.c
+++ b/src/bench.c
@@ -941,7 +941,7 @@ AGAIN:
 #endif
 		if ((result = benchmark_format(format, salts, &results_m, test_db))) {
 			puts(result);
-			failed++;
+			failed += !event_abort;
 			goto next;
 		}
 #if HAVE_OPENCL
@@ -1096,15 +1096,17 @@ next:
 		opencl_was_skipped = " (OpenCL formats skipped)";
 #endif
 
-	if (failed && total > 1 && !event_abort)
+	if (failed && total > 1)
 		printf("%u out of %u tests have FAILED%s\n", failed, total, opencl_was_skipped);
-	else if (total > 1 && !event_abort && john_main_process) {
+	else if (total > 1 && john_main_process) {
+		const char *all = event_abort ? "" : "All ";
+		const char *not = event_abort ? ", last one aborted" : "";
 #ifndef BENCH_BUILD
 		if (benchmark_time)
-			printf("%u formats benchmarked%s.\n", total, opencl_was_skipped);
+			printf("%s%u formats benchmarked%s%s\n", all, total, not, opencl_was_skipped);
 		else
 #endif
-			printf("All %u formats passed self-tests%s!\n", total, opencl_was_skipped);
+			printf("%s%u formats passed self-tests%s\n", all, total, opencl_was_skipped);
 	}
 
 #ifndef BENCH_BUILD

--- a/src/bench.c
+++ b/src/bench.c
@@ -632,9 +632,12 @@ void benchmark_cps(uint64_t crypts, clock_t time, char *buffer)
 		sprintf(buffer, "%uK", (unsigned int)cps / 1000);
 	} else if (cps >= 100) {
 		sprintf(buffer, "%u", (unsigned int)cps);
-	} else {
+	} else if (cps >= 10) {
 		unsigned int frac = crypts * clk_tck * 10 / time % 10;
 		sprintf(buffer, "%u.%u", (unsigned int)cps, frac);
+	} else {
+		unsigned int frac = crypts * clk_tck * 100 / time % 100;
+		sprintf(buffer, "%u.%02u", (unsigned int)cps, frac);
 	}
 }
 

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -299,8 +299,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			key_iv[15*SIMD_COEF_64 + (index2&(SIMD_COEF_64-1)) + index2/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64] = (SHA512_DIGEST_LENGTH << 3);
 		}
 
-		for (i = 1; i < cur_salt->cry_rounds; i++)  // start at 1; the first iteration is already done
-			SIMDSHA512body(key_iv, key_iv, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
+		// the first iteration is already done above
+		uint64_t rounds = cur_salt->cry_rounds - 1;
+		SIMDSHA512body(key_iv, key_iv, &rounds, SSEi_HALF_IN|SSEi_LOOP);
 
 		for (index2 = 0; index2 < MIN_KEYS_PER_CRYPT; index2++) {
 			AES_KEY aes_key;

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -287,16 +287,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			for (i = 0; i < SHA512_DIGEST_LENGTH/sizeof(uint64_t); ++i) {
 				key_iv[SIMD_COEF_64*i + (index2&(SIMD_COEF_64-1)) + index2/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64] = sha_ctx.h[i];
 			}
-
-			// We need to set ONE time, the upper half of the data buffer.  We put the 0x80 byte (in BE format), at offset
-			// 512-bits (SHA512_DIGEST_LENGTH) multiplied by the SIMD_COEF_64 (same as MIN_KEYS_PER_CRYPT), then zero
-			// out the rest of the buffer, putting 512 (#bits) at the end.  Once this part of the buffer is set up, we never
-			// touch it again, for the rest of the crypt.  We simply overwrite the first half of this buffer, over and over
-			// again, with BE results of the prior hash.
-			key_iv[ SHA512_DIGEST_LENGTH/sizeof(uint64_t) * SIMD_COEF_64 + (index2&(SIMD_COEF_64-1)) + index2/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64 ] = 0x8000000000000000ULL;
-			for (i = (SHA512_DIGEST_LENGTH/sizeof(uint64_t)+1); i < 15; i++)
-				key_iv[i*SIMD_COEF_64 + (index2&(SIMD_COEF_64-1)) + index2/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64] = 0;
-			key_iv[15*SIMD_COEF_64 + (index2&(SIMD_COEF_64-1)) + index2/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64] = (SHA512_DIGEST_LENGTH << 3);
 		}
 
 		// the first iteration is already done above

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -271,6 +271,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		int i;
 
 #ifdef SIMD_COEF_64
+/* We use SSEi_HALF_IN, so can halve SHA_BUF_SIZ */
+#undef SHA_BUF_SIZ
+#define SHA_BUF_SIZ 8
 		char unaligned_buf[MIN_KEYS_PER_CRYPT*SHA_BUF_SIZ*sizeof(uint64_t)+MEM_ALIGN_SIMD];
 		uint64_t *key_iv = (uint64_t*)mem_align(unaligned_buf, MEM_ALIGN_SIMD);
 		JTR_ALIGN(8)  unsigned char hash1[SHA512_DIGEST_LENGTH];            // 512 bits

--- a/src/bitcoin_fmt_plug.c
+++ b/src/bitcoin_fmt_plug.c
@@ -300,7 +300,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		}
 
 		for (i = 1; i < cur_salt->cry_rounds; i++)  // start at 1; the first iteration is already done
-			SIMDSHA512body(key_iv, key_iv, NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+			SIMDSHA512body(key_iv, key_iv, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
 
 		for (index2 = 0; index2 < MIN_KEYS_PER_CRYPT; index2++) {
 			AES_KEY aes_key;

--- a/src/blackberry_ES10_fmt_plug.c
+++ b/src/blackberry_ES10_fmt_plug.c
@@ -206,8 +206,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			p64[15*SIMD_COEF_64] = 0x200;
 		}
 		for (j = 0; j < 98; j++)
-			SIMDSHA512body(keys, keys64, NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
-		SIMDSHA512body(keys, (uint64_t*)crypt_out[index], NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT|SSEi_FLAT_OUT);
+			SIMDSHA512body(keys, keys64, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
+		SIMDSHA512body(keys, (uint64_t*)crypt_out[index], NULL, SSEi_HALF_IN|SSEi_FLAT_OUT);
 #else
 		SHA512_Init(&ctx);
 		SHA512_Update(&ctx, saved_key[index], strlen(saved_key[index]));

--- a/src/blackberry_ES10_fmt_plug.c
+++ b/src/blackberry_ES10_fmt_plug.c
@@ -205,8 +205,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			p64[8*SIMD_COEF_64] = 0x8000000000000000ULL;
 			p64[15*SIMD_COEF_64] = 0x200;
 		}
-		for (j = 0; j < 98; j++)
-			SIMDSHA512body(keys, keys64, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
+		uint64_t rounds = 98;
+		SIMDSHA512body(keys, keys64, &rounds, SSEi_HALF_IN|SSEi_LOOP);
 		SIMDSHA512body(keys, (uint64_t*)crypt_out[index], NULL, SSEi_HALF_IN|SSEi_FLAT_OUT);
 #else
 		SHA512_Init(&ctx);

--- a/src/blackberry_ES10_fmt_plug.c
+++ b/src/blackberry_ES10_fmt_plug.c
@@ -188,7 +188,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		uint64_t *keys64, *tmpBuf64=(uint64_t*)tmpBuf, *p64;
 		keys = (unsigned char*)mem_align(_IBuf, MEM_ALIGN_CACHE);
 		keys64 = (uint64_t*)keys;
-		memset(keys, 0, 128*MIN_KEYS_PER_CRYPT);
 
 		for (i = 0; i < MIN_KEYS_PER_CRYPT; ++i) {
 			SHA512_Init(&ctx);
@@ -202,8 +201,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #else
 				p64[j*SIMD_COEF_64] = tmpBuf64[j];
 #endif
-			p64[8*SIMD_COEF_64] = 0x8000000000000000ULL;
-			p64[15*SIMD_COEF_64] = 0x200;
 		}
 		uint64_t rounds = 98;
 		SIMDSHA512body(keys, keys64, &rounds, SSEi_HALF_IN|SSEi_LOOP);

--- a/src/ecryptfs_fmt_plug.c
+++ b/src/ecryptfs_fmt_plug.c
@@ -211,7 +211,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 		keys = (unsigned char*)mem_align(_IBuf, MEM_ALIGN_CACHE);
 		keys64 = (uint64_t*)keys;
-		memset(keys, 0, 128*MIN_KEYS_PER_CRYPT);
 
 		for (i = 0; i < MIN_KEYS_PER_CRYPT; ++i) {
 			SHA512_Init(&ctx);
@@ -220,14 +219,11 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			SHA512_Final((unsigned char *)tmpBuf, &ctx);
 			for (j = 0; j < 64; ++j)
 				keys[GETPOS_512(j, i)] = tmpBuf[j];
-			keys[GETPOS_512(j, i)] = 0x80;
-			// 64 bytes of crypt data (0x200 bits).
-			keys[GETPOS_512(126, i)] = 0x02;
 		}
 		uint64_t rounds = ECRYPTFS_DEFAULT_NUM_HASH_ITERATIONS - 1;
 		SIMDSHA512body(keys, keys64, &rounds, SSEi_HALF_IN|SSEi_LOOP);
 		// Last one with FLAT_OUT
-		SIMDSHA512body(keys, (uint64_t*)crypt_out[index], NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT|SSEi_FLAT_OUT);
+		SIMDSHA512body(keys, (uint64_t*)crypt_out[index], NULL, SSEi_HALF_IN|SSEi_FLAT_OUT);
 #else
 		SHA512_Init(&ctx);
 		SHA512_Update(&ctx, cur_salt->salt, ECRYPTFS_SALT_SIZE);

--- a/src/ecryptfs_fmt_plug.c
+++ b/src/ecryptfs_fmt_plug.c
@@ -57,6 +57,9 @@ john_register_one(&fmt_ecryptfs1);
 #ifdef SIMD_COEF_64
 #define MIN_KEYS_PER_CRYPT      (SIMD_COEF_64*SIMD_PARA_SHA512)
 #define MAX_KEYS_PER_CRYPT      (SIMD_COEF_64*SIMD_PARA_SHA512 * 2)
+/* We use SSEi_HALF_IN, so can halve SHA_BUF_SIZ */
+#undef SHA_BUF_SIZ
+#define SHA_BUF_SIZ 8
 #if ARCH_LITTLE_ENDIAN==1
 #define GETPOS_512(i, index)    ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64 *8 )
 #else
@@ -206,7 +209,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #ifdef SIMD_COEF_64
 		unsigned char tmpBuf[64];
 		unsigned int i;
-		unsigned char _IBuf[128*MIN_KEYS_PER_CRYPT+MEM_ALIGN_CACHE], *keys;
+		unsigned char _IBuf[8*SHA_BUF_SIZ*MIN_KEYS_PER_CRYPT+MEM_ALIGN_CACHE], *keys;
 		uint64_t *keys64;
 
 		keys = (unsigned char*)mem_align(_IBuf, MEM_ALIGN_CACHE);

--- a/src/ecryptfs_fmt_plug.c
+++ b/src/ecryptfs_fmt_plug.c
@@ -225,9 +225,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			keys[GETPOS_512(126, i)] = 0x02;
 		}
 		for (j = 1; j < ECRYPTFS_DEFAULT_NUM_HASH_ITERATIONS; j++)
-			SIMDSHA512body(keys, keys64, NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+			SIMDSHA512body(keys, keys64, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
 		// Last one with FLAT_OUT
-		SIMDSHA512body(keys, (uint64_t*)crypt_out[index], NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT|SSEi_FLAT_OUT);
+		SIMDSHA512body(keys, (uint64_t*)crypt_out[index], NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT|SSEi_FLAT_OUT);
 #else
 		SHA512_Init(&ctx);
 		SHA512_Update(&ctx, cur_salt->salt, ECRYPTFS_SALT_SIZE);

--- a/src/ecryptfs_fmt_plug.c
+++ b/src/ecryptfs_fmt_plug.c
@@ -224,8 +224,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			// 64 bytes of crypt data (0x200 bits).
 			keys[GETPOS_512(126, i)] = 0x02;
 		}
-		for (j = 1; j < ECRYPTFS_DEFAULT_NUM_HASH_ITERATIONS; j++)
-			SIMDSHA512body(keys, keys64, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
+		uint64_t rounds = ECRYPTFS_DEFAULT_NUM_HASH_ITERATIONS - 1;
+		SIMDSHA512body(keys, keys64, &rounds, SSEi_HALF_IN|SSEi_LOOP);
 		// Last one with FLAT_OUT
 		SIMDSHA512body(keys, (uint64_t*)crypt_out[index], NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT|SSEi_FLAT_OUT);
 #else

--- a/src/hmacSHA512_fmt_plug.c
+++ b/src/hmacSHA512_fmt_plug.c
@@ -555,7 +555,7 @@ static int crypt_all(int *pcount, struct db_salt *salt,
 		SIMDSHA512body(&crypt_key[index * PAD_SIZE],
 		            (uint64_t*)&crypt_key[index * PAD_SIZE],
 		            (uint64_t*)&prep_opad[index * BINARY_SIZE],
-		            SSEi_MIXED_IN|SSEi_RELOAD|SSEi_OUTPUT_AS_INP_FMT|EX_FLAGS);
+		            SSEi_HALF_IN|SSEi_RELOAD|SSEi_OUTPUT_AS_INP_FMT|EX_FLAGS);
 #else
 		SHA512_CTX ctx;
 

--- a/src/hmacSHA512_fmt_plug.c
+++ b/src/hmacSHA512_fmt_plug.c
@@ -555,7 +555,7 @@ static int crypt_all(int *pcount, struct db_salt *salt,
 		SIMDSHA512body(&crypt_key[index * PAD_SIZE],
 		            (uint64_t*)&crypt_key[index * PAD_SIZE],
 		            (uint64_t*)&prep_opad[index * BINARY_SIZE],
-		            SSEi_HALF_IN|SSEi_RELOAD|SSEi_OUTPUT_AS_INP_FMT|EX_FLAGS);
+		            SSEi_MIXED_IN|SSEi_RELOAD|SSEi_OUTPUT_AS_INP_FMT|EX_FLAGS);
 #else
 		SHA512_CTX ctx;
 

--- a/src/keplr_fmt_plug.c
+++ b/src/keplr_fmt_plug.c
@@ -6,7 +6,7 @@
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted.
- ///////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_keplr;
@@ -31,13 +31,24 @@ john_register_one(&fmt_keplr);
 #include "sha2.h"
 #include "jumbo.h"
 
+/* SCRYPT_ALGORITHM_NAME taken from restic_fmt_plug.c */
+#if !defined(JOHN_NO_SIMD) && defined(__XOP__)
+#define SCRYPT_ALGORITHM_NAME "Salsa20/8 128/128 XOP"
+#elif !defined(JOHN_NO_SIMD) && defined(__AVX__)
+#define SCRYPT_ALGORITHM_NAME "Salsa20/8 128/128 AVX"
+#elif !defined(JOHN_NO_SIMD) && defined(__SSE2__)
+#define SCRYPT_ALGORITHM_NAME "Salsa20/8 128/128 SSE2"
+#else
+#define SCRYPT_ALGORITHM_NAME "Salsa20/8 32/" ARCH_BITS_STR
+#endif
+
 #define FORMAT_NAME             "Keplr Wallet"
 #define FORMAT_LABEL            "keplr"
 #define FORMAT_TAG              "$keplr$"
 #define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
-#define ALGORITHM_NAME          "scrypt sha256"
-#define BENCHMARK_COMMENT       ""
-#define BENCHMARK_LENGTH        7
+#define ALGORITHM_NAME          "scrypt " SCRYPT_ALGORITHM_NAME ", SHA256 32/" ARCH_BITS_STR
+#define BENCHMARK_COMMENT       " (131072, 8, 1)"
+#define BENCHMARK_LENGTH        0x507
 #define BINARY_SIZE             0
 #define BINARY_ALIGN            1
 #define SALT_SIZE               sizeof(struct custom_salt)
@@ -46,7 +57,7 @@ john_register_one(&fmt_keplr);
 #define MIN_KEYS_PER_CRYPT      1
 #define MAX_KEYS_PER_CRYPT      1
 
-#define OMP_SCALE               1 // MKPC and scale tuned for i7
+#define OMP_SCALE               1
 
 static int max_threads;
 static yescrypt_local_t *local;

--- a/src/pkcs12_plug.c
+++ b/src/pkcs12_plug.c
@@ -723,8 +723,8 @@ static int mbedtls_pkcs12_derivation_simd_sha512( unsigned char *data[SSE_GROUP_
 		}
 
 		// Perform remaining ( iterations - 1 ) recursive hash calculations
-		for ( i = 1; i < (size_t) iterations; i++ )
-			SIMDSHA512body(sse_buf, (uint64_t*)sse_buf, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
+		uint64_t rounds = iterations - 1;
+		SIMDSHA512body(sse_buf, (uint64_t*)sse_buf, &rounds, SSEi_HALF_IN|SSEi_LOOP);
 
 		// Now unmarshall the data from sse_buf
 		use_len = ( datalen > hlen ) ? hlen : datalen;

--- a/src/pkcs12_plug.c
+++ b/src/pkcs12_plug.c
@@ -724,7 +724,7 @@ static int mbedtls_pkcs12_derivation_simd_sha512( unsigned char *data[SSE_GROUP_
 
 		// Perform remaining ( iterations - 1 ) recursive hash calculations
 		for ( i = 1; i < (size_t) iterations; i++ )
-			SIMDSHA512body(sse_buf, (uint64_t*)sse_buf, NULL, SSEi_MIXED_IN|SSEi_OUTPUT_AS_INP_FMT);
+			SIMDSHA512body(sse_buf, (uint64_t*)sse_buf, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
 
 		// Now unmarshall the data from sse_buf
 		use_len = ( datalen > hlen ) ? hlen : datalen;

--- a/src/pkcs12_plug.c
+++ b/src/pkcs12_plug.c
@@ -634,6 +634,10 @@ static int mbedtls_pkcs12_derivation_simd_sha256( unsigned char *data[SSE_GROUP_
 
 #if defined(SIMD_COEF_64)
 
+/* We use SSEi_HALF_IN, so can halve SHA_BUF_SIZ */
+#undef SHA_BUF_SIZ
+#define SHA_BUF_SIZ 8
+
 // 64 bit mixer
 #if ARCH_LITTLE_ENDIAN==1
 #define GETPOS4(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + (7-((i)&7)) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )

--- a/src/pkcs12_plug.c
+++ b/src/pkcs12_plug.c
@@ -700,7 +700,6 @@ static int mbedtls_pkcs12_derivation_simd_sha512( unsigned char *data[SSE_GROUP_
 	v = 128;
 
 	memset(diversifier, (unsigned char) id, v);
-	memset(sse_buf, 0, sizeof(sse_buf));
 
 	pkcs12_fill_salt_buffer_simd(salt_block, v, salt, saltlen, SSE_GROUP_SZ_SHA512);
 	pkcs12_fill_buffer_simd(pwd_block,  v, pwd,  pwdlen, SSE_GROUP_SZ_SHA512);
@@ -718,8 +717,6 @@ static int mbedtls_pkcs12_derivation_simd_sha512( unsigned char *data[SSE_GROUP_
 			for (i = 0; i < SHA512_DIGEST_LENGTH; ++i) {
 				sse_buf[GETPOS4(i, k)] = hash[i];
 			}
-			sse_buf[GETPOS4(64,k)] = 0x80;
-			sse_buf[GETPOS4(126,k)] = 2; // (SHA512_DIGEST_LENGTH<<3);
 		}
 
 		// Perform remaining ( iterations - 1 ) recursive hash calculations

--- a/src/sha256crypt_common.h
+++ b/src/sha256crypt_common.h
@@ -107,7 +107,6 @@ static struct fmt_tests tests[] = {
 	{"$5$saltstring$5B8vYYiY.CVt1RlTTf8KbXBH3hsxY/GNooZaBBGWEc5", "Hello world!"},
 	{"$5$V8UMZ8/8.j$GGzeGHZy60318qdLiocMj7DddCnfr7jIcLMDIRy9Tr0", "password"},
 
-#ifdef DEBUG
 #if PLAINTEXT_LENGTH > 35
 	{"$5$aewWTiO8RzEz5FBF$CZ3I.vdWF4omQXMQOv1g3XarjhH0wwR29Jwzt6/gvV/", "012345678901234567890123456789012345"},
 #endif
@@ -171,7 +170,6 @@ static struct fmt_tests tests[] = {
 
 	// from a comment in the OpenCL implementation:
 	//{"$5$EKt.VLXiPjwyv.xe$52wdOp9ixFXMsHDI1JcCw8KJ83IakDP6J7MIEV2OUk0", "1234567"},
-#endif
 	// from a comment in the CUDA implementaton:
 	//{"$5$rounds=5000$abcdefghijklmnop$BAYQep7SsuSczAeXlks3F54SpxMUUludHi1C4JVOqpD","abcdefghijklmno"},
 	{NULL}

--- a/src/sha512crypt_common.h
+++ b/src/sha512crypt_common.h
@@ -91,7 +91,6 @@ static struct fmt_tests tests[] = {
 	{"$6$OmBOuxFYBZCYAadG$WCckkSZok9xhp4U1shIZEV7CCVwQUwMVea7L3A77th6SaE9jOPupEMJB.z0vIWCDiN9WLh2m9Oszrj5G.gt330", "*U*U*U*U"},
 	{"$6$ojWH1AiTee9x1peC$QVEnTvRVlPRhcLQCk/HnHaZmlGAAjCfrAN0FtOsOnUk5K5Bn/9eLHHiRzrTzaIKjW9NTLNIBUCtNVOowWS2mN.", ""},
 	{"$6$saltstring$svn8UoSVapNtMuq1ukKS4tPQd8iKwSMHWjl/O817G3uBnIFNjnQJuesI68u4OTLiBFdcbYEdFCoEOfaS35inz1", "Hello world!"},
-#ifdef DEBUG
 	// Special test cases, the first two exceed the plain text length of the GPU implementations
 	//{"$6$va2Z2zTYTtF$1CzJmk3A2FO6aH.UrF2BU99oZOYcFlJu5ewPz7ZFvq0w3yCC2G9y4EsymHZxXe5e6Q7bPbyk4BQ5bekdVbmZ20", "123456789012345678901234"},
 	//{"$6$1234567890123456$938IMfPJvgxpgwvaqbFcmpz9i/yfYSClzgfwcdDcAdjlj6ZH1fVA9BUe4GDGYN/68UiaR2.pLq4gXFfLZxpMr.", "123456789012345678901234"},
@@ -110,8 +109,10 @@ static struct fmt_tests tests[] = {
 	{"$6$DsS6VmHwcMRA5mAo$vWl2YYUsgN3PTtwDLKhfOIEixnA0USAWN2IswislKP7p8pISFLG6PfBJZU8Smekyl0NiReg552lOmEPaOjhKp/", "123456789012345"},
 #endif
 	{"$6$mwt2GD73BqSk4$ol0oMY1zzm59tnAFnH0OM9R/7SL4gi3VJ42AIVQNcGrYx5S1rlZggq5TBqvOGNiNQ0AmjmUMPc.70kL8Lqost.", "password"},
+#ifdef DEBUG
 	{"$6$rounds=391939$saltstring$P5HDSEq.sTdSBNmknrLQpg6UHp.9.vuEv6QibJNP8ecoNGo9Wa.3XuR7LKu8FprtxGDpGv17Y27RfTHvER4kI0", "amy"},
 	{"$6$rounds=391939$saltstring$JAjUHgEFBJB1lSM25mYGFdH42OOBZ8eytTvKCleaR4jI5cSs0KbATSYyhLj3tkMhmU.fUKfsZkT5y0EYbTLcr1", "amy99"},
+#endif
 	{"$6$TtrrO3IN$D7Qz38n3JOn4Cc6y0340giveWD8uUvBAdPeCI0iC1cGYCmYHDrVXUEoSf3Qp5TRgo7x0BXN4lKNEj7KOvFTZV1", ">7fSy+N\\W=o@Wd&"}, // Password: >7fSy+N\W=o@Wd&
 	{"$6$yRihAbCh$V5Gr/BhMSMkl6.fBt4TV5lWYY6MhjqApHxDL04HeTgeAX.mZT/0pDDYvArvmCfmMVa/XxzzOBXf1s7TGa2FDL0", "0H@<:IS:BfM\"V"},   // Password: 0H@<:IS:BfM"V
 	{"$6$rounds=4900$saltstring$p3pnU2njiDujK0Pp5us7qlUvkjVaAM0GilTprwyZ1ZiyGKvsfNyDCnlmc.9ahKmDqyqKXMH3frK1I/oEiEbTK/", "Hello world!"},
@@ -131,7 +132,6 @@ static struct fmt_tests tests[] = {
 	{"$6$saltstring$l2IxCS4o2S/vud70F1S5Z7H1WE67QFIXCYqskySdLFjjorEJdAnAp1ZqdgfNuZj2orjmeVDTsTXHpZ1IoxSKd.", "abcdefghijklm"},
 	{"$6$saltstring$PFzjspQs/CDXWALauDTav3u5bHB3n21xWrfwjnjpFO5eM5vuP0qKwDCXmlyZ5svEgsIH1oiZiGlRqkcBP5PiB.", "abcdefghijklmn"},
 	{"$6$saltstring$rdREv5Pd9C9YGtg.zXEQMb6m0sPeq4b6zFW9oWY9w4ZltmjH3yzMLgl9iBuez9DFFUvF5nJH3Y2xidiq1dH9M.", "abcdefghijklmno"},
-#endif
 	{NULL}
 };
 #endif

--- a/src/simd-intrinsics-load-flags.h
+++ b/src/simd-intrinsics-load-flags.h
@@ -27,8 +27,9 @@
  * in place.
  *
  * SSEi_HALF_IN
- * Input is like SSEi_MIXED_IN, but elements 9 to 14 are assumed all zeroes.
- * Currently only implemented for SHA-512.
+ * Input is like SSEi_MIXED_IN, but length must be exactly half the block,
+ * and the second half is unused (the implementation takes care of the 0x80
+ * and the length field on its own). Currently only implemented for SHA-512.
  *
  * SSEi_FLAT_OUT
  * Output will be just as from OpenSSL. Swapped if applicable, not interleaved.
@@ -77,6 +78,16 @@
  * WARNING, SHA224 requires a FULL SHA256 width output buffer, and SHA384
  * requires a full SHA512 width output buffer.  This is to allow proper
  * reloading and doing multi-limb crypts.
+ *
+ * SSEi_LOOP
+ * Iterated hashing, with hash output reused as input for the next iteration.
+ * Currently supported only for SHA-512 and only along with SSEi_HALF_IN.
+ * Without SSEi_FLAT_OUT, *reload_state is reused as the iteration count (and
+ * is clobbered), and the final output is in the SSEi_OUTPUT_AS_INP_FMT format.
+ * With SSEi_FLAT_OUT, reload_state is reused as pointer to the end of the
+ * multi-hash output, which is in a format similar to that of SSEi_FLAT_OUT
+ * alone but without byte order swapping, and the input data is overwritten
+ * with the final output in the SSEi_OUTPUT_AS_INP_FMT format.
  */
 
 typedef enum {
@@ -97,7 +108,8 @@ typedef enum {
 	SSEi_FLAT_RELOAD_SWAPLAST    = 0x800,
 	SSEi_CRYPT_SHA224            = 0x1000,
 	SSEi_CRYPT_SHA384            = 0x1000,
-	SSEi_OUTPUT_AS_2BUF_INP_FMT  = 0x2000 | SSEi_OUTPUT_AS_INP_FMT
+	SSEi_OUTPUT_AS_2BUF_INP_FMT  = 0x2000 | SSEi_OUTPUT_AS_INP_FMT,
+	SSEi_LOOP                    = 0x8000
 } SSEi_FLAGS;
 
 

--- a/src/simd-intrinsics-load-flags.h
+++ b/src/simd-intrinsics-load-flags.h
@@ -65,10 +65,8 @@
  * 14/15 if in flat mode.
  *
  * SSEi_FLAT_RELOAD_SWAPLAST
- * Can be an issue for flat mode, and reload (i.e. multi buffers.) The last
- * limb should NEVER have this flag set. This also only 'affects' the SHA1
- * and SHA256 formats. Similar to SSEi_4BUF_INPUT_FIRST_BLK, but simply says
- * we will have more buffers coming after this one.
+ * Similar to SSEi_4BUF_INPUT_FIRST_BLK, but simply says we will have more
+ * buffers coming after this one. Currently only enabled/used for SHA-256.
  *
  * SSEi_CRYPT_SHA224     use SHA224 IV.
  * SSEi_CRYPT_SHA384     use SHA384 IV.

--- a/src/simd-intrinsics-load-flags.h
+++ b/src/simd-intrinsics-load-flags.h
@@ -81,13 +81,14 @@
  *
  * SSEi_LOOP
  * Iterated hashing, with hash output reused as input for the next iteration.
- * Currently supported only for SHA-512 and only along with SSEi_HALF_IN.
+ * Currently supported only for SHA-512 and only along with SSEi_MIXED_IN or
+ * SSEi_HALF_IN.
  * Without SSEi_FLAT_OUT, *reload_state is reused as the iteration count (and
- * is clobbered), and the final output is in the SSEi_HALF_IN format.
+ * is clobbered), and the final output is in the input format (full or half).
  * With SSEi_FLAT_OUT, reload_state is reused as pointer to the end of the
  * multi-hash output, which is in a format similar to that of SSEi_FLAT_OUT
  * alone but without byte order swapping, and the input data is overwritten
- * with the final output in the SSEi_HALF_IN format.
+ * with the final output in the SSEi_HALF_IN format, which this mode requires.
  */
 
 typedef enum {

--- a/src/simd-intrinsics-load-flags.h
+++ b/src/simd-intrinsics-load-flags.h
@@ -83,11 +83,11 @@
  * Iterated hashing, with hash output reused as input for the next iteration.
  * Currently supported only for SHA-512 and only along with SSEi_HALF_IN.
  * Without SSEi_FLAT_OUT, *reload_state is reused as the iteration count (and
- * is clobbered), and the final output is in the SSEi_OUTPUT_AS_INP_FMT format.
+ * is clobbered), and the final output is in the SSEi_HALF_IN format.
  * With SSEi_FLAT_OUT, reload_state is reused as pointer to the end of the
  * multi-hash output, which is in a format similar to that of SSEi_FLAT_OUT
  * alone but without byte order swapping, and the input data is overwritten
- * with the final output in the SSEi_OUTPUT_AS_INP_FMT format.
+ * with the final output in the SSEi_HALF_IN format.
  */
 
 typedef enum {

--- a/src/simd-intrinsics-load-flags.h
+++ b/src/simd-intrinsics-load-flags.h
@@ -26,11 +26,9 @@
  * values, the hash function has to shuffle it. But 0x80 and length must be
  * in place.
  *
- * SSEi_CSTRING_IN
- * Input will be just as for OpenSSL: A normal char[COEF][64] array where
- * each string ends in NULL, with no 0x80 or length prepared. The intrinsics
- * function needs to take care of that as well as cleaning (after NULL),
- * shuffling and possibly do endian swapping if applicable.
+ * SSEi_HALF_IN
+ * Input is like SSEi_MIXED_IN, but elements 9 to 14 are assumed all zeroes.
+ * Currently only implemented for SHA-512.
  *
  * SSEi_FLAT_OUT
  * Output will be just as from OpenSSL. Swapped if applicable, not interleaved.
@@ -85,7 +83,7 @@ typedef enum {
 	SSEi_NO_OP                   = 0x0, /* No-op */
 	SSEi_MIXED_IN                = 0x0,
 	SSEi_FLAT_IN                 = 0x1,
-/*	SSEi_CSTRING_IN              = 0x2,	NOT IMPLEMENTED YET*/
+	SSEi_HALF_IN                 = 0x2,
 	SSEi_FLAT_OUT                = 0x4,
 	SSEi_RELOAD                  = 0x8,
 	SSEi_RELOAD_INP_FMT          = 0x10 | SSEi_RELOAD,

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -174,8 +174,8 @@ void SIMDmd5body(vtype* _data, unsigned int *out,
 			for (i=0; i < 14; i++)
 				W[i] = vswap32(W[i]);
 			if (((SSEi_flags & SSEi_2BUF_INPUT_FIRST_BLK) == SSEi_2BUF_INPUT_FIRST_BLK) ||
-			    ((SSEi_flags & SSEi_4BUF_INPUT_FIRST_BLK) == SSEi_4BUF_INPUT_FIRST_BLK) ||
-			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST)) {
+			    ((SSEi_flags & SSEi_4BUF_INPUT_FIRST_BLK) == SSEi_4BUF_INPUT_FIRST_BLK) /* ||
+			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST) */) {
 				W[14] = vswap32(W[14]);
 				W[15] = vswap32(W[15]);
 			}
@@ -836,8 +836,8 @@ void SIMDmd4body(vtype* _data, unsigned int *out, uint32_t *reload_state,
 			for (i=0; i < 14; i++)
 				W[i] = vswap32(W[i]);
 			if (((SSEi_flags & SSEi_2BUF_INPUT_FIRST_BLK) == SSEi_2BUF_INPUT_FIRST_BLK) ||
-			    ((SSEi_flags & SSEi_4BUF_INPUT_FIRST_BLK) == SSEi_4BUF_INPUT_FIRST_BLK) ||
-			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST)) {
+			    ((SSEi_flags & SSEi_4BUF_INPUT_FIRST_BLK) == SSEi_4BUF_INPUT_FIRST_BLK) /* ||
+			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST) */) {
 				W[14] = vswap32(W[14]);
 				W[15] = vswap32(W[15]);
 			}
@@ -1297,8 +1297,8 @@ void SIMDSHA1body(vtype* _data, uint32_t *out, uint32_t *reload_state,
 				saved_key += (VS32<<4);
 			}
 			if (((SSEi_flags & SSEi_2BUF_INPUT_FIRST_BLK) == SSEi_2BUF_INPUT_FIRST_BLK) ||
-			    ((SSEi_flags & SSEi_4BUF_INPUT_FIRST_BLK) == SSEi_4BUF_INPUT_FIRST_BLK) ||
-			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST)) {
+			    ((SSEi_flags & SSEi_4BUF_INPUT_FIRST_BLK) == SSEi_4BUF_INPUT_FIRST_BLK) /* ||
+			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST) */) {
 				W[14] = vswap32(W[14]);
 				W[15] = vswap32(W[15]);
 			}
@@ -1331,8 +1331,8 @@ void SIMDSHA1body(vtype* _data, uint32_t *out, uint32_t *reload_state,
 			for (i=0; i < 14; i++)
 				W[i] = vswap32(W[i]);
 			if (((SSEi_flags & SSEi_2BUF_INPUT_FIRST_BLK) == SSEi_2BUF_INPUT_FIRST_BLK) ||
-			    ((SSEi_flags & SSEi_4BUF_INPUT_FIRST_BLK) == SSEi_4BUF_INPUT_FIRST_BLK) ||
-			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST)) {
+			    ((SSEi_flags & SSEi_4BUF_INPUT_FIRST_BLK) == SSEi_4BUF_INPUT_FIRST_BLK) /* ||
+			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST) */) {
 				W[14] = vswap32(W[14]);
 				W[15] = vswap32(W[15]);
 			}
@@ -2419,8 +2419,8 @@ static MAYBE_INLINE void SIMDSHA512univ(vtype* data, uint64_t *out, uint64_t *re
 				_data += (VS64<<4);
 			}
 #if ARCH_LITTLE_ENDIAN
-			if (((SSEi_flags & SSEi_2BUF_INPUT_FIRST_BLK) == SSEi_2BUF_INPUT_FIRST_BLK) ||
-			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST)) {
+			if (((SSEi_flags & SSEi_2BUF_INPUT_FIRST_BLK) == SSEi_2BUF_INPUT_FIRST_BLK) /* ||
+			    (SSEi_flags & SSEi_FLAT_RELOAD_SWAPLAST) */) {
 				tmp1[k] = vswap64(tmp1[k]);
 				tmp2[k] = vswap64(tmp2[k]);
 			}

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -380,6 +380,7 @@ void SIMDmd5body(vtype* _data, unsigned int *out,
 	else
 #endif
 
+#if SIMD_PARA_MD5 > 1
 	if (SSEi_flags & SSEi_OUTPUT_AS_INP_FMT)
 	{
 		if ((SSEi_flags & SSEi_OUTPUT_AS_2BUF_INP_FMT) == SSEi_OUTPUT_AS_2BUF_INP_FMT) {
@@ -400,6 +401,7 @@ void SIMDmd5body(vtype* _data, unsigned int *out,
 			}
 		}
 	}
+#endif
 	else
 	{
 		MD5_PARA_DO(i)
@@ -1027,6 +1029,7 @@ void SIMDmd4body(vtype* _data, unsigned int *out, uint32_t *reload_state,
 	else
 #endif
 
+#if SIMD_PARA_MD4 > 1
 	if (SSEi_flags & SSEi_OUTPUT_AS_INP_FMT)
 	{
 		if ((SSEi_flags & SSEi_OUTPUT_AS_2BUF_INP_FMT) == SSEi_OUTPUT_AS_2BUF_INP_FMT) {
@@ -1048,6 +1051,7 @@ void SIMDmd4body(vtype* _data, unsigned int *out, uint32_t *reload_state,
 		}
 	}
 	else
+#endif
 	{
 		MD4_PARA_DO(i)
 		{
@@ -1566,6 +1570,7 @@ void SIMDSHA1body(vtype* _data, uint32_t *out, uint32_t *reload_state,
 #endif
 		}
 	}
+#if SIMD_PARA_SHA1 > 1
 	else if (SSEi_flags & SSEi_OUTPUT_AS_INP_FMT)
 	{
 		if ((SSEi_flags & SSEi_OUTPUT_AS_2BUF_INP_FMT) == SSEi_OUTPUT_AS_2BUF_INP_FMT) {
@@ -1588,6 +1593,7 @@ void SIMDSHA1body(vtype* _data, uint32_t *out, uint32_t *reload_state,
 			}
 		}
 	}
+#endif
 	else
 	{
 		SHA1_PARA_DO(i)
@@ -2104,6 +2110,7 @@ void SIMDSHA256body(vtype *data, uint32_t *out, uint32_t *reload_state, unsigned
 #endif
 		}
 	}
+#if SIMD_PARA_SHA256 > 1
 	else if (SSEi_flags & SSEi_OUTPUT_AS_INP_FMT) {
 		if ((SSEi_flags & SSEi_OUTPUT_AS_2BUF_INP_FMT) == SSEi_OUTPUT_AS_2BUF_INP_FMT) {
 			SHA256_PARA_DO(i)
@@ -2131,6 +2138,7 @@ void SIMDSHA256body(vtype *data, uint32_t *out, uint32_t *reload_state, unsigned
 			}
 		}
 	}
+#endif
 	else
 	{
 		SHA256_PARA_DO(i)

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -1,7 +1,7 @@
 /*
  * This software is
  * Copyright (c) 2010 bartavelle, <bartavelle at bandecon.com>,
- * Copyright (c) 2012 Solar Designer,
+ * Copyright (c) 2012,2015,2024 Solar Designer,
  * Copyright (c) 2011-2015 JimF,
  * Copyright (c) 2011-2023 magnum,
  * and it is hereby released to the general public under the following terms:

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -2421,7 +2421,7 @@ static MAYBE_INLINE void SIMDSHA512univ(vtype* data, uint64_t *out, uint64_t *re
 			w[k][15] = tmp2[k];
 		}
 	} else if (SSEi_flags & SSEi_HALF_IN) {
-		SSEi_flags &= ~(SSEi_FLAT_IN|SSEi_RELOAD|SSEi_REVERSE_STEPS|SSEi_CRYPT_SHA384|SSEi_OUTPUT_AS_2BUF_INP_FMT);
+		SSEi_flags &= ~(SSEi_FLAT_IN|SSEi_RELOAD|SSEi_REVERSE_STEPS|SSEi_CRYPT_SHA384|SSEi_OUTPUT_AS_INP_FMT);
 
 		vtype *_data = data;
 		SHA512_PARA_DO(k)
@@ -2444,7 +2444,7 @@ static MAYBE_INLINE void SIMDSHA512univ(vtype* data, uint64_t *out, uint64_t *re
 			w[k][14] = vset1_epi64(0);
 #endif
 			w[k][15] = vset1_epi64(64 << 3);
-			_data += 16;
+			_data += 8;
 		}
 next:
 		SHA512_PARA_DO(k)
@@ -2816,6 +2816,7 @@ next:
 #endif
 		}
 	}
+#if SIMD_PARA_SHA512 > 1
 	else if (SSEi_flags & SSEi_OUTPUT_AS_INP_FMT)
 	{
 		if ((SSEi_flags & SSEi_OUTPUT_AS_2BUF_INP_FMT) == SSEi_OUTPUT_AS_2BUF_INP_FMT) {
@@ -2831,7 +2832,6 @@ next:
 				vstore((vtype*)&out[i*32*VS64+7*VS64], h[i]);
 			}
 		} else {
-out:
 			SHA512_PARA_DO(i)
 			{
 				vstore((vtype*)&out[i*16*VS64+0*VS64], a[i]);
@@ -2845,8 +2845,10 @@ out:
 			}
 		}
 	}
+#endif
 	else
 	{
+out:
 		SHA512_PARA_DO(i)
 		{
 			vstore((vtype*)&(out[i*8*VS64+0*VS64]), a[i]);
@@ -2873,7 +2875,7 @@ void SIMDSHA512halfloopflat(vtype* data, uint64_t *out, uint64_t *end)
 
 void SIMDSHA512halfinout(vtype* data, uint64_t *out)
 {
-	SIMDSHA512univ(data, out, NULL, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
+	SIMDSHA512univ(data, out, NULL, SSEi_HALF_IN);
 }
 
 void SIMDSHA512half(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -2368,6 +2368,8 @@ static MAYBE_INLINE void SIMDSHA512univ(vtype* data, uint64_t *out, uint64_t *re
 	vtype tmp1[SIMD_PARA_SHA512], tmp2[SIMD_PARA_SHA512];
 
 	if (SSEi_flags & SSEi_FLAT_IN) {
+		SSEi_flags &= ~SSEi_HALF_IN;
+
 		uint64_t *_data = (uint64_t*)data;
 		SHA512_PARA_DO(k)
 		{
@@ -2415,6 +2417,8 @@ static MAYBE_INLINE void SIMDSHA512univ(vtype* data, uint64_t *out, uint64_t *re
 			w[k][15] = tmp2[k];
 		}
 	} else if (SSEi_flags & SSEi_HALF_IN) {
+		SSEi_flags &= ~(SSEi_FLAT_IN|SSEi_RELOAD|SSEi_REVERSE_STEPS|SSEi_CRYPT_SHA384|SSEi_OUTPUT_AS_2BUF_INP_FMT);
+
 		vtype *_data = data;
 		SHA512_PARA_DO(k)
 		{

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -2468,12 +2468,49 @@ next_half:
 #endif
 			w[k][15] = vset1_epi64(64 << 3);
 		}
+	} else if (SSEi_flags & SSEi_LOOP) {
+		SSEi_flags &= ~(SSEi_HALF_IN|SSEi_FLAT_IN|SSEi_RELOAD|SSEi_REVERSE_STEPS|SSEi_CRYPT_SHA384);
+
+		vtype *_data = data;
+		SHA512_PARA_DO(k)
+		{
+			w[k][0] = _data[0];
+			w[k][1] = _data[1];
+			w[k][2] = _data[2];
+			w[k][3] = _data[3];
+			w[k][4] = _data[4];
+			w[k][5] = _data[5];
+			w[k][6] = _data[6];
+			w[k][7] = _data[7];
+			w[k][8] = _data[8];
+			w[k][9] = _data[9];
+			w[k][10] = _data[10];
+			w[k][11] = _data[11];
+			w[k][12] = _data[12];
+			w[k][13] = _data[13];
+			w[k][14] = _data[14];
+			w[k][15] = _data[15];
+			_data += 16;
+		}
+next_full:
+		_data = data;
+		SHA512_PARA_DO(k)
+		{
+			w[k][8] = _data[8];
+			w[k][9] = _data[9];
+			w[k][10] = _data[10];
+			w[k][11] = _data[11];
+			w[k][12] = _data[12];
+			w[k][13] = _data[13];
+			w[k][14] = _data[14];
+			w[k][15] = _data[15];
+			_data += 16;
+		}
 	} else
 		memcpy(w, data, 16 * sizeof(vtype) * SIMD_PARA_SHA512);
 
 	//dump_stuff_shammx64_msg("\nindex 2", w, 128, 2);
 
-next_full:
 	if (SSEi_flags & SSEi_RELOAD) {
 		if ((SSEi_flags & SSEi_RELOAD_INP_FMT) == SSEi_RELOAD_INP_FMT)
 		{
@@ -2785,19 +2822,6 @@ next_full:
 			if (--*reload_state)
 				goto next_half;
 		} else {
-			vtype *_data = data + 8;
-			SHA512_PARA_DO(i)
-			{
-				w[i][8] = _data[0];
-				w[i][9] = _data[1];
-				w[i][10] = _data[2];
-				w[i][11] = _data[3];
-				w[i][12] = _data[4];
-				w[i][13] = _data[5];
-				w[i][14] = _data[6];
-				w[i][15] = _data[7];
-				_data += 16;
-			}
 			if (--*reload_state)
 				goto next_full;
 			goto out_full;

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -2954,6 +2954,11 @@ void SIMDSHA512half(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned
 	SIMDSHA512univ(data, out, reload_state, (SSEi_flags & ~SSEi_LOOP) | SSEi_HALF_IN);
 }
 
+void SIMDSHA512flatin2buf(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
+{
+	SIMDSHA512univ(data, out, reload_state, SSEi_FLAT_IN|SSEi_2BUF_INPUT_FIRST_BLK | (SSEi_flags & SSEi_RELOAD));
+}
+
 void SIMDSHA512fullloop(vtype* data, uint64_t *out, uint64_t *count)
 {
 	SIMDSHA512univ(data, out, count, SSEi_MIXED_IN|SSEi_LOOP);

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -2352,8 +2352,7 @@ void sha384_unreverse(uint64_t *hash)
 
 #undef INIT_D
 
-void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_state,
-                   unsigned SSEi_flags)
+static MAYBE_INLINE void SIMDSHA512univ(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
 {
 	unsigned int i, k;
 
@@ -2762,6 +2761,21 @@ void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_state,
 			vstore((vtype*)&(out[i*8*VS64+7*VS64]), h[i]);
 		}
 	}
+}
+
+void SIMDSHA512halfinout(vtype* data, uint64_t *out, uint64_t *reload_state)
+{
+	SIMDSHA512univ(data, out, reload_state, SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT);
+}
+
+void SIMDSHA512half(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
+{
+	SIMDSHA512univ(data, out, reload_state, SSEi_flags | SSEi_HALF_IN);
+}
+
+void SIMDSHA512full(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
+{
+	SIMDSHA512univ(data, out, reload_state, SSEi_flags & ~SSEi_HALF_IN);
 }
 
 #endif /* SIMD_PARA_SHA512 */

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -2434,6 +2434,16 @@ static MAYBE_INLINE void SIMDSHA512univ(vtype* data, uint64_t *out, uint64_t *re
 			w[k][5] = _data[5];
 			w[k][6] = _data[6];
 			w[k][7] = _data[7];
+			w[k][8] = vset1_epi64(0x8000000000000000ULL);
+#if !SHA512_MANUAL_OPT
+			w[k][9] =
+			w[k][10] =
+			w[k][11] =
+			w[k][12] =
+			w[k][13] =
+			w[k][14] = vset1_epi64(0);
+#endif
+			w[k][15] = vset1_epi64(64 << 3);
 			_data += 16;
 		}
 next:

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -2951,7 +2951,7 @@ void SIMDSHA512halfinout(vtype* data, uint64_t *out)
 
 void SIMDSHA512half(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
 {
-	SIMDSHA512univ(data, out, reload_state, SSEi_flags | SSEi_HALF_IN);
+	SIMDSHA512univ(data, out, reload_state, (SSEi_flags & ~SSEi_LOOP) | SSEi_HALF_IN);
 }
 
 void SIMDSHA512fullloop(vtype* data, uint64_t *out, uint64_t *count)

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -111,7 +111,18 @@ void SIMDSHA256body(vtype* data, uint32_t *out, uint32_t *reload_state, unsigned
 
 #ifdef SIMD_COEF_64
 #define SHA512_ALGORITHM_NAME	BITS " " SIMD_TYPE " " SHA512_N_STR
-void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
+void SIMDSHA512halfinout(vtype* data, uint64_t *out, uint64_t *reload_state);
+void SIMDSHA512half(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
+void SIMDSHA512full(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
+static inline void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
+{
+	if (SSEi_flags == (SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT))
+		SIMDSHA512halfinout(data, out, reload_state);
+	else if (SSEi_flags & SSEi_HALF_IN)
+		SIMDSHA512half(data, out, reload_state, SSEi_flags);
+	else
+		SIMDSHA512full(data, out, reload_state, SSEi_flags);
+}
 #endif
 
 #else

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -122,7 +122,7 @@ static inline void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_s
 		SIMDSHA512halfloop(data, out, reload_state);
 	else if (SSEi_flags == (SSEi_HALF_IN|SSEi_LOOP|SSEi_FLAT_OUT))
 		SIMDSHA512halfloopflat(data, out, reload_state);
-	else if (SSEi_flags == (SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT))
+	else if (SSEi_flags == SSEi_HALF_IN)
 		SIMDSHA512halfinout(data, out);
 	else if (SSEi_flags & SSEi_HALF_IN)
 		SIMDSHA512half(data, out, reload_state, SSEi_flags);

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -111,13 +111,19 @@ void SIMDSHA256body(vtype* data, uint32_t *out, uint32_t *reload_state, unsigned
 
 #ifdef SIMD_COEF_64
 #define SHA512_ALGORITHM_NAME	BITS " " SIMD_TYPE " " SHA512_N_STR
-void SIMDSHA512halfinout(vtype* data, uint64_t *out, uint64_t *reload_state);
+void SIMDSHA512halfloop(vtype* data, uint64_t *out, uint64_t *count);
+void SIMDSHA512halfloopflat(vtype* data, uint64_t *out, uint64_t *end);
+void SIMDSHA512halfinout(vtype* data, uint64_t *out);
 void SIMDSHA512half(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
 void SIMDSHA512full(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
 static inline void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
 {
-	if (SSEi_flags == (SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT))
-		SIMDSHA512halfinout(data, out, reload_state);
+	if (SSEi_flags == (SSEi_HALF_IN|SSEi_LOOP))
+		SIMDSHA512halfloop(data, out, reload_state);
+	else if (SSEi_flags == (SSEi_HALF_IN|SSEi_LOOP|SSEi_FLAT_OUT))
+		SIMDSHA512halfloopflat(data, out, reload_state);
+	else if (SSEi_flags == (SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT))
+		SIMDSHA512halfinout(data, out);
 	else if (SSEi_flags & SSEi_HALF_IN)
 		SIMDSHA512half(data, out, reload_state, SSEi_flags);
 	else

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -115,10 +115,14 @@ void SIMDSHA512halfloop(vtype* data, uint64_t *out, uint64_t *count);
 void SIMDSHA512halfloopflat(vtype* data, uint64_t *out, uint64_t *end);
 void SIMDSHA512halfinout(vtype* data, uint64_t *out);
 void SIMDSHA512half(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
+void SIMDSHA512flatin2buf(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
 void SIMDSHA512fullloop(vtype* data, uint64_t *out, uint64_t *count);
 void SIMDSHA512full(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
 static inline void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
 {
+#if SIMD_PARA_SHA512 == 1
+	SSEi_flags &= ~SSEi_OUTPUT_AS_INP_FMT; /* Flag only matters for SIMD_PARA_SHA512 > 1 */
+#endif
 	if (SSEi_flags == (SSEi_HALF_IN|SSEi_LOOP))
 		SIMDSHA512halfloop(data, out, reload_state);
 	else if (SSEi_flags == (SSEi_HALF_IN|SSEi_LOOP|SSEi_FLAT_OUT))
@@ -127,8 +131,10 @@ static inline void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_s
 		SIMDSHA512halfinout(data, out);
 	else if (SSEi_flags & SSEi_HALF_IN)
 		SIMDSHA512half(data, out, reload_state, SSEi_flags);
+	else if ((SSEi_flags & ~SSEi_RELOAD) == (SSEi_FLAT_IN|SSEi_2BUF_INPUT_FIRST_BLK))
+		SIMDSHA512flatin2buf(data, out, reload_state, SSEi_flags); /* Optional SSEi_RELOAD */
 	else if ((SSEi_flags & ~SSEi_OUTPUT_AS_INP_FMT) == (SSEi_MIXED_IN|SSEi_LOOP))
-		SIMDSHA512fullloop(data, out, reload_state);
+		SIMDSHA512fullloop(data, out, reload_state); /* Implies SSEi_OUTPUT_AS_INP_FMT */
 	else
 		SIMDSHA512full(data, out, reload_state, SSEi_flags);
 }

--- a/src/simd-intrinsics.h
+++ b/src/simd-intrinsics.h
@@ -115,6 +115,7 @@ void SIMDSHA512halfloop(vtype* data, uint64_t *out, uint64_t *count);
 void SIMDSHA512halfloopflat(vtype* data, uint64_t *out, uint64_t *end);
 void SIMDSHA512halfinout(vtype* data, uint64_t *out);
 void SIMDSHA512half(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
+void SIMDSHA512fullloop(vtype* data, uint64_t *out, uint64_t *count);
 void SIMDSHA512full(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags);
 static inline void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_state, unsigned SSEi_flags)
 {
@@ -126,6 +127,8 @@ static inline void SIMDSHA512body(vtype* data, uint64_t *out, uint64_t *reload_s
 		SIMDSHA512halfinout(data, out);
 	else if (SSEi_flags & SSEi_HALF_IN)
 		SIMDSHA512half(data, out, reload_state, SSEi_flags);
+	else if ((SSEi_flags & ~SSEi_OUTPUT_AS_INP_FMT) == (SSEi_MIXED_IN|SSEi_LOOP))
+		SIMDSHA512fullloop(data, out, reload_state);
 	else
 		SIMDSHA512full(data, out, reload_state, SSEi_flags);
 }


### PR DESCRIPTION
This introduces specialized versions of SIMDSHA512body() and makes use of them in a few formats, including in the recently added Armory, where it provides a speedup of 4% on i7-4770K and some smaller speedups on some other machines I tested.

There are 3 specialized functions now, but I mostly care about the case of `SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT` (as that's what's used in some iterated formats now) and the original case from prior to my changes here (not to introduce performance regressions via increased code size). The third case of having `SSEi_HALF_IN` along with other or no flags is specialized merely to avoid code size increase in the original case. We could alternatively unsupport `SSEi_HALF_IN` except in `SSEi_HALF_IN|SSEi_OUTPUT_AS_INP_FMT`, but for now I opted to have it supported separately as well.

Further optimization potential is doing similar for SHA-256 (should be easy now) and maybe for others (it'd be different there), and introducing function specializations also for the previously existing flags (to reduce code size in the functions that many/most formats use).