### PR TITLE
python: recommend pycryptodome package over PyCrypto

### DIFF
--- a/doc/Auditing-Kerio-Connect.md
+++ b/doc/Auditing-Kerio-Connect.md
@@ -41,7 +41,7 @@ The following script can be used to reverse these "D3S" scrambled password strin
 #!/usr/bin/env python
 
 import sys
-from Crypto.Cipher import DES3  # pip install --user pycrypto
+from Crypto.Cipher import DES3  # pip install --user pycryptodome
 
 # Password unscrambler for Kerio Connect.
 #
@@ -180,7 +180,7 @@ follows,
 #!/usr/bin/env python
 
 import sys
-from Crypto.Cipher import DES  # pip install --user pycrypto
+from Crypto.Cipher import DES  # pip install --user pycryptodome
 
 # Password unscrambler for Kerio Connect.
 

--- a/run/DPAPImk2john.py
+++ b/run/DPAPImk2john.py
@@ -30,7 +30,7 @@ try:
     from Crypto.Cipher import DES
     from Crypto.Cipher import DES3
 except ImportError:
-    sys.stderr.write("Error: Please install PyCrypto package.\n")
+    sys.stderr.write("pycryptodome python package is missing, please install it using 'pip install --user pycryptodome' command.\n")
     sys.exit(1)
 
 debug = False

--- a/run/telegram2john.py
+++ b/run/telegram2john.py
@@ -59,8 +59,8 @@ try:
     from Crypto.Cipher import AES
 except ImportError:
     check_empty_pass = False
-    sys.stderr.write("For additional functionality, please install the PyCrypto package.\n")
-    sys.stderr.write("run 'pip install --user PyCrypto' to install it!\n")
+    sys.stderr.write("For additional functionality, please install the pycryptodome package.\n")
+    sys.stderr.write("run 'pip install --user pycryptodome' to install it!\n")
 
 PY3 = sys.version_info[0] == 3
 
@@ -153,7 +153,7 @@ def is_correct_ige_decryption(file_path, key, data):
 
 def is_map0_empty_pass(file_path, salt_hex, data_hex):
     if not check_empty_pass:
-        sys.stderr.write("ATTENTION: it couldn't be verified if a password was set for the file/account: '%s' (please install the PyCrypto package)\n" % file_path)
+        sys.stderr.write("ATTENTION: it couldn't be verified if a password was set for the file/account: '%s' (please install the pycryptodome package)\n" % file_path)
         return False
 
     salt = binascii.unhexlify(salt_hex)
@@ -165,7 +165,7 @@ def is_map0_empty_pass(file_path, salt_hex, data_hex):
 
 def is_key_datas_empty_pass(file_path, salt_hex, data_hex):
     if not check_empty_pass:
-        sys.stderr.write("ATTENTION: it couldn't be verified if a password was set for the file/account: '%s' (please install the PyCrypto package)\n" % file_path)
+        sys.stderr.write("ATTENTION: it couldn't be verified if a password was set for the file/account: '%s' (please install the pycryptodome package)\n" % file_path)
         return False
 
     salt = binascii.unhexlify(salt_hex)


### PR DESCRIPTION
The PyCrypto package is old and deprecated, pycryptodome works as a drop-in replacement with the same API.