### PR TITLE
New version of Radius2john.py

### DIFF
--- a/run/radius2john.py
+++ b/run/radius2john.py
@@ -24,95 +24,92 @@
 # "3.1 Response Authenticator Based Shared Secret Attack"
 
 # For attack 3.3 :
-# we try authentications using a known password, and sniff the radius packets to a pcpap file.
+# We try authentications using a known password, and sniff the radius packets to a pcap file.
 # This script reads access-request in the pcap file, and dumps the md5(RA+secret) and RA, in a john-friendly format.
-# The password must be always the same, be less then 16 bytes long, and entered in the $PASSWORD variable below.
-# The user names used during this attack must be entered in @LOGINS below.
 
 # For attack 3.1:
-# we don't need to try authentications. Just sniff the radius packets in a pcap file.
+# We don't need to try authentications. Just sniff the radius packets in a pcap file.
 # This script reads the pcap file, matches radius responses with the corresponding all_requests,
 # and dumps md5 and salt as needed.
 
-import scapy.all as scapy
 import binascii
 import sys
+import argparse
 
+try:
+    import scapy.all as scapy
+except ImportError:
+    print(
+        "Scapy seems to be missing, run 'pip install --user scapy' to install it"
+    )
+    sys.exit(1)
 
-# Global variables
-PASSWORD = b"1"  # The user password used for the 3.3 attack
-LOGINS = ["max"]  # The user logins used for the 3.3 attack
-UNIQUE = 1  # Set to 0 to disable unicity of client IPs in the output file
-VALID_LOGIN = {login: True for login in LOGINS}
-
-all_requests = {}
-dumped_ips = {}
-
-
-def read_file(filename):
+def read_file(args, filename):
     packets = scapy.rdpcap(filename)
     for packet in packets:
-        process_packet(packet)
+        process_packet(args, packet)
 
 
-def process_packet(packet):
+def process_packet(args, packet):
     if packet.haslayer(scapy.IP) and packet.haslayer(scapy.UDP):
         ip_layer = packet[scapy.IP]
         udp_layer = packet[scapy.UDP]
 
         if udp_layer.dport in [1812, 1813] or udp_layer.sport in [1812, 1813]: 
-            radius_data = bytes(udp_layer.payload)
-            process_radius(ip_layer, radius_data, bytes(udp_layer.payload))
+            process_radius(args, ip_layer, bytes(udp_layer.payload))
 
 
-def process_radius(ip, radius_data, udpdata):
-    radius_packet = scapy.Radius(radius_data)
+def process_radius(args, ip, udpdata):
+    radius_packet = scapy.Radius(udpdata)
 
     if radius_packet.code in [1, 4]:  # Access-Request, Accounting-Request
 
-        user_name, user_password = None, None
-        for _ in range(len(radius_packet.attributes)):
-            if radius_packet.attributes[_].name == "User-Name":
-                user_name = radius_packet.attributes[_].value.decode("utf-8")
+        if args['password'] is not None:
 
-            if radius_packet.attributes[_].name == "User-Password":
-                user_password = radius_packet.attributes[_].value.decode("utf-8")
+            user_name, user_hash = None, None
 
-        if user_name in VALID_LOGIN and user_password:
-            dump_access_request(
-                ip.src, user_name, radius_packet.authenticator, user_password
-            )
+            for attr in radius_packet.attributes:
+                if attr.name == "User-Name":
+                    user_name = attr.value.decode("utf-8")
+
+                if attr.name == "User-Password":
+                    user_hash = attr.value
+
+            if user_hash is not None:
+                if (args['login'] is not None and user_name == args['login']) or args['login'] is None:
+                    dump_access_request(
+                        args, ip.src, radius_packet.authenticator, user_hash
+                    )
 
         all_requests[f"{ip.src}-{radius_packet.id}"] = radius_packet.authenticator
 
     elif radius_packet.code in [2, 11, 3, 5]:  # Access-Accept, Access-Challenge, Access-Reject, Accounting-Response
         key = f"{ip.dst}-{radius_packet.id}"
         if key in all_requests:
-            dump_response(ip.dst, all_requests[key], radius_packet, udpdata)
+            dump_response(args, ip.dst, all_requests[key], radius_packet.authenticator, udpdata)
 
 
-def dump_response(ip, req_ra, radius_packet, udpdata):  # 3.1 attack
-    if UNIQUE and ip in dumped_ips:
+def dump_response(args, ip, req_ra, ra, udpdata):  # 3.1 attack
+    if args["single"] and ip in dumped_ips:
         return
