### PR TITLE
pcap2john.py: improved HSRP parsing

### DIFF
--- a/run/dns/rdata.py
+++ b/run/dns/rdata.py
@@ -274,7 +274,7 @@ class GenericRdata(Rdata):
     @classmethod
     def from_text(cls, rdclass, rdtype, tok, origin=None, relativize=True):
         token = tok.get()
-        if not token.is_identifier() or token.value != '\#':
+        if not token.is_identifier() or token.value != r'\#':
             raise dns.exception.SyntaxError(
                 r'generic rdata does not start with \#')
         length = tok.get_int()

--- a/run/pcap2john.py
+++ b/run/pcap2john.py
@@ -582,86 +582,20 @@ def pcap_parser_isis(fname):
 
     f.close()
 
-"""
-
-UDP payload (HSRP message) format (https://www.ietf.org/rfc/rfc2281.txt)
-
-                          1                   2                   3
-
-   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |   Version     |   Op Code     |     State     |   Hellotime   |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |   Holdtime    |   Priority    |     Group     |   Reserved    |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                      Authentication  Data                     |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                      Authentication  Data                     |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                      Virtual IP Address                       |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-
-# from scapy sources
-if len(hsrp-payload) > 28:
-    MD5 authentication is being used
-
-class HSRPmd5(Packet):
-    name = "HSRP MD5 Authentication"
-    fields_desc = [
-        ByteEnumField("type", 4, {4: "MD5 authentication"}),
-        ByteField("len", None),
-        ByteEnumField("algo", 0, {1: "MD5"}),
-        ByteField("padding", 0x00),
-        XShortField("flags", 0x00),
-        IPField("sourceip", None),
-        XIntField("keyid", 0x00),  # 14 bytes here
-        StrFixedLenField("authdigest", "\00" * 16, 16)]
-
-"""
-
 
 def pcap_parser_hsrp(fname):
+    # HSRP message format: https://www.ietf.org/rfc/rfc2281.txt
 
-    f = open(fname, "rb")
-    pcap = dpkt.pcap.Reader(f)
+    pcap = rdpcap(fname)
 
-    for _, buf in pcap:
-        eth = dpkt.ethernet.Ethernet(buf)
-        if eth.type == dpkt.ethernet.ETH_TYPE_IP:
-            ip = eth.data
-
-            if ip.v != 4:  # IPv6 is a fad
+    for pkt in pcap:
+        if pkt.haslayer(HSRPmd5):
+            pkt = pkt['HSRP']
+            if pkt['HSRPmd5'].type != 4:
                 continue
-
-            if ip.p != dpkt.ip.IP_PROTO_UDP:
-                continue
-
-            udp = ip.data
-            hsrp = udp.data
-
-            if udp.dport != 1985:  # is this HSRP traffic?
-                continue
-
-            if ord(hsrp[0]) != 0:  # HSRP version
-                continue
-
-            if len(hsrp) <= 28:  # doesn't use MD5 authentication
-                continue
-
-            if len(hsrp) != 50:  # 20 bytes HSRP + 30 bytes for the MD5 authentication payload
-                continue
-
-            auth_type = ord(hsrp[20])
-            if auth_type != 4:
-                continue
-
-            h = hsrp[-16:].encode("hex")  # MD5 hash
-            # 20 bytes (HSRP) + 14 (till "keyid") + zero padding (double-check this) to make 50 bytes!
-            salt = hsrp.encode("hex")[:68] + ("\x00" * (50 - 20 - 14)).encode("hex")
-            print("$hsrp$%s$%s" % (salt, h))
-
-    f.close()
+            h = bytes(pkt['HSRPmd5'].authdigest)
+            salt = bytes(pkt)[:34] + b"\x00"*16
+            print("$hsrp$%s$%s" % (hexlify(salt).decode('ascii'), hexlify(h).decode('ascii')))
 
 
 def pcap_parser_hsrp_v2(fname):


### PR DESCRIPTION
Improves parsing of HSRP packets in `pcap2john.py`. It was not compatible with python3 but now is with both, python3 and python2. Did this by using scapy instead of the dpkt library, which also simplifies the code a lot.

The other commit just fixes a syntax warning in the dns implementation.

closes #5499

Tested with all pcaps in https://github.com/openwall/john-samples/tree/main/HSRP/packet-captures

(Please note that I may not respond over this weekend if there are any questions.)