### PR TITLE
External modes test and minor optimization

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -758,6 +758,9 @@ check: default
 	$(MAKE) unit-tests
 	../run/john --test=0 --verbosity=2 --format=cpu
 	../run/john --test=0 --verbosity=2 --format=+dynamic,all
+	if [ -x /usr/bin/md5sum ]; then \
+		JOHN=../run/john tests/test_externals.sh | md5sum -c tests/test_externals.md5; \
+	fi
 
 depend:
 	makedepend -fMakefile.dep -Y *.c 2>> /dev/null

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -537,8 +537,17 @@ static int c_expr(char term, struct c_ident *vars, char *token, int pop)
 
 			left = 1;
 		} else
-		if ((c >= '0' && c <= '9') || c == '\'') {
+		if ((c >= '0' && c <= '9') || c == '\'' || (c == '-' && !left)) {
+			if (c == '-') {
+				lookahead = c_getchar(0);
+				c_ungetchar(lookahead);
+				if (lookahead < '0' || lookahead > '9')
+					goto other;
+				token = c_gettoken();
+			}
 			value.imm = c_getint(token);
+			if (c == '-')
+				value.imm = -value.imm;
 			last = c_push(last, c_op_push_imm, &value);
 
 			left = 1; balance++;
@@ -552,6 +561,7 @@ static int c_expr(char term, struct c_ident *vars, char *token, int pop)
 			left = 0;
 		} else
 		if (c != ' ') {
+other:
 			if (c_isident[ARCH_INDEX(c)])
 				var = c_find_ident(vars, NULL, token);
 			else

--- a/src/tests/test_externals.md5
+++ b/src/tests/test_externals.md5
@@ -1,0 +1,1 @@
+fb58e1c442718dc91b0d6bc6faf1ec31  -

--- a/src/tests/test_externals.sh
+++ b/src/tests/test_externals.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+test -n "$JOHN" || JOHN=../../run/john
+
+set -x
+
+for mode in `$JOHN --list=ext-modes`; do
+# KDEPaste's output depends on the current time
+	if [ $mode != kdepaste ]; then
+		$JOHN --external=$mode --stdout --max-candidates=100000
+	fi
+done
+
+for mode in `$JOHN --list=ext-hybrids` `./john --list=ext-filters`; do
+	$JOHN -w --external=$mode --stdout --max-candidates=100000
+done


### PR DESCRIPTION
This tests almost all external modes on `make check`, which we run on CI.

This also adds proper compile-time handling of negative integer constants, which previously emitted the unary `-` instruction. Unfortunately, the code for this is a hack. It was cleaner not to handle this case specially.

My additional test case (not included here) for this optimization is:

```
[List.External:Test]
void generate()
{
	if (word[2] == 666) {
		word = 0;
		return;
	}
	word[0] =-1 + 'a' + 1 - -111 -111 - 222 + 222 -111-111+222;
	word[0] -=-22;
	word[0] -= 22;
	word[0]-=-22;
	word[0]-=22;
	word[1] = -1 + 1;
	word[2] = 666;
}
```

This has a mix of `-` in different meanings, which the compiler has to distinguish properly. The expected output is `a`.