-
-    hash_val = radius_packet.authenticator
 
     salt = bytearray(udpdata)
     salt[4:20] = req_ra  # Replace Response Authenticator with the Request Authenticator
 
     response_type = "1009" if len(salt) <= 16 else "1017"
     print(
-        f"{ip}:$dynamic_{response_type}${binascii.hexlify(hash_val).decode()}$HEX${binascii.hexlify(salt).decode('utf-8')}"
+        f"{ip}:$dynamic_{response_type}${binascii.hexlify(ra).decode()}$HEX${binascii.hexlify(salt).decode('utf-8')}"
     )
 
     dumped_ips[ip] = "reply"
 
 
-def dump_access_request(ip, login, ra, hashed):  # 3.3 attack
-    if UNIQUE and ip in dumped_ips and dumped_ips[ip] == "request":
+def dump_access_request(args, ip, ra, hashed):  # 3.3 attack
+    if args["single"] and ip in dumped_ips and dumped_ips[ip] == "request":
         return
 
-    xor_result = bytes(a ^ b for a, b in zip(hashed, PASSWORD))
+    xor_result = bytes(a ^ b for a, b in zip(hashed, args['password'][:16].encode('utf-8').ljust(16, b'\x00')))
+
     print(
         f"{ip}:$dynamic_1008${binascii.hexlify(xor_result).decode()}$HEX${binascii.hexlify(ra).decode('utf-8')}"
     )
@@ -122,18 +119,45 @@ def dump_access_request(ip, login, ra, hashed):  # 3.3 attack
 
 if __name__ == "__main__":
 
-    try:
-        import scapy.all as scapy
-    except ImportError:
-        print(
-            "Scapy seems to be missing, run 'pip install --user scapy' to install it"
-        )
-        exit(1)
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,epilog=
+    """
+    ### Utility to bruteforce RADIUS shared-secret written by k4amos
+    Basic Usage: ./radius2john.py <pcap files>"
 
-    if len(sys.argv) > 1 and "-h" not in sys.argv and "--help" not in sys.argv:
-        for filename in sys.argv[1:]:
-            read_file(filename)
-    else:
-        print(
-            "Utility to bruteforce RADIUS shared-secret written by k4amos \nUsage: ./radius2john.py <pcap files>"
-        )
+    ---
+
+    Application of two  methods described in http://www.untruth.org/~josh/security/radius/radius-auth.html :
+    - "3.3 User-Password Attribute Based Shared Secret Attack"
+    - "3.1 Response Authenticator Based Shared Secret Attack"
+
+    # For attack 3.3 :
+    We try authentications using a known password, and sniff the radius packets to a pcap file.
+    This script reads access-request in the pcap file, and dumps the md5(RA+secret) and RA, in a john-friendly format.
+
+    # For attack 3.1:
+    We don't need to try authentications. Just sniff the radius packets in a pcap file.
+    This script reads the pcap file, matches radius responses with the corresponding all_requests,
+    and dumps md5 and salt as needed.
+    		""")
+
+    parser.add_argument('-f', '--file', type=str, required=True, nargs='+')
+    parser.add_argument('--single', help='To get only one hash per client IPs', action='store_true', default=False)
+    parser.add_argument('-l', '--login', type=str,help='User login used for the 3.3 attack')
+    parser.add_argument('-p', '--password', type=str, help='User password used for the 3.3 attack')
+    
+
+
+    parsed_args = parser.parse_args()
+    args = vars(parsed_args)
+
+    if args["login"] is not None and args["password"] is None:
+        print("You must specify the password used by the client for the '3.3 User-Password Attribute Based Shared Secret Attack'")
+        print("Basic Usage: ./radius2john.py <pcap files>")
+        print("You can specify '-h' to display help")
+        sys.exit(1)
+
+    all_requests = {}
+    dumped_ips = {}
+
+    for filename in args['file']:
+        read_file(args, filename)

--- a/run/radius2john.py
+++ b/run/radius2john.py
@@ -1,68 +1,126 @@
 #!/usr/bin/env python
 
-# This software is Copyright (c) 2019 Maxime GOYETTE <maxgoyette0-at-gmail.com>,
+# This software is Copyright (c) 2024, k4amos <k4amos at proton.me>
 # and it is hereby released to the general public under the following terms:
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted.
-#
+
+# This script is the python version of radius2john.pl written by Didier ARENZANA
+
 # Utility to bruteforce RADIUS shared-secret
 # Usage: ./radius2john.py <pcap files>
 #
 # This script depends on Scapy (https://scapy.net)
 # To install: pip install --user scapy
 
