### PR TITLE
External mode compiler: Compile-time evaluate most constant subexpressions

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -321,6 +321,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Add Combinator external mode (combines words into pairs).  [Solar; 2024]
 
+- External mode compiler: Compile-time evaluate most constant subexpressions.
+  [Solar; 2024]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -537,17 +537,8 @@ static int c_expr(char term, struct c_ident *vars, char *token, int pop)
 
 			left = 1;
 		} else
-		if ((c >= '0' && c <= '9') || c == '\'' || (c == '-' && !left)) {
-			if (c == '-') {
-				lookahead = c_getchar(0);
-				c_ungetchar(lookahead);
-				if (lookahead < '0' || lookahead > '9')
-					goto other;
-				token = c_gettoken();
-			}
+		if ((c >= '0' && c <= '9') || c == '\'') {
 			value.imm = c_getint(token);
-			if (c == '-')
-				value.imm = -value.imm;
 			last = c_push(last, c_op_push_imm, &value);
 
 			left = 1; balance++;
@@ -561,7 +552,6 @@ static int c_expr(char term, struct c_ident *vars, char *token, int pop)
 			left = 0;
 		} else
 		if (c != ' ') {
-other:
 			if (c_isident[ARCH_INDEX(c)])
 				var = c_find_ident(vars, NULL, token);
 			else

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -21,7 +21,7 @@
 #define C_ERROR_NONE			0
 #define C_ERROR_UNKNOWN			1
 #define C_ERROR_UNEXPECTED		2
-#define C_ERROR_COUNT			3
+#define C_ERROR_EXPR			3
 #define C_ERROR_TOOLONG			4
 #define C_ERROR_TOOCOMPLEX		5
 #define C_ERROR_ARRAYSIZE		6


### PR DESCRIPTION
This replaces yesterday's optimization of negative integer constants.

While the code explicitly implements constant subexpression evaluation only for individual operations (unary or binary), one at a time, it usually does also work for longer constant subexpressions, where one operation's result may get further merged into another's, all at compile time.

For unary operations, this is the easiest - a VM push instruction's last immediate operand can get repeatedly updated with subsequent unary operations' results.

For binary operations, we first get a second `push_imm` optimized into `push_imm_imm`, then the binary operation optimizes that "back" into a single `push_imm` of the result, which can get further optimized into a `push_imm_imm` to accommodate a third constant input and then into a `push_imm` again with the second binary operation's result, and so on.

This also works for mixes of unary and binary operations.

That said, there's still an unimplemented case here as documented in a comment, which makes optimization stop when encountered:

```c
        /* Compile-time evaluate binary op after push_*_imm, push_imm */
        /* Unimplemented, need to start tracking penultimate op first */
```

Our multi-push instructions on one hand help here (we can detect that a binary op has two immediate operands with one check and without keeping track of more than the last instruction), but on the other they hurt (there are many combinations, including those where a binary op's operands may have been split across two pushes anyway).

The compile-time evaluation is done by invoking tiny pieces of temporary VM code, with the VM `assign_pop` instruction tricked into it patching an immediate operand in the final VM code.

While this is fun and something I've been meaning to add for years, there's a reason why I didn't approach it sooner - there's almost no speedup from it on our existing external modes, where we don't commonly write constant subexpressions in performance-critical places. The occasional `-1` constants are pretty much the only cases where this matters in practice so far (and this was also taken care of by a more specialized change yesterday).

My new test case, which now gets optimized a lot:

```
[List.External:Test]
void generate()
{
	if (word[2] == 666) {
		word = 0;
		return;
	}
	word[0] =-1 + 'a' + 1 - -111 -111 - 222 + 222 -111-111+222;
	word[0] -=-22;
	word[0] -= 22;
	word[0]-=-22;
	word[0]-=22;
	word[0]+=(33+(33+33))-(44+44+44)+(11+11+11);
	word[1] = -1 + 1;
	word[2] = 666;
}
```

The `33+(33+33)` part triggers the yet unimplemented case mentioned above.