### PR TITLE
pcap2john.py: improvements for htdigest, gadu, cleanup

### DIFF
--- a/run/pcap2john.py
+++ b/run/pcap2john.py
@@ -16,7 +16,6 @@ import os
 import socket
 import struct
 import sys
-import time
 
 import logging
 l = logging.getLogger("scapy.runtime")
@@ -180,6 +179,9 @@ def pcap_parser_vtp(fname):
 
 
 def pcap_parser_vrrp(fname):
+    """
+    Parse packets of the Virtual Router Redundancy Protocol (VRRP).
+    """
 
     pcap = rdpcap(fname)
 
@@ -585,7 +587,10 @@ def pcap_parser_isis(fname):
 
 
 def pcap_parser_hsrp(fname):
-    # HSRP message format: https://www.ietf.org/rfc/rfc2281.txt
+    """
+    Parse packets of the Hot Standby Router Protocol (HSRP).
+    https://www.rfc-editor.org/rfc/rfc2281
+    """
 
     pcap = rdpcap(fname)
 
@@ -1308,7 +1313,6 @@ if __name__ == "__main__":
 
     # advertise what is not handled
     sys.stderr.write("Note: This program does not have the functionality of wpapcap2john, SIPdump, eapmd5tojohn, and vncpcap2john programs which are included with JtR Jumbo.\n\n")
-    time.sleep(1)
 
     for i in range(1, len(sys.argv)):
         try:


### PR DESCRIPTION
Some enhancements for `pcap2john.py`.

- Rewrote `pcap_parser_htdigest` function to use scapy for parsing. Prior to this change, it was crashing on pcapng files (as opposed to pcap). Furthermore, it was not compatible with Python 3, now it is. While I was at it, I decided to print Basic Auth credentials directly to stderr. Could be interesting too, but no cracking required. Renamed the function to `pcap_parser_http_authorization` in this course. Since there was no example file for testing I created https://github.com/openwall/john-samples/pull/26.

- A cleanup commit removes an annoying call to `sleep` and adds a few comments.

- Accidentally, I discovered `pcap_parser_gadu` was not compatible with Python 3, now it is. I refactored the function a bit to make it more conformant to the remainder of the script. Tested with the [available sample files](https://github.com/openwall/john-samples/tree/main/Gadu-Gadu).