-try:
-    from scapy.all import *
-except ImportError:
-    print("scapy is missing, run 'pip install --user scapy' to install it!")
-    exit(1)
+# application of two  methods described in http://www.untruth.org/~josh/security/radius/radius-auth.html :
+# "3.3 User-Password Attribute Based Shared Secret Attack" and
+# "3.1 "Response Authenticator Based Shared Secret Attack"
 
-from binascii import hexlify
-from sys import argv
-import os
+# For attack 3.3 :
+# we try authentications using a known password, and sniff the radius packets to a pcpap file.
+# This script reads access-request in the pcap file, and dumps the md5(RA+secret) and RA, in a john-friendly format.
+# The password must be always the same, be less then 16 bytes long, and entered in the $PASSWORD variable below.
+# The user names used during this attack must be entered in @LOGINS below.
 
-if len(argv) < 2:
-    print('Usage: ./radius2john.py <pcap files>')
-    exit(1)
+# For attack 3.1:
+# we don't need to try authentications. Just sniff the radius packets in a pcap file.
+# This script reads the pcap file, matches radius responses with the corresponding all_requests,
+# and dumps md5 and salt as needed.
 
-filenames = argv[1:]
+import scapy.all as scapy
+import binascii
+import sys
 
-for filename in filenames:
 
-    capture_file = rdpcap(filename)
+# Global variables
+PASSWORD = b"1"  # The user password used for the 3.3 attack
+LOGINS = ["max"]  # The user logins used for the 3.3 attack
+UNIQUE = 1  # Set to 0 to disable unicity of client IPs in the output file
+VALID_LOGIN = {login: True for login in LOGINS}
 
-    accounting_request_packets = {}
-    accounting_response_packets = {}
+all_requests = {}
+dumped_ips = {}
 
-    for packet in capture_file:
 
-        if Radius in packet:
-            src_ip = packet[IP].src
-            dst_ip = packet[IP].dst
+def read_file(filename):
+    packets = scapy.rdpcap(filename)
+    for packet in packets:
+        process_packet(packet)
 
-            if packet[Radius].code == 4 and not (src_ip, dst_ip) in accounting_request_packets:
-                accounting_request_packets[(src_ip, dst_ip)] = packet
-            elif packet[Radius].code == 5 and not (dst_ip, src_ip) in accounting_response_packets:
-                accounting_response_packets[(dst_ip, src_ip)] = packet
 
-    for ips, packet in accounting_response_packets.items():
-        if ips in accounting_request_packets:
-            code = hex(packet[Radius].code)[2:].zfill(2)
-            identifier = hex(packet[Radius].id)[2:].zfill(2)
-            length = hex(packet[Radius].len)[2:].zfill(4)
-            authenticator = hexlify(accounting_request_packets[ips][Radius].authenticator).decode('utf-8')
+def process_packet(packet):
+    if packet.haslayer(scapy.IP) and packet.haslayer(scapy.UDP):
+        ip_layer = packet[scapy.IP]
+        udp_layer = packet[scapy.UDP]
 
-            salt = code + identifier + length + authenticator
+        if udp_layer.dport == 1812 or udp_layer.sport == 1812:
+            radius_data = bytes(udp_layer.payload)
+            process_radius(ip_layer, radius_data, bytes(udp_layer.payload))
 
-            hash_content = hexlify(packet[Radius].authenticator).decode('utf-8')
-            hash_type = 1009 if len(salt) <= 16 else 1017
 
-            file_path = os.path.abspath(filename)
+def process_radius(ip, radius_data, udpdata):
+    radius_packet = scapy.Radius(radius_data)
 
-            print('{ip}({file_path}):$dynamic_{type}${hash}$HEX${salt}'.format(
-                file_path=file_path,
-                ip=ips[1],
-                type=hash_type,
-                hash=hash_content,
-                salt=salt
-            ))
+    if radius_packet.code == 1:  # Access-Request
+
+        user_name, user_password = None, None
+        for _ in range(len(radius_packet.attributes)):
+            if radius_packet.attributes[_].name == "User-Name":
+                user_name = radius_packet.attributes[_].value.decode("utf-8")
+
+            if radius_packet.attributes[_].name == "User-Password":
+                user_password = radius_packet.attributes[_].value.decode("utf-8")
+
+        if user_name in VALID_LOGIN and user_password:
+            dump_access_request(
+                ip.src, user_name, radius_packet.authenticator, user_password
+            )
+
+        all_requests[f"{ip.src}-{radius_packet.id}"] = radius_packet.authenticator
+
+    elif radius_packet.code in [2, 11, 3]:  # Access-Accept, Access-Challenge, Access-Reject
+        key = f"{ip.dst}-{radius_packet.id}"
+        if key in all_requests:
+            dump_response(ip.dst, all_requests[key], radius_packet, udpdata)
+
+
+def dump_response(ip, req_ra, radius_packet, udpdata):  # 3.1 attack
+    if UNIQUE and ip in dumped_ips:
+        return
+
+    hash_val = radius_packet.authenticator
+
+    salt = bytearray(udpdata)
+    salt[4:20] = req_ra  # Replace Response Authenticator with the Request Authenticator
+
+    response_type = "1009" if len(salt) <= 16 else "1017"
+    print(
+        f"{ip}:$dynamic_{response_type}${binascii.hexlify(hash_val).decode()}$HEX${binascii.hexlify(salt).decode('utf-8')}"
+    )
+
+    dumped_ips[ip] = "reply"
+
+
+def dump_access_request(ip, login, ra, hashed):  # 3.3 attack
+    if UNIQUE and ip in dumped_ips and dumped_ips[ip] == "request":
+        return
+
+    xor_result = bytes(a ^ b for a, b in zip(hashed, PASSWORD))
+    print(
+        f"{ip}:$dynamic_1008${binascii.hexlify(xor_result).decode()}$HEX${binascii.hexlify(ra).decode('utf-8')}"
+    )
+
+    dumped_ips[ip] = "request"
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) > 1 and "-h" not in sys.argv and "--help" not in sys.argv:
+        for filename in sys.argv[1:]:
+            read_file(filename)
+    else:
+        print(
+            "Utility to bruteforce RADIUS shared-secret written by k4amos \nUsage: ./radius2john.py <pcap files>"
+        )

--- a/run/radius2john.py
+++ b/run/radius2john.py
@@ -12,7 +12,7 @@
 # ---
 
 # Utility to bruteforce RADIUS shared-secret
-# Usage: ./radius2john.py <pcap files>
+# Usage: ./radius2john.py -f <pcap files>
 #
 # This script depends on Scapy (https://scapy.net)
 # To install: pip install --user scapy
@@ -76,7 +76,7 @@ def process_radius(args, ip, udpdata):
                     user_hash = attr.value
 
             if user_hash is not None:
-                if (args['login'] is not None and user_name == args['login']) or args['login'] is None:
+                if args['login'] is None or user_name == args['login']:
                     dump_access_request(
                         args, ip.src, radius_packet.authenticator, user_hash
                     )
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,epilog=
     """
     ### Utility to bruteforce RADIUS shared-secret written by k4amos
-    Basic Usage: ./radius2john.py <pcap files>"
+    Basic Usage: ./radius2john.py -f <pcap files>"
 
     ---
 
@@ -145,14 +145,13 @@ if __name__ == "__main__":
     parser.add_argument('-l', '--login', type=str,help='User login used for the 3.3 attack')
     parser.add_argument('-p', '--password', type=str, help='User password used for the 3.3 attack')
     
-
-
     parsed_args = parser.parse_args()
     args = vars(parsed_args)
 
-    if args["login"] is not None and args["password"] is None:
+    if args["login"] is not None and args["password"] is None: 
+        # Attack 3.3 can work without login verification (if there is only one client, there is no point), but cannot work without a password
         print("You must specify the password used by the client for the '3.3 User-Password Attribute Based Shared Secret Attack'")
-        print("Basic Usage: ./radius2john.py <pcap files>")
+        print("Basic Usage: ./radius2john.py -f <pcap files>")
         print("You can specify '-h' to display help")
         sys.exit(1)
 


### PR DESCRIPTION
`radius2john.py` didn't seem to be able to work properly : 

- The attack method is described  [here](http://www.untruth.org/~josh/security/radius/radius-auth.html). The previous version of `radius2john.py` implemented the _3.1 Response Authenticator Based Shared Secret Attack_. The attacker can pre-compute the MD5 state for (Code+ID+Length+RequestAuth+Attributes). However, the value of the attributes was forgotten in the code, the calculated hash could not be broken if there were attributes.
- The _3.3 User-Password Attribute Based Shared Secret Attack_ was not implemented

For these two reasons, I propose a new version of radius2john.py much closer to the perl version _radius2john.pl_

![image](https://github.com/openwall/john/assets/70712826/1e94c5f0-3ba8-4249-8d93-9f03a94b7029)
