### PR TITLE
PDF-opencl

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -334,6 +334,10 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Add tokenize.pl (identify and replace most common multi-character tokens in a
   wordlist or password list e.g. to augment incremental mode).  [Solar; 2024]
 
+- Add OpenCL version of PDF format.  This also corrected bugs in handling of
+  v3 RC-40 hashes as well as more obscure key lengths that are probably not
+  used anywhere.  [magnum; 2024]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/run/opencl/ed25519-donna/ed25519-hash.h
+++ b/run/opencl/ed25519-donna/ed25519-hash.h
@@ -17,14 +17,14 @@ ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {
 	ulong W[16];
 	ulong A, B, C, D, E, F, G, H, t;
 
-	A = SHA2_INIT_A;
-	B = SHA2_INIT_B;
-	C = SHA2_INIT_C;
-	D = SHA2_INIT_D;
-	E = SHA2_INIT_E;
-	F = SHA2_INIT_F;
-	G = SHA2_INIT_G;
-	H = SHA2_INIT_H;
+	A = SHA512_INIT_A;
+	B = SHA512_INIT_B;
+	C = SHA512_INIT_C;
+	D = SHA512_INIT_D;
+	E = SHA512_INIT_E;
+	F = SHA512_INIT_F;
+	G = SHA512_INIT_G;
+	H = SHA512_INIT_H;
 
 	/* Assume inlen is 32 */
 	GET_UINT64BE(W[0], in, 0);
@@ -40,13 +40,13 @@ ed25519_hash(uint8_t *hash, const uint8_t *in, size_t inlen) {
 
 	SHA512_ZEROS(A, B, C, D, E, F, G, H, W);
 
-	PUT_UINT64BE(A + SHA2_INIT_A, hash, 0);
-	PUT_UINT64BE(B + SHA2_INIT_B, hash, 8);
-	PUT_UINT64BE(C + SHA2_INIT_C, hash, 16);
-	PUT_UINT64BE(D + SHA2_INIT_D, hash, 24);
-	PUT_UINT64BE(E + SHA2_INIT_E, hash, 32);
-	PUT_UINT64BE(F + SHA2_INIT_F, hash, 40);
-	PUT_UINT64BE(G + SHA2_INIT_G, hash, 48);
-	PUT_UINT64BE(H + SHA2_INIT_H, hash, 56);
+	PUT_UINT64BE(A + SHA512_INIT_A, hash, 0);
+	PUT_UINT64BE(B + SHA512_INIT_B, hash, 8);
+	PUT_UINT64BE(C + SHA512_INIT_C, hash, 16);
+	PUT_UINT64BE(D + SHA512_INIT_D, hash, 24);
+	PUT_UINT64BE(E + SHA512_INIT_E, hash, 32);
+	PUT_UINT64BE(F + SHA512_INIT_F, hash, 40);
+	PUT_UINT64BE(G + SHA512_INIT_G, hash, 48);
+	PUT_UINT64BE(H + SHA512_INIT_H, hash, 56);
 }
 #endif

--- a/run/opencl/md5x50.h
+++ b/run/opencl/md5x50.h
@@ -1,0 +1,248 @@
+/*
+ * This software is Copyright (c) 2024 magnum and it is hereby released to the
+ * general public under the following terms:  Redistribution and use in source
+ * and binary forms, with or without modification, are permitted.
+ */
+
+#include "opencl_md5.h"
+
+#define RnA(a, b, s)        a = rotate(a, (uint)s) + b
+
+#define INIT_A 0x67452301
+#define INIT_B 0xefcdab89
+#define INIT_C 0x98badcfe
+#define INIT_D 0x10325476
+
+inline void md5x50_40(uint* msg)
+{
+	uint a, b, c, d;
+	int i;
+
+	a = msg[0];
+	b = msg[1] & 0xff;
+	c = 0;
+	d = 0;
+
+	for (i = 0; i < 50; ++i) {
+		uint aa, bb;
+
+		b |= 0x8000;
+
+		bb = b;
+		aa = a;
+
+		/** round 1 */
+#if 0
+		a = INIT_A;
+		b = INIT_B;
+		c = INIT_C;
+		d = INIT_D;
+		MD5_STEP(MD5_F, a, b, c, d, aa, 0xd76aa478,  7);
+		MD5_STEP(MD5_F, d, a, b, c, bb, 0xe8c7b756, 12);
+		MD5_STEP(MD5_F, c, d, a, b,  0, 0x242070db, 17);
+		MD5_STEP(MD5_F, b, c, d, a,  0, 0xc1bdceee, 22);
+#else
+		a += 0xd76aa477;
+		RnA(a, INIT_B, 7);
+		d = 0xf8fa0bcc + b + (INIT_C ^ (a & 0x77777777));
+		RnA(d, a, 12);
+		c = 0xbcdb4dd9 + (INIT_B ^ (d & (a ^ INIT_B)));
+		RnA(c, d, 17);
+		b = 0xb18b7a77 + (a ^ (c & (d ^ a)));
+		RnA(b, c, 22);
+#endif
+		MD5_STEP(MD5_F, a, b, c, d,  0, 0xf57c0faf,  7);
+		MD5_STEP(MD5_F, d, a, b, c,  0, 0x4787c62a, 12);
+		MD5_STEP(MD5_F, c, d, a, b,  0, 0xa8304613, 17);
+		MD5_STEP(MD5_F, b, c, d, a,  0, 0xfd469501, 22);
+		MD5_STEP(MD5_F, a, b, c, d,  0, 0x698098d8,  7);
+		MD5_STEP(MD5_F, d, a, b, c,  0, 0x8b44f7af, 12);
+		MD5_STEP(MD5_F, c, d, a, b,  0, 0xffff5bb1, 17);
+		MD5_STEP(MD5_F, b, c, d, a,  0, 0x895cd7be, 22);
+		MD5_STEP(MD5_F, a, b, c, d,  0, 0x6b901122,  7);
+		MD5_STEP(MD5_F, d, a, b, c,  0, 0xfd987193, 12);
+		MD5_STEP(MD5_F, c, d, a, b, 40, 0xa679438e, 17);
+		MD5_STEP(MD5_F, b, c, d, a,  0, 0x49b40821, 22);
+
+		/** round 2 */
+		MD5_STEP(MD5_G, a, b, c, d, bb, 0xf61e2562,  5);
+		MD5_STEP(MD5_G, d, a, b, c,  0, 0xc040b340,  9);
+		MD5_STEP(MD5_G, c, d, a, b,  0, 0x265e5a51, 14);
+		MD5_STEP(MD5_G, b, c, d, a, aa, 0xe9b6c7aa, 20);
+		MD5_STEP(MD5_G, a, b, c, d,  0, 0xd62f105d,  5);
+		MD5_STEP(MD5_G, d, a, b, c,  0, 0x02441453,  9);
+		MD5_STEP(MD5_G, c, d, a, b,  0, 0xd8a1e681, 14);
+		MD5_STEP(MD5_G, b, c, d, a,  0, 0xe7d3fbc8, 20);
+		MD5_STEP(MD5_G, a, b, c, d,  0, 0x21e1cde6,  5);
+		MD5_STEP(MD5_G, d, a, b, c, 40, 0xc33707d6,  9);
+		MD5_STEP(MD5_G, c, d, a, b,  0, 0xf4d50d87, 14);
+		MD5_STEP(MD5_G, b, c, d, a,  0, 0x455a14ed, 20);
+		MD5_STEP(MD5_G, a, b, c, d,  0, 0xa9e3e905,  5);
+		MD5_STEP(MD5_G, d, a, b, c,  0, 0xfcefa3f8,  9);
+		MD5_STEP(MD5_G, c, d, a, b,  0, 0x676f02d9, 14);
+		MD5_STEP(MD5_G, b, c, d, a,  0, 0x8d2a4c8a, 20);
+
+		/** round 3 */
+		MD5_STEP(MD5_H,  a, b, c, d,  0, 0xfffa3942,  4);
+		MD5_STEP(MD5_H2, d, a, b, c,  0, 0x8771f681, 11);
+		MD5_STEP(MD5_H,  c, d, a, b,  0, 0x6d9d6122, 16);
+		MD5_STEP(MD5_H2, b, c, d, a, 40, 0xfde5380c, 23);
+		MD5_STEP(MD5_H,  a, b, c, d, bb, 0xa4beea44,  4);
+		MD5_STEP(MD5_H2, d, a, b, c,  0, 0x4bdecfa9, 11);
+		MD5_STEP(MD5_H,  c, d, a, b,  0, 0xf6bb4b60, 16);
+		MD5_STEP(MD5_H2, b, c, d, a,  0, 0xbebfbc70, 23);
+		MD5_STEP(MD5_H,  a, b, c, d,  0, 0x289b7ec6,  4);
+		MD5_STEP(MD5_H2, d, a, b, c, aa, 0xeaa127fa, 11);
+		MD5_STEP(MD5_H,  c, d, a, b,  0, 0xd4ef3085, 16);
+		MD5_STEP(MD5_H2, b, c, d, a,  0, 0x04881d05, 23);
+		MD5_STEP(MD5_H,  a, b, c, d,  0, 0xd9d4d039,  4);
+		MD5_STEP(MD5_H2, d, a, b, c,  0, 0xe6db99e5, 11);
+		MD5_STEP(MD5_H,  c, d, a, b,  0, 0x1fa27cf8, 16);
+		MD5_STEP(MD5_H2, b, c, d, a,  0, 0xc4ac5665, 23);
+
+		/** round 4 */
+		MD5_STEP(MD5_I, a, b, c, d, aa, 0xf4292244,  6);
+		MD5_STEP(MD5_I, d, a, b, c,  0, 0x432aff97, 10);
+		MD5_STEP(MD5_I, c, d, a, b, 40, 0xab9423a7, 15);
+		MD5_STEP(MD5_I, b, c, d, a,  0, 0xfc93a039, 21);
+		MD5_STEP(MD5_I, a, b, c, d,  0, 0x655b59c3,  6);
+		MD5_STEP(MD5_I, d, a, b, c,  0, 0x8f0ccc92, 10);
+		MD5_STEP(MD5_I, c, d, a, b,  0, 0xffeff47d, 15);
+		MD5_STEP(MD5_I, b, c, d, a, bb, 0x85845dd1, 21);
+		MD5_STEP(MD5_I, a, b, c, d,  0, 0x6fa87e4f,  6);
+		MD5_STEP(MD5_I, d, a, b, c,  0, 0xfe2ce6e0, 10);
+		MD5_STEP(MD5_I, c, d, a, b,  0, 0xa3014314, 15);
+		MD5_STEP(MD5_I, b, c, d, a,  0, 0x4e0811a1, 21);
+		MD5_STEP(MD5_I, a, b, c, d,  0, 0xf7537e82,  6);
+		MD5_STEP(MD5_I, d, a, b, c,  0, 0xbd3af235, 10);
+		MD5_STEP(MD5_I, c, d, a, b,  0, 0x2ad7d2bb, 15);
+		MD5_STEP(MD5_I, b, c, d, a,  0, 0xeb86d391, 21);
+
+		a += INIT_A;
+		b = (b + INIT_B) & 0xff;
+		c = 0;
+		d = 0;
+	}
+
+	msg[0] = a;
+	msg[1] = b;
+	msg[2] = 0;
+	msg[3] = 0;
+}
+
+inline void md5x50_128(uint* msg)
+{
+	uint a, b, c, d;
+	int i;
+
+	a = msg[0];
+	b = msg[1];
+	c = msg[2];
+	d = msg[3];
+
+	for (i = 0; i < 50; ++i) {
+		uint aa, bb, cc, dd;
+
+		dd = d;
+		cc = c;
+		bb = b;
+		aa = a;
+
+		/** round 1 */
+#if 0
+		a = INIT_A;
+		b = INIT_B;
+		c = INIT_C;
+		d = INIT_D;
+		MD5_STEP(MD5_F, a, b, c, d, aa, 0xd76aa478,  7);
+		MD5_STEP(MD5_F, d, a, b, c, bb, 0xe8c7b756, 12);
+		MD5_STEP(MD5_F, c, d, a, b, cc, 0x242070db, 17);
+		MD5_STEP(MD5_F, b, c, d, a, dd, 0xc1bdceee, 22);
+#else
+		a += 0xd76aa477;
+		RnA(a, INIT_B, 7);
+		d = 0xf8fa0bcc + b + (INIT_C ^ (a & 0x77777777));
+		RnA(d, a, 12);
+		c += 0xbcdb4dd9 + (INIT_B ^ (d & (a ^ INIT_B)));
+		RnA(c, d, 17);
+		b = 0xb18b7a77 + dd + (a ^ (c & (d ^ a)));
+		RnA(b, c, 22);
+#endif
+		MD5_STEP(MD5_F, a, b, c, d, 0x80, 0xf57c0faf,  7);
+		MD5_STEP(MD5_F, d, a, b, c,    0, 0x4787c62a, 12);
+		MD5_STEP(MD5_F, c, d, a, b,    0, 0xa8304613, 17);
+		MD5_STEP(MD5_F, b, c, d, a,    0, 0xfd469501, 22);
+		MD5_STEP(MD5_F, a, b, c, d,    0, 0x698098d8,  7);
+		MD5_STEP(MD5_F, d, a, b, c,    0, 0x8b44f7af, 12);
+		MD5_STEP(MD5_F, c, d, a, b,    0, 0xffff5bb1, 17);
+		MD5_STEP(MD5_F, b, c, d, a,    0, 0x895cd7be, 22);
+		MD5_STEP(MD5_F, a, b, c, d,    0, 0x6b901122,  7);
+		MD5_STEP(MD5_F, d, a, b, c,    0, 0xfd987193, 12);
+		MD5_STEP(MD5_F, c, d, a, b,  128, 0xa679438e, 17);
+		MD5_STEP(MD5_F, b, c, d, a,    0, 0x49b40821, 22);
+
+		/** round 2 */
+		MD5_STEP(MD5_G, a, b, c, d,   bb, 0xf61e2562,  5);
+		MD5_STEP(MD5_G, d, a, b, c,    0, 0xc040b340,  9);
+		MD5_STEP(MD5_G, c, d, a, b,    0, 0x265e5a51, 14);
+		MD5_STEP(MD5_G, b, c, d, a,   aa, 0xe9b6c7aa, 20);
+		MD5_STEP(MD5_G, a, b, c, d,    0, 0xd62f105d,  5);
+		MD5_STEP(MD5_G, d, a, b, c,    0, 0x02441453,  9);
+		MD5_STEP(MD5_G, c, d, a, b,    0, 0xd8a1e681, 14);
+		MD5_STEP(MD5_G, b, c, d, a, 0x80, 0xe7d3fbc8, 20);
+		MD5_STEP(MD5_G, a, b, c, d,    0, 0x21e1cde6,  5);
+		MD5_STEP(MD5_G, d, a, b, c,  128, 0xc33707d6,  9);
+		MD5_STEP(MD5_G, c, d, a, b,   dd, 0xf4d50d87, 14);
+		MD5_STEP(MD5_G, b, c, d, a,    0, 0x455a14ed, 20);
+		MD5_STEP(MD5_G, a, b, c, d,    0, 0xa9e3e905,  5);
+		MD5_STEP(MD5_G, d, a, b, c,   cc, 0xfcefa3f8,  9);
+		MD5_STEP(MD5_G, c, d, a, b,    0, 0x676f02d9, 14);
+		MD5_STEP(MD5_G, b, c, d, a,    0, 0x8d2a4c8a, 20);
+
+		/** round 3 */
+		MD5_STEP(MD5_H,  a, b, c, d,    0, 0xfffa3942,  4);
+		MD5_STEP(MD5_H2, d, a, b, c,    0, 0x8771f681, 11);
+		MD5_STEP(MD5_H,  c, d, a, b,    0, 0x6d9d6122, 16);
+		MD5_STEP(MD5_H2, b, c, d, a,  128, 0xfde5380c, 23);
+		MD5_STEP(MD5_H,  a, b, c, d,   bb, 0xa4beea44,  4);
+		MD5_STEP(MD5_H2, d, a, b, c, 0x80, 0x4bdecfa9, 11);
+		MD5_STEP(MD5_H,  c, d, a, b,    0, 0xf6bb4b60, 16);
+		MD5_STEP(MD5_H2, b, c, d, a,    0, 0xbebfbc70, 23);
+		MD5_STEP(MD5_H,  a, b, c, d,    0, 0x289b7ec6,  4);
+		MD5_STEP(MD5_H2, d, a, b, c,   aa, 0xeaa127fa, 11);
+		MD5_STEP(MD5_H,  c, d, a, b,   dd, 0xd4ef3085, 16);
+		MD5_STEP(MD5_H2, b, c, d, a,    0, 0x04881d05, 23);
+		MD5_STEP(MD5_H,  a, b, c, d,    0, 0xd9d4d039,  4);
+		MD5_STEP(MD5_H2, d, a, b, c,    0, 0xe6db99e5, 11);
+		MD5_STEP(MD5_H,  c, d, a, b,    0, 0x1fa27cf8, 16);
+		MD5_STEP(MD5_H2, b, c, d, a,   cc, 0xc4ac5665, 23);
+
+		/** round 4 */
+		MD5_STEP(MD5_I, a, b, c, d,   aa, 0xf4292244,  6);
+		MD5_STEP(MD5_I, d, a, b, c,    0, 0x432aff97, 10);
+		MD5_STEP(MD5_I, c, d, a, b,  128, 0xab9423a7, 15);
+		MD5_STEP(MD5_I, b, c, d, a,    0, 0xfc93a039, 21);
+		MD5_STEP(MD5_I, a, b, c, d,    0, 0x655b59c3,  6);
+		MD5_STEP(MD5_I, d, a, b, c,   dd, 0x8f0ccc92, 10);
+		MD5_STEP(MD5_I, c, d, a, b,    0, 0xffeff47d, 15);
+		MD5_STEP(MD5_I, b, c, d, a,   bb, 0x85845dd1, 21);
+		MD5_STEP(MD5_I, a, b, c, d,    0, 0x6fa87e4f,  6);
+		MD5_STEP(MD5_I, d, a, b, c,    0, 0xfe2ce6e0, 10);
+		MD5_STEP(MD5_I, c, d, a, b,    0, 0xa3014314, 15);
+		MD5_STEP(MD5_I, b, c, d, a,    0, 0x4e0811a1, 21);
+		MD5_STEP(MD5_I, a, b, c, d, 0x80, 0xf7537e82,  6);
+		MD5_STEP(MD5_I, d, a, b, c,    0, 0xbd3af235, 10);
+		MD5_STEP(MD5_I, c, d, a, b,   cc, 0x2ad7d2bb, 15);
+		MD5_STEP(MD5_I, b, c, d, a,    0, 0xeb86d391, 21);
+
+		a += INIT_A;
+		b += INIT_B;
+		c += INIT_C;
+		d += INIT_D;
+	}
+
+	msg[0] = a;
+	msg[1] = b;
+	msg[2] = c;
+	msg[3] = d;
+}

--- a/run/opencl/opencl_rc4.h
+++ b/run/opencl/opencl_rc4.h
@@ -1,15 +1,15 @@
 /*
  * OpenCL RC4
  *
- * Copyright (c) 2014-2023, magnum
+ * Copyright (c) 2014-2024, magnum
  * This software is hereby released to the general public under
  * the following terms: Redistribution and use in source and binary
  * forms, with or without modification, are permitted.
  *
- * NOTICE: After changes in headers, you probably need to drop cached
- * kernels to ensure the changes take effect.
+ * These functions assume 32-bit aligment - no assertions!
  *
- * NOTE: These function assume 32-bit aligment - no assertions!
+ * NOTE: After changes, you probably need to drop cached kernels to
+ * ensure the changes take effect: "make kernel-cache-clean"
  */
 
 #ifndef _OPENCL_RC4_H
@@ -29,74 +29,64 @@
 
 #include "opencl_misc.h"
 
-#define RC4_IV32
+#define lid     get_local_id(0)
 
-#if !gpu_amd(DEVICE_INFO) || DEV_VER_MAJOR < 1445
-/* bug in Catalyst 14.9, besides it is slower */
-#define RC4_UNROLLED_KEY
-#define RC4_UNROLLED
-#endif
-
-#if !defined(__OS_X__) && __GPU__ /* Actually we want discrete GPUs */
+#if __GPU__
 #define RC4_USE_LOCAL
+#if gpu_amd(DEVICE_INFO)
+#define MAX_LOCAL_RC4	64
+#define COALESCE_IDX8(i)  (((i) & 3) + (((i) / 4) * 128) + ((lid & 31) * 4) + ((lid / 32) * 8192))
+#define COALESCE_IDX32(i) (((i) * 32) + (lid & 31) + ((lid / 32) * 2048))
+#else
+#define MAX_LOCAL_RC4	32
+#define COALESCE_IDX8(i)  (((i) & 3) + (((i) / 4) * 128) + (lid * 4))
+#define COALESCE_IDX32(i) (((i) * 32) + lid)
 #endif
-
-typedef struct {
-	uint state[256/4];
-	uint x, y;
-	uint len;
-} RC4_CTX;
-
-#ifdef RC4_IV32
-__constant uint rc4_iv[64] = { 0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c,
-                               0x13121110, 0x17161514, 0x1b1a1918, 0x1f1e1d1c,
-                               0x23222120, 0x27262524, 0x2b2a2928, 0x2f2e2d2c,
-                               0x33323130, 0x37363534, 0x3b3a3938, 0x3f3e3d3c,
-                               0x43424140, 0x47464544, 0x4b4a4948, 0x4f4e4d4c,
-                               0x53525150, 0x57565554, 0x5b5a5958, 0x5f5e5d5c,
-                               0x63626160, 0x67666564, 0x6b6a6968, 0x6f6e6d6c,
-                               0x73727170, 0x77767574, 0x7b7a7978, 0x7f7e7d7c,
-                               0x83828180, 0x87868584, 0x8b8a8988, 0x8f8e8d8c,
-                               0x93929190, 0x97969594, 0x9b9a9998, 0x9f9e9d9c,
-                               0xa3a2a1a0, 0xa7a6a5a4, 0xabaaa9a8, 0xafaeadac,
-                               0xb3b2b1b0, 0xb7b6b5b4, 0xbbbab9b8, 0xbfbebdbc,
-                               0xc3c2c1c0, 0xc7c6c5c4, 0xcbcac9c8, 0xcfcecdcc,
-                               0xd3d2d1d0, 0xd7d6d5d4, 0xdbdad9d8, 0xdfdedddc,
-                               0xe3e2e1e0, 0xe7e6e5e4, 0xebeae9e8, 0xefeeedec,
-                               0xf3f2f1f0, 0xf7f6f5f4, 0xfbfaf9f8, 0xfffefdfc };
 #endif
 
 #define GETCHAR_KEY(buf, index)	(((RC4_KEY_TYPE uchar*)(buf))[(index)])
 #define GETCHAR_IN(buf, index)	(((RC4_IN_TYPE uchar*)(buf))[(index)])
 
-#define PUTCHAR_OUT(buf, index, val)	PUTCHAR((RC4_OUT_TYPE uchar*)(buf), (index), (val))
-
 #ifdef RC4_USE_LOCAL
-#define GETSTATE	GETCHAR_L
-#define PUTSTATE	PUTCHAR_L
-#else
-#define GETSTATE	GETCHAR
-#define PUTSTATE	PUTCHAR
-#endif
+typedef struct {
+	uint state[MAX_LOCAL_RC4 * 256/4];
+	uint x[MAX_LOCAL_RC4];
+	uint y[MAX_LOCAL_RC4];
+	uint len[MAX_LOCAL_RC4];
+} RC4_CTX;
+#define GETSTATE(i)      GETCHAR_L(ctx->state, COALESCE_IDX8(i))
+#define PUTSTATE(i, v)   PUTCHAR_L(ctx->state, COALESCE_IDX8(i), v)
+#define PUTSTATE32(i, v) ctx->state[COALESCE_IDX32(i)] = v
+#define STATE(var)       ctx->var[lid]
 
-#define X8	(x & 255)
-#define state	ctx->state
+#else
+typedef struct {
+	uint state[256/4];
+	uint x;
+	uint y;
+	uint len;
+} RC4_CTX;
+#define GETSTATE(i)      GETCHAR(ctx->state, i)
+#define PUTSTATE(i, v)   PUTCHAR(ctx->state, i, v)
+#define PUTSTATE32(i, v) ctx->state[i] = v
+#define STATE(var)       ctx->var
+#endif
 
 #undef swap_byte
 #define swap_byte(a, b) {	  \
-		uint tmp = GETSTATE(state, a); \
-		PUTSTATE(state, a, GETSTATE(state, b)); \
-		PUTSTATE(state, b, tmp); \
+		uint tmp = GETSTATE(a); \
+		PUTSTATE(a, GETSTATE(b)); \
+		PUTSTATE(b, tmp); \
 	}
 #undef swap_no_inc
 #define swap_no_inc(n) {	  \
-		index2 = (GETCHAR_KEY(key, index1) + GETSTATE(state, n) + index2) & 255; \
+		index2 = (GETCHAR_KEY(key, index1) + GETSTATE(n) + index2) & 255; \
 		swap_byte(n, index2); \
 	}
 #undef swap_state
 #define swap_state(n) {	  \
 		swap_no_inc(n); \
-		index1 = (index1 + 1) & 15; /* WARNING: &15 == %keylen */ \
+		if (++index1 == keylen) index1 = 0; \
 	}
 #undef swap_anc_inc
 #define swap_and_inc(n) {	  \
@@ -105,139 +95,92 @@ __constant uint rc4_iv[64] = { 0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c,
 	}
 
 /*
- * One-shot RC4 with fixed keylen of 16 but unlimited data length (len),
- * expressed in bytes but must be multiple of 4).
+ * Set IV.  Clever, compact 32-bit implementation nicked from hashcat, replacing
+ * the (also 32-bit) constant array we had.  No difference in speed though.
  */
-inline void rc4_oneshot(
+inline void rc4_init(
 #ifdef RC4_USE_LOCAL
                 __local
 #endif
-	                RC4_CTX *restrict ctx,
-                const uint *restrict key,
-#ifdef RC4_IN_PLACE
-                uint *buf,
-#else
-                RC4_IN_TYPE const uint *restrict in,
-                RC4_OUT_TYPE uint *restrict out,
-#endif
-                uint len)
+                RC4_CTX *restrict ctx)
 {
-	uint x;
-	uint y = 0;
-	uint index1 = 0;
-	uint index2 = 0;
+	uint v = 0x03020100;
+	const uint a = 0x04040404;
 
-	/* RC4_init() */
-#ifdef RC4_IV32
-	for (x = 0; x < 256/4; x++)
-		state[x] = rc4_iv[x];
-#else
-	for (x = 0; x < 256; x++)
-		PUTSTATE(state, x, x);
-#endif
-
-	/* RC4_set_key() */
-#ifdef RC4_UNROLLED_KEY
-	/* Unrolled for hard-coded key length 16 */
-	for (x = 0; x < 256; x++) {
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_and_inc(x);
-		swap_no_inc(x);
-		index1 = 0;
-	}
-#else
-	for (x = 0; x < 256; x++)
-		swap_state(x);
-#endif
-
-	/* RC4() */
-#ifdef RC4_UNROLLED
-	/* Unrolled to 32-bit xor */
-	for (x = 1; x <= len; x++) {
-		uint xor_word;
-
-		y = (GETSTATE(state, X8) + y) & 255;
-		swap_byte(X8, y);
-		xor_word = GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255);
-		x++;
-
-		y = (GETSTATE(state, X8) + y) & 255;
-		swap_byte(X8, y);
-		xor_word += GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255) << 8;
-		x++;
-
-		y = (GETSTATE(state, X8) + y) & 255;
-		swap_byte(X8, y);
-		xor_word += GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255) << 16;
-		x++;
-
-		y = (GETSTATE(state, X8) + y) & 255;
-		swap_byte(X8, y);
-		xor_word += GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255) << 24;
-
-#ifdef RC4_IN_PLACE
-		*buf++ ^= xor_word;
-#else
-		*out++ = *in++ ^ xor_word;
-#endif
-	}
-#else /* RC4_UNROLLED */
-	for (x = 1; x <= len; x++) {
-		y = (GETSTATE(state, X8) + y) & 255;
-		swap_byte(X8, y);
-#ifdef RC4_IN_PLACE
-		XORCHAR(buf, x - 1, GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255));
-#else
-		PUTCHAR_OUT(out, x - 1, GETCHAR_IN(in, x - 1) ^
-		          (GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255)));
-#endif
-	}
-#endif /* RC4_UNROLLED */
-	ctx->x = x;
-	ctx->y = y;
-	ctx->len = len;
+	for (uint i = 0; i < 256/4; i++, v += a)
+		PUTSTATE32(i, v);
 }
 
 /*
- * Fixed keylen of 16.
+ * Arbitrary length key
  */
 inline void rc4_set_key(
 #ifdef RC4_USE_LOCAL
                 __local
 #endif
                 RC4_CTX *restrict ctx,
+                const uint keylen,
                 const uint *restrict key)
 {
-	uint x;
+	rc4_init(ctx);
+
 	uint index1 = 0;
 	uint index2 = 0;
 
-	/* RC4_init() */
-#ifdef RC4_IV32
-	for (x = 0; x < 256/4; x++)
-		state[x] = rc4_iv[x];
-#else
-	for (x = 0; x < 256; x++)
-		PUTSTATE(state, x, x);
-#endif
+	for (uint x = 0; x < 256; x++)
+		swap_state(x);
 
-	/* RC4_set_key() */
-#ifdef RC4_UNROLLED_KEY
-	/* Unrolled for hard-coded key length 16 */
-	for (x = 0; x < 256; x++) {
+	STATE(x) = 1;
+	STATE(y) = 0;
+	STATE(len) = 0;
+}
+
+/*
+ * Unrolled fixed keylen of 5 (40-bit).
+ */
+inline void rc4_40_set_key(
+#ifdef RC4_USE_LOCAL
+                __local
+#endif
+                RC4_CTX *restrict ctx,
+                const uint *restrict key)
+{
+	rc4_init(ctx);
+
+	uint index1 = 0;
+	uint index2 = 0;
+
+	for (uint x = 0; x < 255; x++) {
+		swap_and_inc(x);
+		swap_and_inc(x);
+		swap_and_inc(x);
+		swap_and_inc(x);
+		swap_no_inc(x);
+		index1 = 0;
+	}
+	swap_no_inc(255);
+
+	STATE(x) = 1;
+	STATE(y) = 0;
+	STATE(len) = 0;
+}
+
+/*
+ * Unrolled fixed keylen of 16 (128-bit).
+ */
+inline void rc4_128_set_key(
+#ifdef RC4_USE_LOCAL
+                __local
+#endif
+                RC4_CTX *restrict ctx,
+                const uint *restrict key)
+{
+	rc4_init(ctx);
+
+	uint index1 = 0;
+	uint index2 = 0;
+
+	for (uint x = 0; x < 256; x++) {
 		swap_and_inc(x);
 		swap_and_inc(x);
 		swap_and_inc(x);
@@ -256,18 +199,15 @@ inline void rc4_set_key(
 		swap_no_inc(x);
 		index1 = 0;
 	}
-#else
-	for (x = 0; x < 256; x++)
-		swap_state(x);
-#endif
 
-	ctx->x = 1;
-	ctx->y = 0;
-	ctx->len = 0;
+	STATE(x) = 1;
+	STATE(y) = 0;
+	STATE(len) = 0;
 }
 
+#define X8      (x & 255)
+
 /*
- * Used after rc4_set_key() *or* rc4_oneshot() and can be called multiple times for more data.
  * Len is given in bytes but must be multiple of 4.
  */
 inline void rc4(
@@ -275,73 +215,46 @@ inline void rc4(
                 __local
 #endif
 	                RC4_CTX *restrict ctx,
-#ifdef RC4_IN_PLACE
-                uint *buf,
-#else
-                RC4_IN_TYPE const uint *restrict in,
-                RC4_OUT_TYPE uint *restrict out,
-#endif
+                RC4_IN_TYPE const uint *in,
+                RC4_OUT_TYPE uint *out,
                 uint len)
 {
-	uint x = ctx->x;
-	uint y = ctx->y;
+	uint x = STATE(x);
+	uint y = STATE(y);
 
-	len += ctx->len;
+	len += STATE(len);
 
-#ifdef RC4_UNROLLED
 	/* Unrolled to 32-bit xor */
 	for (; x <= len; x++) {
 		uint xor_word;
 
-		y = (GETSTATE(state, X8) + y) & 255;
+		y = (GETSTATE(X8) + y) & 255;
 		swap_byte(X8, y);
-		xor_word = GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255);
+		xor_word = GETSTATE((GETSTATE(X8) + GETSTATE(y)) & 255);
 		x++;
 
-		y = (GETSTATE(state, X8) + y) & 255;
+		y = (GETSTATE(X8) + y) & 255;
 		swap_byte(X8, y);
-		xor_word += GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255) << 8;
+		xor_word += GETSTATE((GETSTATE(X8) + GETSTATE(y)) & 255) << 8;
 		x++;
 
-		y = (GETSTATE(state, X8) + y) & 255;
+		y = (GETSTATE(X8) + y) & 255;
 		swap_byte(X8, y);
-		xor_word += GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255) << 16;
+		xor_word += GETSTATE((GETSTATE(X8) + GETSTATE(y)) & 255) << 16;
 		x++;
 
-		y = (GETSTATE(state, X8) + y) & 255;
+		y = (GETSTATE(X8) + y) & 255;
 		swap_byte(X8, y);
-		xor_word += GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255) << 24;
+		xor_word += GETSTATE((GETSTATE(X8) + GETSTATE(y)) & 255) << 24;
 
-#ifdef RC4_IN_PLACE
-		*buf++ ^= xor_word;
-#else
 		*out++ = *in++ ^ xor_word;
-#endif
 	}
-#else /* RC4_UNROLLED */
-#ifdef RC4_IN_PLACE
-	buf -= x / 4;
-#else
-	out -= x / 4;
-	in -= x / 4;
-#endif
-	for (; x <= len; x++) {
-		y = (GETSTATE(state, X8) + y) & 255;
-		swap_byte(X8, y);
-#ifdef RC4_IN_PLACE
-		XORCHAR(buf, x - 1, GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255));
-#else
-		PUTCHAR_OUT(out, x - 1, GETCHAR_IN(in, x - 1) ^
-		          (GETSTATE(state, (GETSTATE(state, X8) + GETSTATE(state, y)) & 255)));
-#endif
-	}
-#endif /* RC4_UNROLLED */
-	ctx->x = x;
-	ctx->y = y;
-	ctx->len = len;
+
+	STATE(x) = x;
+	STATE(y) = y;
+	STATE(len) = len;
 }
 
-#undef state
 #undef X8
 
 #endif /* _OPENCL_RC4_H */

--- a/run/opencl/opencl_sha2.h
+++ b/run/opencl/opencl_sha2.h
@@ -1,7 +1,7 @@
 /*
  * This software is
  * Copyright (c) 2013 Lukas Odzioba <ukasz at openwall dot net>
- * Copyright (c) 2014-2018 magnum
+ * Copyright (c) 2014-2024 magnum
  * Copyright (c) 2021 Solar Designer
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
@@ -17,6 +17,10 @@
 
 #ifndef SHA256_DIGEST_LENGTH
 #define SHA256_DIGEST_LENGTH 32
+#endif
+
+#ifndef SHA384_DIGEST_LENGTH
+#define SHA384_DIGEST_LENGTH 48
 #endif
 
 #ifndef SHA512_DIGEST_LENGTH
@@ -498,14 +502,23 @@ __constant ulong K[] = {
 #define sigma1_64(x) (ror64(x, 19) ^ ror64(x, 61) ^ (x >> 6))
 #endif
 
-#define SHA2_INIT_A	0x6a09e667f3bcc908UL
-#define SHA2_INIT_B	0xbb67ae8584caa73bUL
-#define SHA2_INIT_C	0x3c6ef372fe94f82bUL
-#define SHA2_INIT_D	0xa54ff53a5f1d36f1UL
-#define SHA2_INIT_E	0x510e527fade682d1UL
-#define SHA2_INIT_F	0x9b05688c2b3e6c1fUL
-#define SHA2_INIT_G	0x1f83d9abfb41bd6bUL
-#define SHA2_INIT_H	0x5be0cd19137e2179UL
+#define SHA384_INIT_A	0xcbbb9d5dc1059ed8UL
+#define SHA384_INIT_B	0x629a292a367cd507UL
+#define SHA384_INIT_C	0x9159015a3070dd17UL
+#define SHA384_INIT_D	0x152fecd8f70e5939UL
+#define SHA384_INIT_E	0x67332667ffc00b31UL
+#define SHA384_INIT_F	0x8eb44a8768581511UL
+#define SHA384_INIT_G	0xdb0c2e0d64f98fa7UL
+#define SHA384_INIT_H	0x47b5481dbefa4fa4UL
+
+#define SHA512_INIT_A	0x6a09e667f3bcc908UL
+#define SHA512_INIT_B	0xbb67ae8584caa73bUL
+#define SHA512_INIT_C	0x3c6ef372fe94f82bUL
+#define SHA512_INIT_D	0xa54ff53a5f1d36f1UL
+#define SHA512_INIT_E	0x510e527fade682d1UL
+#define SHA512_INIT_F	0x9b05688c2b3e6c1fUL
+#define SHA512_INIT_G	0x1f83d9abfb41bd6bUL
+#define SHA512_INIT_H	0x5be0cd19137e2179UL
 
 #define ROUND512_A(a, b, c, d, e, f, g, h, ki, wi)	\
 	t = (ki) + (wi) + (h) + Sigma1_64(e) + Ch((e), (f), (g)); \
@@ -678,27 +691,39 @@ inline void sha512_single_s(ulong *W, ulong *output)
 {
 	ulong A, B, C, D, E, F, G, H, t;
 
-	A = SHA2_INIT_A;
-	B = SHA2_INIT_B;
-	C = SHA2_INIT_C;
-	D = SHA2_INIT_D;
-	E = SHA2_INIT_E;
-	F = SHA2_INIT_F;
-	G = SHA2_INIT_G;
-	H = SHA2_INIT_H;
+	A = SHA512_INIT_A;
+	B = SHA512_INIT_B;
+	C = SHA512_INIT_C;
+	D = SHA512_INIT_D;
+	E = SHA512_INIT_E;
+	F = SHA512_INIT_F;
+	G = SHA512_INIT_G;
+	H = SHA512_INIT_H;
 
 	SHA512(A, B, C, D, E, F, G, H, W)
 
-	output[0] = A + SHA2_INIT_A;
-	output[1] = B + SHA2_INIT_B;
-	output[2] = C + SHA2_INIT_C;
-	output[3] = D + SHA2_INIT_D;
-	output[4] = E + SHA2_INIT_E;
-	output[5] = F + SHA2_INIT_F;
-	output[6] = G + SHA2_INIT_G;
-	output[7] = H + SHA2_INIT_H;
+	output[0] = A + SHA512_INIT_A;
+	output[1] = B + SHA512_INIT_B;
+	output[2] = C + SHA512_INIT_C;
+	output[3] = D + SHA512_INIT_D;
+	output[4] = E + SHA512_INIT_E;
+	output[5] = F + SHA512_INIT_F;
+	output[6] = G + SHA512_INIT_G;
+	output[7] = H + SHA512_INIT_H;
 }
 #endif
+
+#define sha512_init(ctx)	  \
+	do { \
+		(ctx)[0] = SHA512_INIT_A; \
+		(ctx)[1] = SHA512_INIT_B; \
+		(ctx)[2] = SHA512_INIT_C; \
+		(ctx)[3] = SHA512_INIT_D; \
+		(ctx)[4] = SHA512_INIT_E; \
+		(ctx)[5] = SHA512_INIT_F; \
+		(ctx)[6] = SHA512_INIT_G; \
+		(ctx)[7] = SHA512_INIT_H; \
+	} while(0)
 
 #define sha512_block(pad, ctx)\
  {	  \
@@ -727,25 +752,25 @@ inline void sha512_single(MAYBE_VECTOR_ULONG *W, MAYBE_VECTOR_ULONG *output)
 {
 	MAYBE_VECTOR_ULONG A, B, C, D, E, F, G, H, t;
 
-	A = SHA2_INIT_A;
-	B = SHA2_INIT_B;
-	C = SHA2_INIT_C;
-	D = SHA2_INIT_D;
-	E = SHA2_INIT_E;
-	F = SHA2_INIT_F;
-	G = SHA2_INIT_G;
-	H = SHA2_INIT_H;
+	A = SHA512_INIT_A;
+	B = SHA512_INIT_B;
+	C = SHA512_INIT_C;
+	D = SHA512_INIT_D;
+	E = SHA512_INIT_E;
+	F = SHA512_INIT_F;
+	G = SHA512_INIT_G;
+	H = SHA512_INIT_H;
 
 	SHA512(A, B, C, D, E, F, G, H, W)
 
-	output[0] = A + SHA2_INIT_A;
-	output[1] = B + SHA2_INIT_B;
-	output[2] = C + SHA2_INIT_C;
-	output[3] = D + SHA2_INIT_D;
-	output[4] = E + SHA2_INIT_E;
-	output[5] = F + SHA2_INIT_F;
-	output[6] = G + SHA2_INIT_G;
-	output[7] = H + SHA2_INIT_H;
+	output[0] = A + SHA512_INIT_A;
+	output[1] = B + SHA512_INIT_B;
+	output[2] = C + SHA512_INIT_C;
+	output[3] = D + SHA512_INIT_D;
+	output[4] = E + SHA512_INIT_E;
+	output[5] = F + SHA512_INIT_F;
+	output[6] = G + SHA512_INIT_G;
+	output[7] = H + SHA512_INIT_H;
 }
 
 inline void sha512_single_zeros(MAYBE_VECTOR_ULONG *W,
@@ -753,25 +778,39 @@ inline void sha512_single_zeros(MAYBE_VECTOR_ULONG *W,
 {
 	MAYBE_VECTOR_ULONG A, B, C, D, E, F, G, H, t;
 
-	A = SHA2_INIT_A;
-	B = SHA2_INIT_B;
-	C = SHA2_INIT_C;
-	D = SHA2_INIT_D;
-	E = SHA2_INIT_E;
-	F = SHA2_INIT_F;
-	G = SHA2_INIT_G;
-	H = SHA2_INIT_H;
+	A = SHA512_INIT_A;
+	B = SHA512_INIT_B;
+	C = SHA512_INIT_C;
+	D = SHA512_INIT_D;
+	E = SHA512_INIT_E;
+	F = SHA512_INIT_F;
+	G = SHA512_INIT_G;
+	H = SHA512_INIT_H;
 
 	SHA512_ZEROS(A, B, C, D, E, F, G, H, W)
 
-	output[0] = A + SHA2_INIT_A;
-	output[1] = B + SHA2_INIT_B;
-	output[2] = C + SHA2_INIT_C;
-	output[3] = D + SHA2_INIT_D;
-	output[4] = E + SHA2_INIT_E;
-	output[5] = F + SHA2_INIT_F;
-	output[6] = G + SHA2_INIT_G;
-	output[7] = H + SHA2_INIT_H;
+	output[0] = A + SHA512_INIT_A;
+	output[1] = B + SHA512_INIT_B;
+	output[2] = C + SHA512_INIT_C;
+	output[3] = D + SHA512_INIT_D;
+	output[4] = E + SHA512_INIT_E;
+	output[5] = F + SHA512_INIT_F;
+	output[6] = G + SHA512_INIT_G;
+	output[7] = H + SHA512_INIT_H;
 }
+
+#define sha384_init(ctx)	  \
+	do { \
+		(ctx)[0] = SHA384_INIT_A; \
+		(ctx)[1] = SHA384_INIT_B; \
+		(ctx)[2] = SHA384_INIT_C; \
+		(ctx)[3] = SHA384_INIT_D; \
+		(ctx)[4] = SHA384_INIT_E; \
+		(ctx)[5] = SHA384_INIT_F; \
+		(ctx)[6] = SHA384_INIT_G; \
+		(ctx)[7] = SHA384_INIT_H; \
+	} while(0)
+
+#define sha384_block(pad, ctx)	sha512_block(pad,ctx)
 
 #endif /* _OPENCL_SHA2_H */

--- a/run/opencl/pbkdf2_hmac_sha512_kernel.cl
+++ b/run/opencl/pbkdf2_hmac_sha512_kernel.cl
@@ -20,14 +20,14 @@ inline void _phs512_preproc(__global const ulong *key, uint keylen,
 	ulong W[16];
 	ulong A, B, C, D, E, F, G, H, t;
 
-	A = SHA2_INIT_A;
-	B = SHA2_INIT_B;
-	C = SHA2_INIT_C;
-	D = SHA2_INIT_D;
-	E = SHA2_INIT_E;
-	F = SHA2_INIT_F;
-	G = SHA2_INIT_G;
-	H = SHA2_INIT_H;
+	A = SHA512_INIT_A;
+	B = SHA512_INIT_B;
+	C = SHA512_INIT_C;
+	D = SHA512_INIT_D;
+	E = SHA512_INIT_E;
+	F = SHA512_INIT_F;
+	G = SHA512_INIT_G;
+	H = SHA512_INIT_H;
 
 	j = ((keylen+7)/8);
 	for (i = 0; i < j; i++)
@@ -38,14 +38,14 @@ inline void _phs512_preproc(__global const ulong *key, uint keylen,
 
 	SHA512(A, B, C, D, E, F, G, H, W);
 
-	state[0] = A + SHA2_INIT_A;
-	state[1] = B + SHA2_INIT_B;
-	state[2] = C + SHA2_INIT_C;
-	state[3] = D + SHA2_INIT_D;
-	state[4] = E + SHA2_INIT_E;
-	state[5] = F + SHA2_INIT_F;
-	state[6] = G + SHA2_INIT_G;
-	state[7] = H + SHA2_INIT_H;
+	state[0] = A + SHA512_INIT_A;
+	state[1] = B + SHA512_INIT_B;
+	state[2] = C + SHA512_INIT_C;
+	state[3] = D + SHA512_INIT_D;
+	state[4] = E + SHA512_INIT_E;
+	state[5] = F + SHA512_INIT_F;
+	state[6] = G + SHA512_INIT_G;
+	state[7] = H + SHA512_INIT_H;
 }
 
 inline void _phs512_hmac(ulong *output, ulong *ipad_state, ulong *opad_state,

--- a/run/opencl/pdf_kernel.cl
+++ b/run/opencl/pdf_kernel.cl
@@ -1,0 +1,695 @@
+/*
+ * This software is Copyright (c) 2024 magnum and it is hereby released to the
+ * general public under the following terms:  Redistribution and use in source
+ * and binary forms, with or without modification, are permitted.
+ *
+ * See CPU format for human-readable code ;-)
+ */
+
+#include "opencl_misc.h"
+#include "opencl_mask.h"
+#include "opencl_md5.h"
+#include "md5x50.h"
+#include "opencl_md5_ctx.h"
+#include "opencl_sha2_ctx.h"
+#include "opencl_rc4.h"
+#include "opencl_aes.h"
+
+/*
+ * RC4 key length other than 40 or 128 should be extremely rare but is supported
+ * by the spec for rev. 3 and 4, in multiples of 4.  Disabling it may lead to better
+ * performance but I didn't see that so left it enabled.
+ */
+#define RC4_ANY_KEY_LENGTH	1
+
+typedef struct {
+	uint V;             // populated but unused
+	uint R;
+	int P;
+	uint encrypt_metadata;
+	uchar u[128];
+	uchar o[128];
+	uchar id[128];
+	uint key_length;    // key length in bits
+	uint id_len;
+	uint u_len;
+	uint o_len;
+} pdf_salt_type;
+
+__constant uint padding[8] = {
+	0x5e4ebf28, 0x418a754e, 0x564e0064, 0x0801faff,
+	0xb6002e2e, 0x803e68d0, 0xfea90c2f, 0x7a695364
+};
+
+inline uint prepare234(__global const uchar *pwbuf, __global const uint *index, uint *password)
+{
+	uint i;
+	uint gid = get_global_id(0);
+	uint base = index[gid];
+	uint len = index[gid + 1] - base;
+
+	pwbuf += base;
+
+	/* Work-around for self-tests not always calling set_key() like IRL */
+	if (len > PLAINTEXT_LENGTH)
+		len = 0;
+
+	for (i = 0; i < len; i++)
+		((uchar*)password)[i] = pwbuf[i];
+
+	/* Pad for rev < 5, offloading the inner loop */
+	if (len < 32)
+		memcpy_cp((uchar*)password + len, (__constant uchar*)padding, 32 - len);
+
+	return 32;
+}
+
+__kernel
+#ifdef RC4_USE_LOCAL
+__attribute__((work_group_size_hint(MAX_LOCAL_RC4, 1, 1)))
+#endif
+void pdf_r2(__global const uchar *pwbuf,
+            __global const uint *index,
+            __constant pdf_salt_type *pdf_salt,
+            __global uint *result,
+            volatile __global uint *crack_count_ret,
+            __global uint *int_key_loc,
+#if USE_CONST_CACHE
+            __constant
+#else
+            __global
+#endif
+            uint *int_keys)
+{
+#ifdef RC4_USE_LOCAL
+	__local
+#endif
+	RC4_CTX rc4_ctx;
+	uint password[(PLAINTEXT_LENGTH + 3) / 4]; // Not null terminated
+	uint gid = get_global_id(0);
+#if NUM_INT_KEYS > 1 && !IS_STATIC_GPU_MASK
+	uint ikl = int_key_loc[gid];
+	uint loc0 = ikl & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+	uint loc1 = (ikl & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+	uint loc2 = (ikl & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+	uint loc3 = (ikl & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+#if !IS_STATIC_GPU_MASK
+#define GPU_LOC_0 loc0
+#define GPU_LOC_1 loc1
+#define GPU_LOC_2 loc2
+#define GPU_LOC_3 loc3
+#else
+#define GPU_LOC_0 LOC_0
+#define GPU_LOC_1 LOC_1
+#define GPU_LOC_2 LOC_2
+#define GPU_LOC_3 LOC_3
+#endif
+
+	/* Prepare password */
+	prepare234(pwbuf, index, password);
+
+	for (uint mi = 0; mi < NUM_INT_KEYS; mi++) {
+
+		/* Apply GPU-side mask */
+#if NUM_INT_KEYS > 1
+		password[GPU_LOC_0] = int_keys[mi] & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+		password[GPU_LOC_1] = (int_keys[mi] & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+		password[GPU_LOC_2] = (int_keys[mi] & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+		password[GPU_LOC_3] = (int_keys[mi] & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+		uint gidx = gid * NUM_INT_KEYS + mi;
+
+		uint key[4];
+		md5_init(key);
+
+		/* Password already padded in prepare() and always len 32 */
+		uint W[16];
+		memcpy_macro(W, password, 32/4);
+		memcpy_macro(W + 32/4, (__constant uint*)pdf_salt->o, 32/4);
+
+		/* The above is always one M-D block */
+		md5_block(uint, W, key);
+
+		W[0] = (uint)pdf_salt->P;
+		uint md5_len = 4;
+
+		memcpy_macro(W + 1, (__constant uint*)pdf_salt->id, pdf_salt->id_len / 4);
+		md5_len += pdf_salt->id_len;
+
+		W[md5_len / 4] = 0x00000080;
+		for (uint i = md5_len / 4 + 1; i < 14; i++)
+			W[i] = 0;
+		W[14] = (64 + md5_len) << 3;
+		W[15] = 0;
+
+		md5_block(uint, W, key);
+
+		uint output[16/4];
+		memcpy_macro(output, padding, 16/4);
+
+		rc4_40_set_key(&rc4_ctx, key);
+		rc4(&rc4_ctx, output, output, 16);
+
+		if ((result[gidx] = !memcmp_pc(output, pdf_salt->u, 16)))
+			atomic_max(crack_count_ret, gidx + 1);
+	}
+}
+
+__kernel
+#ifdef RC4_USE_LOCAL
+__attribute__((work_group_size_hint(MAX_LOCAL_RC4, 1, 1)))
+#endif
+void pdf_r34(__global const uchar *pwbuf,
+             __global const uint *index,
+             __constant pdf_salt_type *pdf_salt,
+             __global uint *result,
+             volatile __global uint *crack_count_ret,
+             __global uint *int_key_loc,
+#if USE_CONST_CACHE
+             __constant
+#else
+             __global
+#endif
+             uint *int_keys)
+{
+#ifdef RC4_USE_LOCAL
+	__local
+#endif
+	RC4_CTX rc4_ctx;
+	uint password[(PLAINTEXT_LENGTH + 3) / 4]; // Not null terminated
+	uint gid = get_global_id(0);
+#if NUM_INT_KEYS > 1 && !IS_STATIC_GPU_MASK
+	uint ikl = int_key_loc[gid];
+	uint loc0 = ikl & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+	uint loc1 = (ikl & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+	uint loc2 = (ikl & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+	uint loc3 = (ikl & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+#if !IS_STATIC_GPU_MASK
+#define GPU_LOC_0 loc0
+#define GPU_LOC_1 loc1
+#define GPU_LOC_2 loc2
+#define GPU_LOC_3 loc3
+#else
+#define GPU_LOC_0 LOC_0
+#define GPU_LOC_1 LOC_1
+#define GPU_LOC_2 LOC_2
+#define GPU_LOC_3 LOC_3
+#endif
+
+	/* Prepare password */
+	prepare234(pwbuf, index, password);
+
+	for (uint mi = 0; mi < NUM_INT_KEYS; mi++) {
+
+		/* Apply GPU-side mask */
+#if NUM_INT_KEYS > 1
+		password[GPU_LOC_0] = int_keys[mi] & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+		password[GPU_LOC_1] = (int_keys[mi] & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+		password[GPU_LOC_2] = (int_keys[mi] & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+		password[GPU_LOC_3] = (int_keys[mi] & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+		uint gidx = gid * NUM_INT_KEYS + mi;
+		uint output[32 / 4];
+		uint key[MAX_KEY_SIZE / 8 / 4];
+		uint digest[16 / 4];
+		uint W[(32 + sizeof(pdf_salt->id) + 63 + 9) / 64 * 16]; // Max. 160 bytes, three limbs
+
+		md5_init(key);
+
+		/* Password already padded in prepare() */
+		memcpy_macro(W, password, 32/4);
+		memcpy_macro(W + 32/4, (__constant uint*)pdf_salt->o, 32/4);
+
+		/* The above is always one M-D block */
+		md5_block(uint, W, key);
+
+		W[0] = (uint)pdf_salt->P;
+		uint md5_len = 4;
+
+		memcpy_macro(W + 1, (__constant uint*)pdf_salt->id, pdf_salt->id_len / 4);
+		md5_len += pdf_salt->id_len;
+
+		if (pdf_salt->R >= 4 && !pdf_salt->encrypt_metadata) {
+			W[md5_len / 4] = 0xffffffff;
+			md5_len += 4;
+		}
+
+		W[md5_len / 4] = 0x00000080;
+		for (uint i = md5_len / 4 + 1; i < 14; i++)
+			W[i] = 0;
+		W[14] = (64 + md5_len) << 3;
+		W[15] = 0;
+
+		md5_block(uint, W, key);
+
+		if (pdf_salt->key_length == 40)
+			md5x50_40(key);
+		else
+#if RC4_ANY_KEY_LENGTH
+		if (pdf_salt->key_length == 128)
+#endif
+			md5x50_128(key);
+#if RC4_ANY_KEY_LENGTH
+		else {
+			uint n = pdf_salt->key_length / 8;
+
+			for (uint i = 0; i < 50; i++) {
+				MD5_CTX md5;
+
+				MD5_Init(&md5);
+				MD5_Update(&md5, (uchar*)key, n);
+				MD5_Final((uchar*)key, &md5);
+			}
+		}
+#endif
+
+		uint md5len = 32 + pdf_salt->id_len;
+
+		memcpy_macro(W, padding, 8);
+		memcpy_macro(W + 8, (__constant uint*)pdf_salt->id, pdf_salt->id_len / 4);
+		LASTCHAR(W, md5len, 0x80);
+
+		/* Clean the last M-D block */
+		uint start_clean = md5len / 4 + 1;
+		uint md_len_pos = (start_clean & ~0xfU) + 14 + (((md5len & 63) > 55) ? 16 : 0);
+		for (uint i = start_clean; i < md_len_pos; i++)
+			W[i] = 0;
+		W[md_len_pos] = md5len << 3;
+		W[md_len_pos + 1] = 0;
+
+		md5_init(digest);
+
+		uint *WP = W;
+		for (uint left = md5len; left > 55; left -= 64, WP +=16)
+			md5_block(uint, WP, digest);
+		md5_block(uint, WP, digest);
+
+		if (pdf_salt->key_length == 40) {
+			rc4_40_set_key(&rc4_ctx, key);
+			rc4(&rc4_ctx, digest, output, 16);
+			for (uint x = 0x01010101; x <= 0x13131313; x += 0x01010101) {
+				uint xor[2];
+
+				xor[0] = key[0] ^ x;
+				xor[1] = key[1] ^ x;
+
+				rc4_40_set_key(&rc4_ctx, xor);
+				rc4(&rc4_ctx, output, output, 16);
+			}
+		} else
+#if RC4_ANY_KEY_LENGTH
+		if (pdf_salt->key_length == 128)
+#endif
+		{
+			rc4_128_set_key(&rc4_ctx, key);
+			rc4(&rc4_ctx, digest, output, 16);
+			for (uint x = 0x01010101; x <= 0x13131313; x += 0x01010101) {
+				uint xor[16 / 4];
+
+				xor[0] = key[0] ^ x;
+				xor[1] = key[1] ^ x;
+				xor[2] = key[2] ^ x;
+				xor[3] = key[3] ^ x;
+
+				rc4_128_set_key(&rc4_ctx, xor);
+				rc4(&rc4_ctx, output, output, 16);
+			}
+#if RC4_ANY_KEY_LENGTH
+		} else {
+			rc4_set_key(&rc4_ctx, pdf_salt->key_length / 8, key);
+			rc4(&rc4_ctx, digest, output, 16);
+			for (uint x = 0x01010101; x <= 0x13131313; x += 0x01010101) {
+				uint xor[16 / 4];
+
+				xor[0] = key[0] ^ x;
+				xor[1] = key[1] ^ x;
+				xor[2] = key[2] ^ x;
+				xor[3] = key[3] ^ x;
+
+				rc4_set_key(&rc4_ctx, pdf_salt->key_length / 8, xor);
+				rc4(&rc4_ctx, output, output, 16);
+			}
+#endif
+		}
+
+		if ((result[gidx] = !memcmp_pc(output, pdf_salt->u, 16)))
+			atomic_max(crack_count_ret, gidx + 1);
+	}
+}
+
+inline uint prepare56(__global const uchar *pwbuf, __global const uint *index, uint *password)
+{
+	uint i;
+	uint gid = get_global_id(0);
+	uint base = index[gid];
+	uint len = index[gid + 1] - base;
+
+	pwbuf += base;
+
+	/* Work-around for self-tests not always calling set_key() like IRL */
+	if (len > PLAINTEXT_LENGTH)
+		len = 0;
+
+	for (i = 0; i < len; i++)
+		((uchar*)password)[i] = pwbuf[i];
+
+	return len;
+}
+
+__kernel
+void pdf_r5(__global const uchar *pwbuf,
+            __global const uint *index,
+            __constant pdf_salt_type *pdf_salt,
+            __global uint *result,
+            volatile __global uint *crack_count_ret,
+            __global uint *int_key_loc,
+#if USE_CONST_CACHE
+            __constant
+#else
+            __global
+#endif
+            uint *int_keys)
+{
+	uint password[(PLAINTEXT_LENGTH + 3) / 4]; // Not null terminated
+	uint gid = get_global_id(0);
+#if NUM_INT_KEYS > 1 && !IS_STATIC_GPU_MASK
+	uint ikl = int_key_loc[gid];
+	uint loc0 = ikl & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+	uint loc1 = (ikl & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+	uint loc2 = (ikl & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+	uint loc3 = (ikl & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+#if !IS_STATIC_GPU_MASK
+#define GPU_LOC_0 loc0
+#define GPU_LOC_1 loc1
+#define GPU_LOC_2 loc2
+#define GPU_LOC_3 loc3
+#else
+#define GPU_LOC_0 LOC_0
+#define GPU_LOC_1 LOC_1
+#define GPU_LOC_2 LOC_2
+#define GPU_LOC_3 LOC_3
+#endif
+
+	/* Prepare password */
+	uint pw_len = prepare56(pwbuf, index, password);
+
+	for (uint mi = 0; mi < NUM_INT_KEYS; mi++) {
+
+		/* Apply GPU-side mask */
+#if NUM_INT_KEYS > 1
+		password[GPU_LOC_0] = int_keys[mi] & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+		password[GPU_LOC_1] = (int_keys[mi] & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+		password[GPU_LOC_2] = (int_keys[mi] & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+		password[GPU_LOC_3] = (int_keys[mi] & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+		uint gidx = gid * NUM_INT_KEYS + mi;
+		uint W[(PLAINTEXT_LENGTH + 8 + 63 + 9) / 64 * 16]; // Max. 133 bytes, three limbs
+		uint *WP = W;
+		uint sha256[8];
+		const uint sha256len = pw_len + 8;
+
+		uint i = 0;
+		do {
+			*WP++ = SWAP32(password[i]);
+		} while (4 * ++i < pw_len);
+
+		__constant uchar *c = (__constant uchar*)pdf_salt->u + 32;
+		for (i = pw_len; i < pw_len + 8; i++)
+			PUTCHAR_BE(W, i, *c++);
+
+		LASTCHAR_BE(W, sha256len, 0x80);
+
+		/* Clean the last M-D block */
+		uint start_clean = sha256len / 4 + 1;
+		uint md_len_pos = (start_clean & ~0xfU) + 15 + (((sha256len & 63) > 55) ? 16 : 0);
+		for (uint i = start_clean; i < md_len_pos; i++)
+			W[i] = 0;
+		W[md_len_pos] = sha256len << 3;
+
+		sha256_init(sha256);
+
+		WP = W;
+		for (uint left = sha256len; left > 55; left -= 64, WP +=16)
+			sha256_block(WP, sha256);
+		sha256_block(WP, sha256);
+		block_swap32(sha256, 8);
+
+		if ((result[gidx] = !memcmp_pc(sha256, pdf_salt->u, 16)))
+			atomic_max(crack_count_ret, gidx + 1);
+	}
+}
+
+__kernel
+void pdf_r6(__global const uchar *pwbuf,
+            __global const uint *index,
+            __constant pdf_salt_type *pdf_salt,
+            __global uint *result,
+            volatile __global uint *crack_count_ret,
+            __global uint *int_key_loc,
+#if USE_CONST_CACHE
+            __constant
+#else
+            __global
+#endif
+            uint *int_keys)
+{
+	uint password[(PLAINTEXT_LENGTH + 3) / 4]; // Not null terminated
+	uint gid = get_global_id(0);
+#if NUM_INT_KEYS > 1 && !IS_STATIC_GPU_MASK
+	uint ikl = int_key_loc[gid];
+	uint loc0 = ikl & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+	uint loc1 = (ikl & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+	uint loc2 = (ikl & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+	uint loc3 = (ikl & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+#if !IS_STATIC_GPU_MASK
+#define GPU_LOC_0 loc0
+#define GPU_LOC_1 loc1
+#define GPU_LOC_2 loc2
+#define GPU_LOC_3 loc3
+#else
+#define GPU_LOC_0 LOC_0
+#define GPU_LOC_1 LOC_1
+#define GPU_LOC_2 LOC_2
+#define GPU_LOC_3 LOC_3
+#endif
+
+	/* Prepare password */
+	uint pw_len = prepare56(pwbuf, index, password);
+
+	for (uint mi = 0; mi < NUM_INT_KEYS; mi++) {
+
+		/* Apply GPU-side mask */
+#if NUM_INT_KEYS > 1
+		password[GPU_LOC_0] = int_keys[mi] & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+		password[GPU_LOC_1] = (int_keys[mi] & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+		password[GPU_LOC_2] = (int_keys[mi] & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+		password[GPU_LOC_3] = (int_keys[mi] & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+		uint gidx = gid * NUM_INT_KEYS + mi;
+		// Max. 12096 bytes, up to 158x 32-bit or 95x 64-bit limbs
+		ulong data64[(((PLAINTEXT_LENGTH + 64) * 64) + 127 + 17) / 128 * 16];
+		uint *data32 = (uint*)data64;
+		uchar *data = (uchar*)data64;
+		ulong block64[64/8];
+		uint *block32=(uint*)block64;
+		uchar *block=(uchar*)block64;
+		uint block_size = 32;
+		uint data_len = 0;
+		uint i, j, sum, magic = 0;
+		AES_KEY aes;
+		uint start_clean;
+		uint md_len_pos;
+
+		for (j = 0; j < pw_len; j++)
+			data[j ^ 3] = ((uchar*)password)[j];
+		for (j = 0; j < 8; j++)
+			data[(pw_len + j) ^ 3] = pdf_salt->u[32 + j];
+		int sha256len = pw_len + 8;
+		LASTCHAR_BE(data32, sha256len, 0x80);
+
+		/* Clean the last M-D block */
+		start_clean = sha256len / 4 + 1;
+		md_len_pos = (start_clean & ~0xfU) + 15 + (((sha256len & 63) > 55) ? 16 : 0);
+		for (j = start_clean; j < md_len_pos; j++)
+			data32[j] = 0;
+		data32[md_len_pos] = sha256len << 3;
+
+		sha256_init(block32);
+		uint *WP = data32;
+		for (uint left = sha256len; left > 55; left -= 64, WP +=16)
+			sha256_block(WP, block32);
+		sha256_block(WP, block32);
+		block_swap32(block32, 8);
+
+		for (i = 0; i < 64 || i < magic + 32; i++) {
+			memcpy_pp(data, password, pw_len);
+			memcpy_pp(data + pw_len, block32, block_size);
+			data_len = pw_len + block_size;
+			for (j = 1; j < 64; j++)
+				memcpy_pp(data + j * data_len, data, data_len);
+			data_len *= 64;
+
+			AES_set_encrypt_key(block32, 128, &aes);
+			AES_cbc_encrypt(data, data, data_len, &aes, block32 + (16 / 4));
+
+			magic = data[data_len - 1];
+
+			for (j = 0, sum = 0; j < 16; j++)
+				sum += data[j];
+
+			block_size = 32 + (sum % 3) * 16;
+
+			if (block_size == 32) {
+				block_swap32(data32, data_len / 4);
+				LASTCHAR_BE(data32, data_len, 0x80);
+
+				/* Clean the last M-D block */
+				start_clean = data_len / 4 + 1;
+				md_len_pos = (start_clean & ~0xfU) + 15 + (((data_len & 63) > 55) ? 16 : 0);
+				for (j = start_clean; j < md_len_pos; j++)
+					data32[j] = 0;
+				data32[md_len_pos] = data_len << 3;
+
+				sha256_init(block32);
+
+				WP = data32;
+				for (uint left = data_len; left > 55; left -= 64, WP +=16)
+					sha256_block(WP, block32);
+				sha256_block(WP, block32);
+				block_swap32(block32, 8);
+			} else {
+				block_swap64(data64, data_len / 8);
+				LASTCHAR_BE64(data64, data_len, 0x80);
+
+				/* Clean the last M-D block */
+				start_clean = data_len / 8 + 1;
+				md_len_pos = (start_clean & ~0xfU) + 15 + (((data_len & 127) > 111) ? 16 : 0);
+				for (j = start_clean; j < md_len_pos; j++)
+					data64[j] = 0;
+				data64[md_len_pos] = data_len << 3;
+
+				if (block_size == 48)
+					sha384_init(block64);
+				else
+					sha512_init(block64);
+
+				ulong *W64P = data64;
+				for (uint left = data_len; left > 111; left -= 128, W64P +=16)
+					sha512_block(W64P, block64);
+				sha512_block(W64P, block64);
+				block_swap64(block64, 8);
+			}
+		}
+
+		if ((result[gidx] = !memcmp_pc(block, pdf_salt->u, 16)))
+			atomic_max(crack_count_ret, gidx + 1);
+	}
+}

--- a/run/opencl/tezos_kernel.cl
+++ b/run/opencl/tezos_kernel.cl
@@ -27,14 +27,14 @@ inline void _tezos_preproc_(const ulong *key, uint keylen,
 	ulong W[16];
 	ulong A, B, C, D, E, F, G, H, t;
 
-	A = SHA2_INIT_A;
-	B = SHA2_INIT_B;
-	C = SHA2_INIT_C;
-	D = SHA2_INIT_D;
-	E = SHA2_INIT_E;
-	F = SHA2_INIT_F;
-	G = SHA2_INIT_G;
-	H = SHA2_INIT_H;
+	A = SHA512_INIT_A;
+	B = SHA512_INIT_B;
+	C = SHA512_INIT_C;
+	D = SHA512_INIT_D;
+	E = SHA512_INIT_E;
+	F = SHA512_INIT_F;
+	G = SHA512_INIT_G;
+	H = SHA512_INIT_H;
 
 	j = ((keylen+7)/8);
 	for (i = 0; i < j; i++)
@@ -45,14 +45,14 @@ inline void _tezos_preproc_(const ulong *key, uint keylen,
 
 	SHA512(A, B, C, D, E, F, G, H, W);
 
-	state[0] = A + SHA2_INIT_A;
-	state[1] = B + SHA2_INIT_B;
-	state[2] = C + SHA2_INIT_C;
-	state[3] = D + SHA2_INIT_D;
-	state[4] = E + SHA2_INIT_E;
-	state[5] = F + SHA2_INIT_F;
-	state[6] = G + SHA2_INIT_G;
-	state[7] = H + SHA2_INIT_H;
+	state[0] = A + SHA512_INIT_A;
+	state[1] = B + SHA512_INIT_B;
+	state[2] = C + SHA512_INIT_C;
+	state[3] = D + SHA512_INIT_D;
+	state[4] = E + SHA512_INIT_E;
+	state[5] = F + SHA512_INIT_F;
+	state[6] = G + SHA512_INIT_G;
+	state[7] = H + SHA512_INIT_H;
 }
 
 inline void _tezos_hmac_(ulong *output, ulong *ipad_state, ulong *opad_state, ulong *salt, uint saltlen)

--- a/src/opencl_autotune.h
+++ b/src/opencl_autotune.h
@@ -133,7 +133,7 @@ static void autotune_run_extra(struct fmt_main *self, unsigned int rounds,
 		gws_limit = MIN(gws_limit, 0x7fffffffU / mask_int_cand.num_int_cand / ocl_v_width);
 
 	/* Read LWS/GWS prefs from config or environment */
-	opencl_get_user_preferences(FORMAT_LABEL);
+	opencl_get_user_preferences(self->params.label);
 
 	need_best_lws = !local_work_size && !getenv("LWS");
 	if (need_best_lws) {

--- a/src/opencl_cryptosafe_fmt_plug.c
+++ b/src/opencl_cryptosafe_fmt_plug.c
@@ -360,8 +360,9 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], cl_crack_count_ret, CL_TRUE, 0, sizeof(int), &crack_count_ret, 0, NULL, NULL), "failed reading results back");
 
 	if (crack_count_ret) {
+		/* This is benign - may happen when gws > count due to GET_NEXT_MULTIPLE() */
 		if (crack_count_ret > *pcount)
-			error_msg("Corrupt return: Got a claimed %u cracks out of %d\n", crack_count_ret, *pcount);
+			crack_count_ret = *pcount;
 
 		BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], cl_result, CL_TRUE, 0, sizeof(unsigned int) * crack_count_ret, cracked, 0, NULL, NULL), "failed reading results back");
 

--- a/src/opencl_krb5_tgs_fmt_plug.c
+++ b/src/opencl_krb5_tgs_fmt_plug.c
@@ -77,7 +77,10 @@ static const char *warn[] = {
 /* ------- Helper functions ------- */
 static size_t get_task_max_work_group_size()
 {
-	size_t s = MIN(autotune_get_task_max_work_group_size(FALSE, 0, init_kernel), 32);
+	size_t ls = gpu_amd(device_info[gpu_id]) ? 64 :
+		gpu(device_info[gpu_id]) ? 32 : 1024;
+
+	size_t s = MIN(autotune_get_task_max_work_group_size(FALSE, 0, init_kernel), ls);
 	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel));
 
 	return s;
@@ -392,9 +395,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
 
-	/* kernel is made for lws 32, using local memory */
 	size_t lws = local_work_size ? local_work_size : 32;
-	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
+	size_t gws = GET_NEXT_MULTIPLE(count, lws);
 
 	*pcount *= mask_int_cand.num_int_cand;
 

--- a/src/opencl_krb5pa-md5_fmt_plug.c
+++ b/src/opencl_krb5pa-md5_fmt_plug.c
@@ -135,7 +135,10 @@ static const char *warn[] = {
 /* ------- Helper functions ------- */
 static size_t get_task_max_work_group_size()
 {
-	return MIN(autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel), 32);
+	size_t ls = gpu_amd(device_info[gpu_id]) ? 64 :
+		gpu(device_info[gpu_id]) ? 32 : 1024;
+
+	return MIN(ls, autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel));
 }
 
 struct fmt_main FMT_STRUCT;
@@ -841,7 +844,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
 
-	/* kernel is made for lws 32, using local memory */
 	size_t lws = local_work_size ? local_work_size : 32;
 	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
 

--- a/src/opencl_pdf_fmt_plug.c
+++ b/src/opencl_pdf_fmt_plug.c
@@ -1,0 +1,509 @@
+/*
+ * This software is Copyright (c) 2024 magnum and it is hereby released to the
+ * general public under the following terms:  Redistribution and use in source
+ * and binary forms, with or without modification, are permitted.
+ */
+
+#define FORMAT_STRUCT fmt_pdf_opencl
+
+#ifdef HAVE_OPENCL
+
+#if FMT_REGISTERS_H
+john_register_one(&FORMAT_STRUCT);
+#else
+extern struct fmt_main FORMAT_STRUCT;
+
+#include "pdf_common.h"
+#include "opencl_common.h"
+#include "mask_ext.h"
+
+#define FORMAT_LABEL        "pdf-opencl"
+#define ALGORITHM_NAME      ALGORITHM_BASE " OpenCL"
+#define MAX_KEYS_PER_CRYPT  1
+
+static int new_keys;
+
+/* Boilerplate OpenCL stuff */
+static char *saved_key;
+static unsigned int *saved_idx, key_idx;
+static unsigned int *result, crack_count_ret;
+static size_t key_offset, idx_offset;
+static cl_mem cl_saved_key, cl_saved_idx, cl_salt, cl_result, cl_crack_count_ret;
+static cl_mem pinned_saved_key, pinned_saved_idx, pinned_result;
+static cl_mem pinned_saved_int_key_loc, cl_buffer_int_keys, cl_saved_int_key_loc;
+static cl_uint *saved_int_key_loc;
+static int static_gpu_locations[MASK_FMT_INT_PLHDR];
+static const cl_uint zero = 0;
+
+static cl_kernel pdf_kernel[4];
+static char *kernel_name[4] = { "pdf_r2", "pdf_r34", "pdf_r5", "pdf_r6" };
+
+#define STEP			0
+#define SEED			1024
+
+// This file contains auto-tuning routine(s). Has to be included after formats definitions.
+#include "opencl_autotune.h"
+
+static const char *warn[] = {
+	"xP: ",  ", xI: ",  ", crypt: "
+};
+
+/* ------- Helper functions ------- */
+static size_t get_task_max_work_group_size()
+{
+	int i;
+	size_t s = gpu_amd(device_info[gpu_id]) ? 64 :
+		gpu(device_info[gpu_id]) ? 32 : 1024;
+
+	for (i = 0; i < 4; i++)
+		s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, pdf_kernel[i]));
+
+	return s;
+}
+
+static void release_clobj(void);
+
+#define CL_RO    CL_MEM_READ_ONLY
+#define CL_WO    CL_MEM_WRITE_ONLY
+#define CL_RW    CL_MEM_READ_WRITE
+#define CL_ALLOC CL_MEM_ALLOC_HOST_PTR
+#define CL_COPY  CL_MEM_COPY_HOST_PTR
+
+#define CLCREATEBUFFER(var, flags, size)	  \
+	do { var = clCreateBuffer(context[gpu_id], flags, size, NULL, &ret_code); \
+		HANDLE_CLERROR(ret_code, "Error allocating GPU memory"); } while(0)
+
+#define CLCREATEBUFCOPY(var, flags, size, _hostbuf)	  \
+	do { var = clCreateBuffer(context[gpu_id], flags | CL_COPY, size, _hostbuf, &ret_code); \
+		HANDLE_CLERROR(ret_code, "Error copying host pointer for GPU"); } while(0)
+
+#define CLCREATEPINNED(var, flags, size)	  \
+	do { \
+		pinned_##var = clCreateBuffer(context[gpu_id], flags | CL_ALLOC, size, NULL, &ret_code); \
+		if (ret_code != CL_SUCCESS) { \
+			var = mem_alloc(size); \
+			if (var == NULL) \
+				HANDLE_CLERROR(ret_code, "Error allocating pinned buffer"); \
+		} else { \
+			var = clEnqueueMapBuffer(queue[gpu_id], pinned_##var, CL_TRUE, \
+			                         CL_MAP_READ | CL_MAP_WRITE, 0, size, 0, NULL, NULL, &ret_code); \
+			HANDLE_CLERROR(ret_code, "Error mapping buffer"); \
+			cl_##var = clCreateBuffer(context[gpu_id], flags, size, NULL, &ret_code); \
+			HANDLE_CLERROR(ret_code, "Error creating device buffer"); \
+		} \
+	} while(0)
+
+#define CLKERNELARG(kernel, id, arg)	  \
+	HANDLE_CLERROR(clSetKernelArg(kernel, id, sizeof(arg), &arg), \
+	               "Error setting kernel argument")
+
+#define CLKRNARGLOC(kernel, id, arg)	  \
+	HANDLE_CLERROR(clSetKernelArg(kernel, id, sizeof(arg), NULL), \
+	               "Error setting kernel argument for local memory")
+
+#define CLWRITE(gpu_var, wait, offset, size, host_var, event)	  \
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], gpu_var, wait, offset, size, host_var, 0, NULL, event), \
+	               "Failed writing buffer")
+
+#define CLWRITE_CRYPT(gpu_var, wait, offset, size, host_var, event)	  \
+	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], gpu_var, wait, offset, size, host_var, 0, NULL, event), \
+	              "Failed writing buffer")
+
+#define CLREAD_CRYPT(gpu_var, wait, offset, size, host_var, event)	  \
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], gpu_var, wait, offset, size, host_var, 0, NULL, event),\
+	              "failed reading buffer")
+
+#define RELEASEPINNED(var)	  \
+	do { \
+		if (pinned_##var) { \
+			HANDLE_CLERROR(clEnqueueUnmapMemObject(queue[gpu_id], pinned_##var, var, 0, NULL, NULL), \
+			               "Error Unmapping buffer"); \
+			HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error releasing memory mapping"); var = NULL; \
+		} else \
+			MEM_FREE(var); \
+		HANDLE_CLERROR(clReleaseMemObject(pinned_##var), "Error releasing pinned buffer"); \
+		pinned_##var = NULL; \
+		HANDLE_CLERROR(clReleaseMemObject(cl_##var), "Error releasing buffer"); \
+		cl_##var = NULL; \
+	} while(0);
+
+#define RELEASEBUFFER(var)	\
+	do { HANDLE_CLERROR(clReleaseMemObject(var), "Release buffer"); var = NULL; } while(0)
+
+static void create_clobj(size_t gws, struct fmt_main *self)
+{
+	int i;
+
+	release_clobj();
+
+	CLCREATEPINNED(saved_key, CL_RO, PLAINTEXT_LENGTH * gws);
+	CLCREATEPINNED(saved_idx, CL_RO, sizeof(cl_uint) * (gws + 1));
+	CLCREATEPINNED(result, CL_WO, sizeof(cl_uint) * gws * mask_int_cand.num_int_cand);
+	CLCREATEBUFFER(cl_salt, CL_RO, sizeof(pdf_salt_type));
+	CLCREATEBUFFER(cl_crack_count_ret, CL_RW, sizeof(cl_uint));
+
+	/* For GPU-side mask */
+	CLCREATEPINNED(saved_int_key_loc, CL_RO, sizeof(cl_uint) * gws);
+	CLCREATEBUFCOPY(cl_buffer_int_keys, CL_RO, 4 * mask_int_cand.num_int_cand,
+	                mask_int_cand.int_cand ? mask_int_cand.int_cand : (void*)&zero);
+
+	crack_count_ret = 0;
+	CLWRITE(cl_crack_count_ret, CL_TRUE, 0, sizeof(cl_uint), &crack_count_ret, NULL);
+
+	for (i = 0; i < 4; i++) {
+		CLKERNELARG(pdf_kernel[i], 0, cl_saved_key);
+		CLKERNELARG(pdf_kernel[i], 1, cl_saved_idx);
+		CLKERNELARG(pdf_kernel[i], 2, cl_salt);
+		CLKERNELARG(pdf_kernel[i], 3, cl_result);
+		CLKERNELARG(pdf_kernel[i], 4, cl_crack_count_ret);
+		CLKERNELARG(pdf_kernel[i], 5, cl_saved_int_key_loc);
+		CLKERNELARG(pdf_kernel[i], 6, cl_buffer_int_keys);
+	}
+}
+
+static void release_clobj(void)
+{
+	if (cl_salt) {
+		RELEASEPINNED(result);
+		RELEASEPINNED(saved_key);
+		RELEASEPINNED(saved_idx);
+		RELEASEPINNED(saved_int_key_loc);
+		RELEASEBUFFER(cl_crack_count_ret);
+		RELEASEBUFFER(cl_salt);
+		RELEASEBUFFER(cl_buffer_int_keys);
+	}
+}
+
+static void done(void)
+{
+	if (program[gpu_id]) {
+		int i;
+
+		release_clobj();
+
+		for (i = 0; i < 4; i++)
+			HANDLE_CLERROR(clReleaseKernel(pdf_kernel[i]), "Release kernel");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program");
+
+		crypt_kernel = NULL;
+		program[gpu_id] = NULL;
+	}
+}
+
+static void init(struct fmt_main *self)
+{
+	opencl_prepare_dev(gpu_id);
+
+	/*
+	 * For lack of a better scheme.  Once we know what is actually loaded, it's
+	 * too late to set the internal mask target.
+	 */
+	if (options.loader.max_cost[0] <= 6) {
+		switch (options.loader.max_cost[0])
+		{
+		case 6:
+			mask_int_cand_target = 0;
+			break;
+		case 5:
+			mask_int_cand_target = opencl_speed_index(gpu_id) / 10000;
+			break;
+		case 2:
+			mask_int_cand_target = opencl_speed_index(gpu_id) / 20000;
+			break;
+		default: // rev 3 and 4, RC4-40 and -128
+			mask_int_cand_target = opencl_speed_index(gpu_id) / 100000;
+		}
+	} else if (options.loader.min_cost[0] == 6)
+		mask_int_cand_target = 0;
+	else
+		mask_int_cand_target = opencl_speed_index(gpu_id) / 100000;
+}
+
+static void reset(struct db_main *db)
+{
+	size_t gws_limit = 4 << 20;
+	cl_ulong const_cache_size;
+	char build_opts[1024];
+	int i;
+
+	if (crypt_kernel)
+		done();
+
+	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
+			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
+				ranges[mask_skip_ranges[i]].pos;
+		else
+			static_gpu_locations[i] = -1;
+
+	HANDLE_CLERROR(clGetDeviceInfo(devices[gpu_id], CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, sizeof(cl_ulong), &const_cache_size, 0), "failed to get CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE.");
+
+	snprintf(build_opts, sizeof(build_opts),
+	         "-DPLAINTEXT_LENGTH=%u -DMAX_KEY_SIZE=%u"
+	         " -DCONST_CACHE_SIZE=%llu -DLOC_0=%d"
+#if MASK_FMT_INT_PLHDR > 1
+	         " -DLOC_1=%d"
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+	         " -DLOC_2=%d"
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+	         " -DLOC_3=%d"
+#endif
+	         " -DNUM_INT_KEYS=%u -DIS_STATIC_GPU_MASK=%d",
+	         PLAINTEXT_LENGTH,
+	         MAX_KEY_SIZE,
+	         (unsigned long long)const_cache_size,
+	         static_gpu_locations[0],
+#if MASK_FMT_INT_PLHDR > 1
+	         static_gpu_locations[1],
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+	         static_gpu_locations[2],
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+	         static_gpu_locations[3],
+#endif
+	         mask_int_cand.num_int_cand, mask_gpu_is_static
+		);
+
+	if (!program[gpu_id])
+		opencl_init("$JOHN/opencl/pdf_kernel.cl", gpu_id, build_opts);
+
+	/* create kernels to execute */
+	if (!crypt_kernel) {
+		for(i = 0; i < 4; i++) {
+			pdf_kernel[i] = clCreateKernel(program[gpu_id], kernel_name[i], &ret_code);
+			HANDLE_CLERROR(ret_code, kernel_name[i]);
+		}
+		crypt_kernel = pdf_kernel[0];
+	}
+
+	// Initialize openCL tuning (library) for this format.
+	opencl_init_auto_setup(SEED, 0, NULL, warn, 2, &FORMAT_STRUCT, create_clobj,
+	                       release_clobj, PLAINTEXT_LENGTH, gws_limit, db);
+
+	// Auto tune execution from shared/included code.
+	autotune_run(&FORMAT_STRUCT, 1, gws_limit, 500);
+
+	new_keys = 1;
+}
+
+static void clear_keys(void)
+{
+	key_idx = 0;
+	saved_idx[0] = 0;
+	key_offset = 0;
+	idx_offset = 0;
+}
+
+static void set_key(char *key, int index)
+{
+	if (mask_int_cand.num_int_cand > 1 && !mask_gpu_is_static) {
+		int i;
+
+		saved_int_key_loc[index] = 0;
+		for (i = 0; i < MASK_FMT_INT_PLHDR; i++) {
+			if (mask_skip_ranges[i] != -1)  {
+				saved_int_key_loc[index] |= ((mask_int_cand.
+				int_cpu_mask_ctx->ranges[mask_skip_ranges[i]].offset +
+				mask_int_cand.int_cpu_mask_ctx->
+				ranges[mask_skip_ranges[i]].pos) & 0xff) << (i << 3);
+			}
+			else
+				saved_int_key_loc[index] |= 0x80 << (i << 3);
+		}
+	}
+
+	while (*key)
+		saved_key[key_idx++] = *key++;
+
+	saved_idx[index + 1] = key_idx;
+	new_keys = 1;
+
+	/* Early partial transfer to GPU */
+	if (index && !(index & (256*1024 - 1))) {
+		CLWRITE(cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, NULL);
+		CLWRITE(cl_saved_idx, CL_FALSE, idx_offset, 4 * (index + 2) - idx_offset, saved_idx + (idx_offset / 4), NULL);
+
+		if (!mask_gpu_is_static)
+			CLWRITE(cl_saved_int_key_loc, CL_FALSE, idx_offset, 4 * (index + 1) - idx_offset, saved_int_key_loc + (idx_offset / 4), NULL);
+
+		HANDLE_CLERROR(clFlush(queue[gpu_id]), "failed in clFlush");
+
+		key_offset = key_idx;
+		idx_offset = 4 * (index + 1);
+		new_keys = 0;
+	}
+}
+
+static char *get_key(int index)
+{
+	static char out[PLAINTEXT_LENGTH + 1];
+	char *key;
+	int i, len;
+	int t = index;
+	int int_index = 0;
+
+	if (mask_int_cand.num_int_cand) {
+		t = index / mask_int_cand.num_int_cand;
+		int_index = index % mask_int_cand.num_int_cand;
+	}
+	else if (t >= global_work_size)
+		t = 0;
+
+	len = saved_idx[t + 1] - saved_idx[t];
+	key = (char*)&saved_key[saved_idx[t]];
+
+	for (i = 0; i < len; i++)
+		out[i] = *key++;
+	out[i] = 0;
+
+	/* Apply GPU-side mask */
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
+			if (mask_gpu_is_static)
+				out[static_gpu_locations[i]] =
+					mask_int_cand.int_cand[int_index].x[i];
+			else
+				out[(saved_int_key_loc[t] & (0xff << (i * 8))) >> (i * 8)] =
+					mask_int_cand.int_cand[int_index].x[i];
+	}
+
+	return out;
+}
+
+static void set_salt(void *salt)
+{
+	int krn;
+
+	pdf_salt = salt;
+
+	if (pdf_salt->R == 2)
+		krn = 0;
+	else if (pdf_salt->R == 3 || pdf_salt->R ==4)
+		krn = 1;
+	else if (pdf_salt->R == 5)
+		krn = 2;
+	else //if (pdf_salt->R == 6)
+		krn = 3;
+
+	crypt_kernel = pdf_kernel[krn];
+
+	CLWRITE(cl_salt, CL_FALSE, 0, sizeof(pdf_salt_type), pdf_salt, NULL);
+	HANDLE_CLERROR(clFlush(queue[gpu_id]), "clFlush failed in set_salt()");
+}
+
+/* Returns the last output index for which there might be a match (against the
+ * supplied salt's hashes) plus 1.  A return value of zero indicates no match.*/
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	int count = *pcount;
+	size_t *lws = local_work_size ? &local_work_size : NULL;
+	size_t gws = GET_NEXT_MULTIPLE(count, local_work_size);
+
+	*pcount *= mask_int_cand.num_int_cand;
+
+	if (new_keys) {
+		/* Self-test kludge */
+		if (idx_offset > 4 * (gws + 1))
+			idx_offset = 0;
+
+		CLWRITE_CRYPT(cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, multi_profilingEvent[0]);
+		CLWRITE_CRYPT(cl_saved_idx, CL_FALSE, idx_offset, 4 * (gws + 1) - idx_offset, saved_idx + (idx_offset / 4), multi_profilingEvent[1]);
+
+		if (!mask_gpu_is_static)
+			CLWRITE_CRYPT(cl_saved_int_key_loc, CL_FALSE, idx_offset, 4 * gws - idx_offset, saved_int_key_loc + (idx_offset / 4), NULL);
+
+		new_keys = 0;
+	}
+
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL, &gws, lws, 0, NULL, multi_profilingEvent[2]), "Failed running crypt kernel");
+
+	CLREAD_CRYPT(cl_crack_count_ret, CL_TRUE, 0, sizeof(cl_uint), &crack_count_ret, NULL);
+
+	if (crack_count_ret) {
+		/* This is benign - may happen when gws > count due to GET_NEXT_MULTIPLE() */
+		if (crack_count_ret > *pcount)
+			crack_count_ret = *pcount;
+
+		CLREAD_CRYPT(cl_result, CL_TRUE, 0, sizeof(cl_uint) * crack_count_ret, result, NULL);
+
+		CLWRITE_CRYPT(cl_crack_count_ret, CL_FALSE, 0, sizeof(cl_uint), &zero, NULL);
+	}
+
+	return crack_count_ret;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	return count;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return result[index];
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+struct fmt_main FORMAT_STRUCT = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_MASK,
+		{
+			"revision",
+			"key length"
+		},
+		{ FORMAT_TAG, FORMAT_TAG_OLD },
+		pdf_tests
+	}, {
+		init,
+		done,
+		reset,
+		pdf_prepare,
+		pdf_valid,
+		fmt_default_split,
+		fmt_default_binary,
+		pdf_get_salt,
+		{
+			pdf_revision,
+			pdf_keylen
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash
+		},
+		fmt_default_salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		clear_keys,
+		crypt_all,
+		{
+			fmt_default_get_hash
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */
+#endif /* HAVE_OPENCL */

--- a/src/pdf_common.h
+++ b/src/pdf_common.h
@@ -1,0 +1,71 @@
+/*
+ * PDF cracker patch for JtR. Hacked together during Monsoon of 2012 by
+ * Dhiru Kholia <dhiru.kholia at gmail.com>.
+ *
+ * This software is
+ * Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
+ * Copyright (c) 2013, Shane Quigley
+ * Copyright (c) 2024, magnum
+ *
+ * Uses code from pdfcrack, Sumatra PDF and MuPDF which are under GPL.
+ */
+
+#include <string.h>
+
+#include "arch.h"
+#include "params.h"
+#include "common.h"
+#include "formats.h"
+#include "misc.h"
+#include "loader.h"
+#include "options.h"
+#include "logger.h"
+
+#define FORMAT_NAME         "PDF encrypted document"
+#define ALGORITHM_BASE      "MD5-RC4 / SHA2-AES"
+#define FORMAT_TAG          "$pdf$"
+#define FORMAT_TAG_LEN      (sizeof(FORMAT_TAG)-1)
+#define FORMAT_TAG_OLD      "$pdf$Standard*"
+#define FORMAT_TAG_OLD_LEN  (sizeof(FORMAT_TAG_OLD)-1)
+#define BENCHMARK_COMMENT   ""
+#define BENCHMARK_LENGTH    0x507
+#define PLAINTEXT_LENGTH    125
+#define BINARY_SIZE         0
+#define SALT_SIZE           sizeof(pdf_salt_type)
+#define BINARY_ALIGN        1
+#define SALT_ALIGN          sizeof(int)
+#define MIN_KEYS_PER_CRYPT  1
+
+#define MAX_KEY_SIZE        256
+#define MAX_U_LEN           sizeof((pdf_salt_type){}.u)
+#define MAX_O_LEN           sizeof((pdf_salt_type){}.o)
+
+typedef struct {
+	int V;                 // populated but unused
+	int R;
+	int P;
+	int encrypt_metadata;
+	unsigned char u[128];
+	unsigned char o[128];
+	unsigned char id[128];
+	int key_length;        // key length in bits
+	int id_len;
+	int u_len;
+	int o_len;
+} pdf_salt_type;
+
+extern pdf_salt_type *pdf_salt;
+extern int *pdf_cracked;
+extern int any_pdf_cracked;
+extern size_t pdf_cracked_size;
+extern struct fmt_tests pdf_tests[];
+extern const unsigned char pdf_padding[32];
+
+extern int pdf_valid(char *ciphertext, struct fmt_main *self);
+extern char *pdf_prepare(char *split_fields[10], struct fmt_main *self);
+extern void *pdf_get_salt(char *ciphertext);
+extern int pdf_cmp_all(void *binary, int count);
+extern int pdf_cmp_one(void *binary, int index);
+extern int pdf_cmp_exact(char *source, int index);
+extern unsigned int pdf_revision(void *salt);
+extern unsigned int pdf_keylen(void *salt);

--- a/src/pdf_common_plug.c
+++ b/src/pdf_common_plug.c
@@ -1,0 +1,336 @@
+/*
+ * PDF cracker patch for JtR. Hacked together during Monsoon of 2012 by
+ * Dhiru Kholia <dhiru.kholia at gmail.com>.
+ *
+ * This software is
+ * Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
+ * Copyright (c) 2013, Shane Quigley
+ * Copyright (c) 2024, magnum
+ *
+ * Uses code from pdfcrack, Sumatra PDF and MuPDF which are under GPL.
+ */
+
+#include "pdf_common.h"
+
+pdf_salt_type* pdf_salt;
+int* pdf_cracked;
+int any_pdf_cracked;
+size_t pdf_cracked_size;
+
+const unsigned char pdf_padding[32] =
+{
+        0x28, 0xbf, 0x4e, 0x5e, 0x4e, 0x75, 0x8a, 0x41,
+        0x64, 0x00, 0x4e, 0x56, 0xff, 0xfa, 0x01, 0x08,
+        0x2e, 0x2e, 0x00, 0xb6, 0xd0, 0x68, 0x3e, 0x80,
+        0x2f, 0x0c, 0xa9, 0xfe, 0x64, 0x53, 0x69, 0x7a
+};
+
+struct fmt_tests pdf_tests[] = {
+	/* R2 MD5 + RC4-40 */
+	/* This hash exposed a problem with our id_len check */
+	{"$pdf$1*2*40*-4*1*36*65623237393831382d636439372d343130332d613835372d343164303037316639386134*32*c7230519f7db63ab1676fa30686428f0f997932bf831f1c1dcfa48cfb3b7fe99*32*161cd2f7c95283ca9db930b36aad3571ee6f5fb5632f30dc790e19c5069c86b8", "vision"},
+	/* This hash has unsigned permission value, and an id length of 0 */
+	{"$pdf$1*2*40*4294967239*1*0**32*585e4cc4113bbd8ff4012dce92dd7df1e1216fb630b29cf5aeea10a820066c26*32*b1db56a883cab5a22dd5fc390618a0f8e16cab8af14e67ccba5f90837aac898b", "123456"},
+	/* Old format hashes */
+	{"$pdf$Standard*9a1156c38ab8177598d1608df7d7e340ae639679bd66bc4cda9bc9a4eedeb170*1f300cd939dd5cf0920c787f12d16be22205e55a5bec5c9c6d563ab4fd0770d7*16*c015cff8dbf99345ac91c84a45667784*1*1*0*1*6*40*-4*2*1", "testpassword"},
+	{"$pdf$Standard*7303809eaf677bdb5ca64b9d8cb0ccdd47d09a7b28ad5aa522c62685c6d9e499*bf38d7a59daaf38365a338e1fc07976102f1dfd6bdb52072032f57920109b43a*16*c56bbc4145d25b468a873618cd71c2d3*1*1*0*1*6*40*-4*2*1", "test"},
+
+	/* R3 MD5 + RC4-40 */
+	/* Code is tested with hash from a real document, but this one is fabricated */
+	{"$pdf$1*3*40*-4*1*16*5e1f73575e1f73575e1f73575e1f7357*32*c0be424bef466277092f2a1ba0fbe506ebabe5c01db100dedc0ffeebabe5c01d*32*0ff1cedeadce110ff1cedeadce110ff1cedeadce110ff1cedeadce11babebabe", "hashcat"},
+
+	/* R3 MD5 + RC4-128 */
+	{"$pdf$2*3*128*-4*1*16*34b1b6e593787af681a9b63fa8bf563b*32*289ece9b5ce451a5d7064693dab3badf101112131415161718191a1b1c1d1e1f*32*badad1e86442699427116d3e5d5271bc80a27814fc5e80f815efeef839354c5f", "test"},
+	/* Old format hashes */
+	{"$pdf$Standard*badad1e86442699427116d3e5d5271bc80a27814fc5e80f815efeef839354c5f*289ece9b5ce451a5d7064693dab3badf101112131415161718191a1b1c1d1e1f*16*34b1b6e593787af681a9b63fa8bf563b*1*1*0*1*4*128*-4*3*2", "test"},
+	{"$pdf$Standard*137ad7063db5114a66ce1900d47e5cab9c5d7053487d92ac978f54db86eca393*0231a4c9cae29b53892874e168cfae9600000000000000000000000000000000*16*c015cff8dbf99345ac91c84a45667784*1*1*0*1*6*128*-1028*3*2", "testpassword"},
+	{"$pdf$Standard*d83a8ab680f144dfb2ff2334c206a6060779e007701ab881767f961aecda7984*a5ed4de7e078cb75dfdcd63e8da7a25800000000000000000000000000000000*16*06a7f710cf8dfafbd394540d40984ae2*1*1*0*1*4*128*-1028*3*2", "July2099"},
+	{"$pdf$Standard*6a80a547b8b8b7636fcc5b322f1c63ce4b670c9b01f2aace09e48d85e1f19f83*e64eb62fc46be66e33571d50a29b464100000000000000000000000000000000*16*14a8c53ffa4a79b3ed9421ef15618420*1*1*0*1*4*128*-1028*3*2", "38r285a9"},
+	{"$pdf$Standard*2446dd5ed2e18b3ce1ac9b56733226018e3f5c2639051eb1c9b2b215b30bc820*fa3af175d761963c8449ee7015b7770800000000000000000000000000000000*16*12a4da1abe6b7a1ceb84610bad87236d*1*1*0*1*4*128*-1028*3*2", "WHATwhatWHERE?"},
+	{"$pdf$Standard*e600ecc20288ad8b0d64a929c6a83ee2517679aa0218beceea8b7986726a8cdb*38aca54678d67c003a8193381b0fa1cc101112131415161718191a1b1c1d1e1f*16*1521fbe61419fcad51878cc5d478d5ff*1*1*0*1*4*128*-3904*3*2", ""},
+
+	/* R4 MD5 + RC4 */
+	{"$pdf$4*4*128*-1028*1*16*e03460febe17a048b0adc7f7631bcc56*32*3456205208ad52066d5604018d498a6400000000000000000000000000000000*32*6d598152b22f8fa8085b19a866dce1317f645788a065a74831588a739a579ac4", "openwall"},
+	{"$pdf$4*4*128*-1028*1*16*c015cff8dbf99345ac91c84a45667784*32*0231a4c9cae29b53892874e168cfae9600000000000000000000000000000000*32*137ad7063db5114a66ce1900d47e5cab9c5d7053487d92ac978f54db86eca393", "testpassword"},
+	/* CMIYC 2013 "pro" hashes */
+	{"$pdf$4*4*128*-4*1*16*f7bc2744e1652cf61ca83cac8fccb535*32*f55cc5032f04b985c5aeacde5ec4270f0122456a91bae5134273a6db134c87c4*32*785d891cdcb5efa59893c78f37e7b75acef8924951039b4fa13f62d92bb3b660", "L4sV3g4z"},
+	{"$pdf$4*4*128*-4*1*16*ec8ea2af2977db1faa4a955904dc956f*32*fc413edb049720b1f8eac87a358faa740122456a91bae5134273a6db134c87c4*32*1ba7aed2f19c77ac6b5061230b62e80b48fc42918f92aef689ceb07d26204991", "ZZt0pr0x"},
+	{"$pdf$4*4*128*-4*1*16*56761d6da774d8d47387dccf1a84428c*32*640782cab5b7c8f6cf5eab82c38016540122456a91bae5134273a6db134c87c4*32*b5720d5f3d9675a280c6bb8050cbb169e039b578b2de4a42a40dc14765e064cf", "24Le`m0ns"},
+
+	/* R5 SHA-256 */
+	{"$pdf$5*5*256*-1028*1*16*762896ef582ca042a15f380c63ab9f2c*127*8713e2afdb65df1d3801f77a4c4da4905c49495e7103afc2deb06d9fba7949a565143288823871270d9d882075a75da600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000*127*15d0b992974ff80529e4b616b8c4c79d787705b6c8a9e0f85446498ae2432e0027d8406b57f78b60b11341a0757d7c4a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000*32*a7a0f3891b469ba7261ce04752dad9c6de0db9c4155c4180e721938a7d9666c7*32*2fa9a0c52badebae2c19dfa7b0005a9cfc909b92babbe7db66a794e96a9f91e3", "openwall"},
+
+	/* R6 SHA-256/384/512 + AES-128-CBC */
+	{"$pdf$5*6*256*-1028*1*16*05e5abeb21ad2e47adac1c2b2c7b7a31*127*51d3a6a09a675503383e5bc0b53da77ec5d5ea1d1998fb94e00a02a1c2e49313c177905272a4e8e68b382254ec8ed74800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000*127*dc38f01ef129aae2fca847396465ed518f9c7cf4f2c8cb4399a849d0fe9110227739ab88ddc9a6cf388ae11941270af500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000*32*b8e137baf316e0789ffa73f888d26495c14d31f2cfff3799e339e2fa078649f5*32*835a9e07461992791914c3d62d37493e07d140937529ab43e26ac2a657152c3c", "testpassword"},
+	{NULL}
+};
+
+int pdf_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *keeptr;
+	char *p;
+	int res;
+
+	if (strncmp(ciphertext,  FORMAT_TAG, FORMAT_TAG_LEN))
+		return 0;
+
+	ctcopy = xstrdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LEN;
+	if ((p = strtokm(ctcopy, "*")) == NULL)	/* V */
+		goto err;
+	if (!isdec(p)) goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* R */
+		goto err;
+	if (!isdec(p)) goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* key_length */
+		goto err;
+	if (!isdec(p)) goto err;
+	res = atoi(p);
+	if (res < 40 || res > MAX_KEY_SIZE || (res % 4))
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* P */
+		goto err;
+	/* Somehow this can be signed or unsigned int; -2147483648 .. 4294967295 */
+	if (!isdec_negok(p) && !isdecu(p)) goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* encrypt_metadata */
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* id_len */
+		goto err;
+	if (!isdec(p)) goto err;
+	res = atoi(p);
+	if (res > 128)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* id */
+		goto err;
+	if (strlen(p) != res * 2)
+		goto err;
+	/* id length can be 0 */
+	if (*p && !ishexlc(p))
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* u_len */
+		goto err;
+	if (!isdec(p)) goto err;
+	res = atoi(p);
+	if (res > MAX_U_LEN)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* u */
+		goto err;
+	if (strlen(p) != res * 2)
+		goto err;
+	if (!ishexlc(p))
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* o_len */
+		goto err;
+	if (!isdec(p)) goto err;
+	res = atoi(p);
+	if (res > MAX_O_LEN)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* o */
+		goto err;
+	if (strlen(p) != res * 2)
+		goto err;
+	if (!ishexlc(p))
+		goto err;
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+static int pdf_old_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy, *ptr, *keeptr;
+	int res;
+
+	if (strncmp(ciphertext, FORMAT_TAG_OLD, FORMAT_TAG_OLD_LEN))
+		return 0;
+	if (!(ctcopy = xstrdup(ciphertext)))
+		return 0;
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_OLD_LEN;
+	if (!(ptr = strtokm(ctcopy, "*"))) /* 1 o_string */
+		goto error;
+	if (!ishexlc(ptr))
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 2 u_string */
+		goto error;
+	if (!ishexlc(ptr))
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 3 fileIDLen */
+		goto error;
+	if (strncmp(ptr, "16", 2))
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 4 fileID */
+		goto error;
+	if (!ishexlc(ptr))
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 5 encryptMetaData */
+		goto error;
+	res = atoi(ptr);
+	if (res != 0 && res != 1)
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 6 work_with_user */
+		goto error;
+	res = atoi(ptr);
+	if (res != 0 && res != 1)
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 7 have_userpassword */
+		goto error;
+	res = atoi(ptr);
+	if (res != 0 && res != 1)
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 8 version_major */
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 9 version_minor */
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 10 key_length */
+		goto error;
+	res = atoi(ptr);
+	if (res < 0 || res > MAX_KEY_SIZE)
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 11 permissions P */
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 12 revision R */
+		goto error;
+	if (!(ptr = strtokm(NULL, "*"))) /* 13 version V */
+		goto error;
+	MEM_FREE(keeptr);
+	return 1;
+error:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+static char* pdf_convert_old_to_new(char ciphertext[])
+{
+	char *ctcopy = xstrdup(ciphertext);
+	char *keeptr = ctcopy;
+	char *out = mem_alloc_tiny(strlen(ctcopy), MEM_ALIGN_NONE);
+	const char *fields[14];
+	char *p;
+	int c = 0;
+
+	p = strtokm(ctcopy, "*");
+	for (c = 0; c < 14; c++) {
+		fields[c] = p;
+		p = strtokm(NULL, "*");
+	}
+	strcpy(out,FORMAT_TAG);
+	strcat(out,fields[13]); // V
+	strcat(out,"*");
+	strcat(out,fields[12]); // R
+	strcat(out,"*");
+	strcat(out,fields[10]); // keylen
+	strcat(out,"*");
+	strcat(out,fields[11]); // P
+	strcat(out,"*");
+	strcat(out,fields[5]); // enc metadata
+	strcat(out,"*");
+	strcat(out,fields[3]); // id_len
+	strcat(out,"*");
+	strcat(out,fields[4]); // id
+	strcat(out,"*32*");    // len u
+	strcat(out,fields[2]); // u
+	strcat(out,"*32*");    // len o
+	strcat(out,fields[1]); // o
+	MEM_FREE(keeptr);
+	return out;
+}
+
+char *pdf_prepare(char *split_fields[10], struct fmt_main *self)
+{
+	// Convert old format to new one
+	if (!strncmp(split_fields[1], FORMAT_TAG_OLD, FORMAT_TAG_OLD_LEN) &&
+	    pdf_old_valid(split_fields[1], self))
+		return pdf_convert_old_to_new(split_fields[1]);
+
+	return split_fields[1];
+}
+
+void *pdf_get_salt(char *ciphertext)
+{
+	char *ctcopy = xstrdup(ciphertext);
+	char *keeptr = ctcopy;
+	int i;
+	char *p;
+	static pdf_salt_type cs;
+
+	memset(&cs, 0, sizeof(cs));
+	ctcopy += FORMAT_TAG_LEN;	/* skip over "$pdf$" marker */
+	p = strtokm(ctcopy, "*");
+	cs.V = atoi(p);
+	p = strtokm(NULL, "*");
+	cs.R = atoi(p);
+	p = strtokm(NULL, "*");
+	cs.key_length = atoi(p);
+	p = strtokm(NULL, "*");
+	cs.P = (int)strtoll(p, (char **)NULL, 10);
+	p = strtokm(NULL, "*");
+	cs.encrypt_metadata = atoi(p);
+	p = strtokm(NULL, "*");
+	cs.id_len = atoi(p);
+	p = strtokm(NULL, "*");
+	for (i = 0; i < cs.id_len; i++)
+		cs.id[i] =
+		    atoi16[ARCH_INDEX(p[i * 2])] * 16 +
+		    atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "*");
+	cs.u_len = atoi(p);
+	p = strtokm(NULL, "*");
+	for (i = 0; i < cs.u_len; i++)
+		cs.u[i] =
+		    atoi16[ARCH_INDEX(p[i * 2])] * 16 +
+		    atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "*");
+	cs.o_len = atoi(p);
+	p = strtokm(NULL, "*");
+	for (i = 0; i < cs.o_len; i++)
+		cs.o[i] =
+		    atoi16[ARCH_INDEX(p[i * 2])] * 16 +
+		    atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	MEM_FREE(keeptr);
+	return (void *)&cs;
+}
+
+int pdf_cmp_all(void *binary, int count)
+{
+	return any_pdf_cracked;
+}
+
+int pdf_cmp_one(void *binary, int index)
+{
+	return pdf_cracked[index];
+}
+
+int pdf_cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+/*
+ * Report revision as tunable cost, since between revisions 2 and 6,
+ * only revisions 3 and 4 seem to have a similar c/s rate.
+ */
+unsigned int pdf_revision(void *salt)
+{
+	pdf_salt_type *pdf_salt = salt;
+
+	return (unsigned int)pdf_salt->R;
+}
+
+/*
+ * This is mostly for being able to pick what to benchmark for rev. 3
+ *
+ * Revisions 2..4 has salt->R as RC4 key length (40 or 128).
+ * Revision 5 use only SHA256 and has salt->R as 256.
+ * Revision 6 also has salt->R as 256 but actually uses AES-128.
+ */
+unsigned int pdf_keylen(void *salt)
+{
+	pdf_salt_type *pdf_salt = salt;
+
+	return (unsigned int)pdf_salt->key_length;
+}

--- a/src/pdf_fmt_plug.c
+++ b/src/pdf_fmt_plug.c
@@ -16,41 +16,19 @@ extern struct fmt_main fmt_pdf;
 john_register_one(&fmt_pdf);
 #else
 
-#include <string.h>
-
 #ifdef _OPENMP
 #include <omp.h>
 #endif
 
-#include "arch.h"
-#include "params.h"
-#include "common.h"
-#include "formats.h"
-#include "misc.h"
+#include "pdf_common.h"
 #include "md5.h"
 #include "aes.h"
 #include "sha2.h"
 #include "rc4.h"
 #include "pdfcrack_md5.h"
-#include "loader.h"
-#include "options.h"
-#include "logger.h"
 
 #define FORMAT_LABEL        "PDF"
-#define FORMAT_NAME         ""
-#define FORMAT_TAG          "$pdf$"
-#define FORMAT_TAG_LEN      (sizeof(FORMAT_TAG)-1)
-#define FORMAT_TAG_OLD      "$pdf$Standard*"
-#define FORMAT_TAG_OLD_LEN  (sizeof(FORMAT_TAG_OLD)-1)
-#define ALGORITHM_NAME      "MD5 SHA2 RC4/AES 32/" ARCH_BITS_STR
-#define BENCHMARK_COMMENT   ""
-#define BENCHMARK_LENGTH    0x507
-#define PLAINTEXT_LENGTH    32
-#define BINARY_SIZE         0
-#define SALT_SIZE           sizeof(struct custom_salt)
-#define BINARY_ALIGN        1
-#define SALT_ALIGN          sizeof(int)
-#define MIN_KEYS_PER_CRYPT  1
+#define ALGORITHM_NAME      ALGORITHM_BASE " 32/" ARCH_BITS_STR
 #define MAX_KEYS_PER_CRYPT  4
 
 #ifndef OMP_SCALE
@@ -58,326 +36,22 @@ john_register_one(&fmt_pdf);
 #endif
 
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
-static int *cracked;
-static int any_cracked;
-static size_t cracked_size;
-
-static struct custom_salt {
-	int V;
-	int R;
-	int P;
-	char encrypt_metadata;
-	unsigned char u[127];
-	unsigned char o[127];
-	unsigned char ue[32];
-	unsigned char oe[32];
-	unsigned char id[128];
-	int length;
-	int length_id;
-	int length_u;
-	int length_o;
-	int length_ue;
-	int length_oe;
-} *crypt_out;
-
-#define MAX_KEY_SIZE        256
-#define MAX_U_SIZE          sizeof(crypt_out->u)
-#define MAX_O_SIZE          sizeof(crypt_out->o)
-
-static struct fmt_tests pdf_tests[] = {
-	{"$pdf$4*4*128*-1028*1*16*e03460febe17a048b0adc7f7631bcc56*32*3456205208ad52066d5604018d498a6400000000000000000000000000000000*32*6d598152b22f8fa8085b19a866dce1317f645788a065a74831588a739a579ac4", "openwall"},
-	{"$pdf$2*3*128*-4*1*16*34b1b6e593787af681a9b63fa8bf563b*32*289ece9b5ce451a5d7064693dab3badf101112131415161718191a1b1c1d1e1f*32*badad1e86442699427116d3e5d5271bc80a27814fc5e80f815efeef839354c5f", "test"},
-	{"$pdf$4*4*128*-1028*1*16*c015cff8dbf99345ac91c84a45667784*32*0231a4c9cae29b53892874e168cfae9600000000000000000000000000000000*32*137ad7063db5114a66ce1900d47e5cab9c5d7053487d92ac978f54db86eca393", "testpassword"},
-	{"$pdf$5*6*256*-1028*1*16*05e5abeb21ad2e47adac1c2b2c7b7a31*127*51d3a6a09a675503383e5bc0b53da77ec5d5ea1d1998fb94e00a02a1c2e49313c177905272a4e8e68b382254ec8ed74800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000*127*dc38f01ef129aae2fca847396465ed518f9c7cf4f2c8cb4399a849d0fe9110227739ab88ddc9a6cf388ae11941270af500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000*32*b8e137baf316e0789ffa73f888d26495c14d31f2cfff3799e339e2fa078649f5*32*835a9e07461992791914c3d62d37493e07d140937529ab43e26ac2a657152c3c", "testpassword"},
-	{"$pdf$5*5*256*-1028*1*16*762896ef582ca042a15f380c63ab9f2c*127*8713e2afdb65df1d3801f77a4c4da4905c49495e7103afc2deb06d9fba7949a565143288823871270d9d882075a75da600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000*127*15d0b992974ff80529e4b616b8c4c79d787705b6c8a9e0f85446498ae2432e0027d8406b57f78b60b11341a0757d7c4a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000*32*a7a0f3891b469ba7261ce04752dad9c6de0db9c4155c4180e721938a7d9666c7*32*2fa9a0c52badebae2c19dfa7b0005a9cfc909b92babbe7db66a794e96a9f91e3", "openwall"},
-	/* following are old-style hashes */
-	{"$pdf$Standard*badad1e86442699427116d3e5d5271bc80a27814fc5e80f815efeef839354c5f*289ece9b5ce451a5d7064693dab3badf101112131415161718191a1b1c1d1e1f*16*34b1b6e593787af681a9b63fa8bf563b*1*1*0*1*4*128*-4*3*2", "test"},
-	{"$pdf$Standard*9a1156c38ab8177598d1608df7d7e340ae639679bd66bc4cda9bc9a4eedeb170*1f300cd939dd5cf0920c787f12d16be22205e55a5bec5c9c6d563ab4fd0770d7*16*c015cff8dbf99345ac91c84a45667784*1*1*0*1*6*40*-4*2*1", "testpassword"},
-	{"$pdf$Standard*7303809eaf677bdb5ca64b9d8cb0ccdd47d09a7b28ad5aa522c62685c6d9e499*bf38d7a59daaf38365a338e1fc07976102f1dfd6bdb52072032f57920109b43a*16*c56bbc4145d25b468a873618cd71c2d3*1*1*0*1*6*40*-4*2*1", "test"},
-	{"$pdf$Standard*137ad7063db5114a66ce1900d47e5cab9c5d7053487d92ac978f54db86eca393*0231a4c9cae29b53892874e168cfae9600000000000000000000000000000000*16*c015cff8dbf99345ac91c84a45667784*1*1*0*1*6*128*-1028*3*2", "testpassword"},
-	{"$pdf$Standard*d83a8ab680f144dfb2ff2334c206a6060779e007701ab881767f961aecda7984*a5ed4de7e078cb75dfdcd63e8da7a25800000000000000000000000000000000*16*06a7f710cf8dfafbd394540d40984ae2*1*1*0*1*4*128*-1028*3*2", "July2099"},
-	{"$pdf$Standard*6a80a547b8b8b7636fcc5b322f1c63ce4b670c9b01f2aace09e48d85e1f19f83*e64eb62fc46be66e33571d50a29b464100000000000000000000000000000000*16*14a8c53ffa4a79b3ed9421ef15618420*1*1*0*1*4*128*-1028*3*2", "38r285a9"},
-	{"$pdf$Standard*2446dd5ed2e18b3ce1ac9b56733226018e3f5c2639051eb1c9b2b215b30bc820*fa3af175d761963c8449ee7015b7770800000000000000000000000000000000*16*12a4da1abe6b7a1ceb84610bad87236d*1*1*0*1*4*128*-1028*3*2", "WHATwhatWHERE?"},
-	{"$pdf$Standard*e600ecc20288ad8b0d64a929c6a83ee2517679aa0218beceea8b7986726a8cdb*38aca54678d67c003a8193381b0fa1cc101112131415161718191a1b1c1d1e1f*16*1521fbe61419fcad51878cc5d478d5ff*1*1*0*1*4*128*-3904*3*2", ""},
-	/* CMIYC 2013 "pro" hashes */
-	{"$pdf$4*4*128*-4*1*16*f7bc2744e1652cf61ca83cac8fccb535*32*f55cc5032f04b985c5aeacde5ec4270f0122456a91bae5134273a6db134c87c4*32*785d891cdcb5efa59893c78f37e7b75acef8924951039b4fa13f62d92bb3b660", "L4sV3g4z"},
-	{"$pdf$4*4*128*-4*1*16*ec8ea2af2977db1faa4a955904dc956f*32*fc413edb049720b1f8eac87a358faa740122456a91bae5134273a6db134c87c4*32*1ba7aed2f19c77ac6b5061230b62e80b48fc42918f92aef689ceb07d26204991", "ZZt0pr0x"},
-	{"$pdf$4*4*128*-4*1*16*56761d6da774d8d47387dccf1a84428c*32*640782cab5b7c8f6cf5eab82c38016540122456a91bae5134273a6db134c87c4*32*b5720d5f3d9675a280c6bb8050cbb169e039b578b2de4a42a40dc14765e064cf", "24Le`m0ns"},
-	/* This hash exposed a problem with our length_id check */
-	{"$pdf$1*2*40*-4*1*36*65623237393831382d636439372d343130332d613835372d343164303037316639386134*32*c7230519f7db63ab1676fa30686428f0f997932bf831f1c1dcfa48cfb3b7fe99*32*161cd2f7c95283ca9db930b36aad3571ee6f5fb5632f30dc790e19c5069c86b8", "vision"},
-	/* This hash has unsigned permission value, and an id length of 0 */
-	{"$pdf$1*2*40*4294967239*1*0**32*585e4cc4113bbd8ff4012dce92dd7df1e1216fb630b29cf5aeea10a820066c26*32*b1db56a883cab5a22dd5fc390618a0f8e16cab8af14e67ccba5f90837aac898b", "123456"},
-	{NULL}
-};
 
 static void init(struct fmt_main *self)
 {
 	omp_autotune(self, OMP_SCALE);
 
 	saved_key = mem_calloc(sizeof(*saved_key), self->params.max_keys_per_crypt);
-	any_cracked = 0;
-	cracked_size = sizeof(*cracked) * self->params.max_keys_per_crypt;
-	cracked = mem_calloc(sizeof(*cracked), self->params.max_keys_per_crypt);
+	any_pdf_cracked = 0;
+	pdf_cracked_size = sizeof(*pdf_cracked) * self->params.max_keys_per_crypt;
+	pdf_cracked = mem_calloc(sizeof(*pdf_cracked), self->params.max_keys_per_crypt);
 }
 
 static void done(void)
 {
-	MEM_FREE(cracked);
+	MEM_FREE(pdf_cracked);
 	MEM_FREE(saved_key);
 }
-
-static int valid(char *ciphertext, struct fmt_main *self)
-{
-	char *ctcopy, *keeptr;
-	char *p;
-	int res;
-
-	if (strncmp(ciphertext,  FORMAT_TAG, FORMAT_TAG_LEN))
-		return 0;
-
-	ctcopy = xstrdup(ciphertext);
-	keeptr = ctcopy;
-	ctcopy += FORMAT_TAG_LEN;
-	if ((p = strtokm(ctcopy, "*")) == NULL)	/* V */
-		goto err;
-	if (!isdec(p)) goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* R */
-		goto err;
-	if (!isdec(p)) goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* length */
-		goto err;
-	if (!isdec(p)) goto err;
-	res = atoi(p);
-	if (res > MAX_KEY_SIZE)
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* P */
-		goto err;
-	/* Somehow this can be signed or unsigned int; -2147483648 .. 4294967295 */
-	if (!isdec_negok(p) && !isdecu(p)) goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* encrypt_metadata */
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* length_id */
-		goto err;
-	if (!isdec(p)) goto err;
-	res = atoi(p);
-	if (res > 128)
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* id */
-		goto err;
-	if (strlen(p) != res * 2)
-		goto err;
-	/* id length can be 0 */
-	if (*p && !ishexlc(p))
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* length_u */
-		goto err;
-	if (!isdec(p)) goto err;
-	res = atoi(p);
-	if (res > MAX_U_SIZE)
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* u */
-		goto err;
-	if (strlen(p) != res * 2)
-		goto err;
-	if (!ishexlc(p))
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* length_o */
-		goto err;
-	if (!isdec(p)) goto err;
-	res = atoi(p);
-	if (res > MAX_O_SIZE)
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* o */
-		goto err;
-	if (strlen(p) != res * 2)
-		goto err;
-	if (!ishexlc(p))
-		goto err;
-	MEM_FREE(keeptr);
-	return 1;
-
-err:
-	MEM_FREE(keeptr);
-	return 0;
-}
-
-static int old_valid(char *ciphertext, struct fmt_main *self)
-{
-	char *ctcopy, *ptr, *keeptr;
-	int res;
-
-	if (strncmp(ciphertext, FORMAT_TAG_OLD, FORMAT_TAG_OLD_LEN))
-		return 0;
-	if (!(ctcopy = xstrdup(ciphertext)))
-		return 0;
-	keeptr = ctcopy;
-	ctcopy += FORMAT_TAG_OLD_LEN;
-	if (!(ptr = strtokm(ctcopy, "*"))) /* o_string */
-		goto error;
-	if (!ishexlc(ptr))
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* u_string */
-		goto error;
-	if (!ishexlc(ptr))
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* fileIDLen */
-		goto error;
-	if (strncmp(ptr, "16", 2))
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* fileID */
-		goto error;
-	if (!ishexlc(ptr))
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* encryptMetaData */
-		goto error;
-	res = atoi(ptr);
-	if (res != 0 && res != 1)
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* work_with_user */
-		goto error;
-	res = atoi(ptr);
-	if (res != 0 && res != 1)
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* have_userpassword */
-		goto error;
-	res = atoi(ptr);
-	if (res != 0 && res != 1)
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* version_major */
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* version_minor */
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* length */
-		goto error;
-	res = atoi(ptr);
-	if (res < 0 || res > 256)
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* permissions */
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* revision */
-		goto error;
-	if (!(ptr = strtokm(NULL, "*"))) /* version */
-		goto error;
-	MEM_FREE(keeptr);
-	return 1;
-error:
-	MEM_FREE(keeptr);
-	return 0;
-}
-
-char* convert_old_to_new(char ciphertext[])
-{
-	char *ctcopy = xstrdup(ciphertext);
-	char *keeptr = ctcopy;
-	char *out = mem_alloc_tiny(strlen(ctcopy), MEM_ALIGN_NONE);
-	const char *fields[14];
-	char *p;
-	int c = 0;
-	p = strtokm(ctcopy, "*");
-	for (c = 0; c < 14; c++) {
-		fields[c] = p;
-		p = strtokm(NULL, "*");
-	}
-	strcpy(out,FORMAT_TAG);
-	strcat(out,fields[13]);
-	strcat(out,"*");
-	strcat(out,fields[12]);
-	strcat(out,"*");
-	strcat(out,fields[10]);
-	strcat(out,"*");
-	strcat(out,fields[11]);
-	strcat(out,"*");
-	strcat(out,fields[5]);
-	strcat(out,"*");
-	strcat(out,fields[3]);
-	strcat(out,"*");
-	strcat(out,fields[4]);
-	strcat(out,"*32*");
-	strcat(out,fields[2]);
-	strcat(out,"*32*");
-	strcat(out,fields[1]);
-	MEM_FREE(keeptr);
-	return out;
-}
-
-static char *prepare(char *split_fields[10], struct fmt_main *self)
-{
-	// Convert old format to new one
-	if (!strncmp(split_fields[1], FORMAT_TAG_OLD, FORMAT_TAG_OLD_LEN) &&
-	    old_valid(split_fields[1], self))
-		return convert_old_to_new(split_fields[1]);
-
-	return split_fields[1];
-}
-
-static void *get_salt(char *ciphertext)
-{
-	char *ctcopy = xstrdup(ciphertext);
-	char *keeptr = ctcopy;
-	int i;
-	char *p;
-	static struct custom_salt cs;
-	memset(&cs, 0, sizeof(cs));
-	ctcopy += FORMAT_TAG_LEN;	/* skip over "$pdf$" marker */
-	p = strtokm(ctcopy, "*");
-	cs.V = atoi(p);
-	p = strtokm(NULL, "*");
-	cs.R = atoi(p);
-	p = strtokm(NULL, "*");
-	cs.length = atoi(p);
-	p = strtokm(NULL, "*");
-	cs.P = (int)strtoll(p, (char **)NULL, 10);
-	p = strtokm(NULL, "*");
-	cs.encrypt_metadata = atoi(p);
-	p = strtokm(NULL, "*");
-	cs.length_id = atoi(p);
-	p = strtokm(NULL, "*");
-	for (i = 0; i < cs.length_id; i++)
-		cs.id[i] =
-		    atoi16[ARCH_INDEX(p[i * 2])] * 16 +
-		    atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	p = strtokm(NULL, "*");
-	cs.length_u = atoi(p);
-	p = strtokm(NULL, "*");
-	for (i = 0; i < cs.length_u; i++)
-		cs.u[i] =
-		    atoi16[ARCH_INDEX(p[i * 2])] * 16 +
-		    atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	p = strtokm(NULL, "*");
-	cs.length_o = atoi(p);
-	p = strtokm(NULL, "*");
-	for (i = 0; i < cs.length_o; i++)
-		cs.o[i] =
-		    atoi16[ARCH_INDEX(p[i * 2])] * 16 +
-		    atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	MEM_FREE(keeptr);
-	return (void *)&cs;
-}
-
-static void set_salt(void *salt)
-{
-	crypt_out = (struct custom_salt *)salt;
-}
-
-static void pdf_set_key(char *key, int index)
-{
-	strnzcpy(saved_key[index], key, sizeof(*saved_key));
-}
-
-static char *get_key(int index)
-{
-	return saved_key[index];
-}
-
-
-static const unsigned char padding[32] =
-{
-        0x28, 0xbf, 0x4e, 0x5e, 0x4e, 0x75, 0x8a, 0x41,
-        0x64, 0x00, 0x4e, 0x56, 0xff, 0xfa, 0x01, 0x08,
-        0x2e, 0x2e, 0x00, 0xb6, 0xd0, 0x68, 0x3e, 0x80,
-        0x2f, 0x0c, 0xa9, 0xfe, 0x64, 0x53, 0x69, 0x7a
-};
-
 
 /* Compute an encryption key (PDF 1.7 algorithm 3.2) */
 static void
@@ -388,23 +62,20 @@ pdf_compute_encryption_key(unsigned char *password, int pwlen, unsigned char *ke
         int n;
         MD5_CTX md5;
 
-        n = crypt_out->length / 8;
+        n = pdf_salt->key_length / 8;
 
-        /* Step 1 - copy and pad password string */
+        /* Step 1-2 - init md5 and hash padded password  */
         if (pwlen > 32)
                 pwlen = 32;
-        memcpy(buf, password, pwlen);
-        memcpy(buf + pwlen, padding, 32 - pwlen);
-
-        /* Step 2 - init md5 and pass value of step 1 */
         MD5_Init(&md5);
-        MD5_Update(&md5, buf, 32);
+        MD5_Update(&md5, password, pwlen);
+        MD5_Update(&md5, pdf_padding, 32 - pwlen);
 
         /* Step 3 - pass O value */
-        MD5_Update(&md5, crypt_out->o, 32);
+        MD5_Update(&md5, pdf_salt->o, 32);
 
         /* Step 4 - pass P value as unsigned int, low-order byte first */
-        p = (unsigned int) crypt_out->P;
+        p = (unsigned int) pdf_salt->P;
         buf[0] = (p) & 0xFF;
         buf[1] = (p >> 8) & 0xFF;
         buf[2] = (p >> 16) & 0xFF;
@@ -412,12 +83,12 @@ pdf_compute_encryption_key(unsigned char *password, int pwlen, unsigned char *ke
         MD5_Update(&md5, buf, 4);
 
         /* Step 5 - pass first element of ID array */
-        MD5_Update(&md5, crypt_out->id, crypt_out->length_id);
+        MD5_Update(&md5, pdf_salt->id, pdf_salt->id_len);
 
         /* Step 6 (revision 4 or greater) - if metadata is not encrypted pass 0xFFFFFFFF */
-        if (crypt_out->R >= 4)
+        if (pdf_salt->R >= 4)
         {
-                if (!crypt_out->encrypt_metadata)
+                if (!pdf_salt->encrypt_metadata)
                 {
                         buf[0] = 0xFF;
                         buf[1] = 0xFF;
@@ -431,10 +102,11 @@ pdf_compute_encryption_key(unsigned char *password, int pwlen, unsigned char *ke
         MD5_Final(buf, &md5);
 
         /* Step 8 (revision 3 or greater) - do some voodoo 50 times */
-        if (crypt_out->R >= 3)
+        if (pdf_salt->R >= 3)
         {
-		int i;
-	        switch(crypt_out->length) {
+	        int i;
+
+	        switch(pdf_salt->key_length) {
 	        case 128:
 		        md5x50_128(buf);
 		        break;
@@ -454,7 +126,6 @@ pdf_compute_encryption_key(unsigned char *password, int pwlen, unsigned char *ke
 }
 
 /* Compute an encryption key (PDF 1.7 ExtensionLevel 3 algorithm 3.2a) */
-
 static void
 pdf_compute_encryption_key_r5(unsigned char *password, int pwlen, int ownerkey, unsigned char *validationkey)
 {
@@ -471,11 +142,11 @@ pdf_compute_encryption_key_r5(unsigned char *password, int pwlen, int ownerkey, 
         memcpy(buffer, password, pwlen);
         if (ownerkey)
         {
-                memcpy(buffer + pwlen, crypt_out->o + 32, 8);
-                memcpy(buffer + pwlen + 8, crypt_out->u, 48);
+                memcpy(buffer + pwlen, pdf_salt->o + 32, 8);
+                memcpy(buffer + pwlen + 8, pdf_salt->u, 48);
         }
         else
-                memcpy(buffer + pwlen, crypt_out->u + 32, 8);
+                memcpy(buffer + pwlen, pdf_salt->u + 32, 8);
 
         SHA256_Init(&sha256);
         SHA256_Update(&sha256, buffer, pwlen + 8 + (ownerkey ? 48 : 0));
@@ -487,7 +158,6 @@ pdf_compute_encryption_key_r5(unsigned char *password, int pwlen, int ownerkey, 
  * Compute an encryption key (PDF 1.7 ExtensionLevel 8 algorithm 3.2b)
  * http://esec-lab.sogeti.com/post/The-undocumented-password-validation-algorithm-of-Adobe-Reader-X
  */
-
 static void
 pdf_compute_hardened_hash_r6(unsigned char *password, int pwlen, unsigned char salt[8],
         unsigned char *ownerkey, unsigned char hash[32])
@@ -518,7 +188,7 @@ pdf_compute_hardened_hash_r6(unsigned char *password, int pwlen, unsigned char s
                 memcpy(data + pwlen, block, block_size);
                 // ownerkey is always NULL
                 // memcpy(data + pwlen + block_size, ownerkey, ownerkey ? 48 : 0);
-                data_len = pwlen + block_size + (ownerkey ? 48 : 0);
+                data_len = pwlen + block_size /* + (ownerkey ? 48 : 0) */;
                 for (j = 1; j < 64; j++)
                         memcpy(data + j * data_len, data, data_len);
 
@@ -553,29 +223,25 @@ pdf_compute_hardened_hash_r6(unsigned char *password, int pwlen, unsigned char s
                 }
         }
 
-        memset(data, 0, sizeof(data));
+        //memset(data, 0, sizeof(data));
         memcpy(hash, block, 32);
 }
 
-
-
-
 /* Computing the user password (PDF 1.7 algorithm 3.4 and 3.5) */
-
 static void pdf_compute_user_password(unsigned char *password,  unsigned char *output)
 {
 	int pwlen = strlen((char*)password);
 	unsigned char key[MAX_KEY_SIZE / 8];
-	int n = crypt_out->length / 8;
+	int n = pdf_salt->key_length / 8;
 
-	if (crypt_out->R == 2) {
+	if (pdf_salt->R == 2) {
 		RC4_KEY arc4;
 
 		pdf_compute_encryption_key(password, pwlen, key);
 		RC4_set_key(&arc4, n, key);
-		RC4(&arc4, 32, padding, output);
+		RC4(&arc4, 32, pdf_padding, output);
 	}
-	else if (crypt_out->R == 3 || crypt_out->R == 4) {
+	else if (pdf_salt->R == 3 || pdf_salt->R == 4) {
 		unsigned char xor[32];
 		unsigned char digest[16];
 		MD5_CTX md5;
@@ -584,8 +250,8 @@ static void pdf_compute_user_password(unsigned char *password,  unsigned char *o
 
 		pdf_compute_encryption_key(password, pwlen, key);
 		MD5_Init(&md5);
-		MD5_Update(&md5, (char*)padding, 32);
-		MD5_Update(&md5, crypt_out->id, crypt_out->length_id);
+		MD5_Update(&md5, (char*)pdf_padding, 32);
+		MD5_Update(&md5, pdf_salt->id, pdf_salt->id_len);
 		MD5_Final(digest, &md5);
 		RC4_set_key(&arc4, n, key);
 		RC4(&arc4, 16, digest, output);
@@ -597,15 +263,16 @@ static void pdf_compute_user_password(unsigned char *password,  unsigned char *o
 		}
 		//memcpy(output + 16, padding, 16);  /* pointless - we only test 16 bytes of it */
 	}
-	if (crypt_out->R == 5) {
+	if (pdf_salt->R == 5) {
 		pdf_compute_encryption_key_r5(password, pwlen, 0, output);
 	}
 
 	/* SumatraPDF: support crypt version 5 revision 6 */
-	if (crypt_out->R == 6)
-		pdf_compute_hardened_hash_r6(password, pwlen, crypt_out->u + 32,  NULL, output);
+	if (pdf_salt->R == 6)
+		pdf_compute_hardened_hash_r6(password, pwlen, pdf_salt->u + 32,  NULL, output);
 
-	if (!bench_or_test_running && crypt_out->length == 40 && !memcmp(output, crypt_out->u, 16)) {
+	/* RC4-40 has password collisions - might be good to know the key */
+	if (!bench_or_test_running && pdf_salt->key_length == 40 && !memcmp(output, pdf_salt->u, 16)) {
 		char h_key[2 * 5 + 1], *p;
 		int i;
 
@@ -620,14 +287,29 @@ static void pdf_compute_user_password(unsigned char *password,  unsigned char *o
 	}
 }
 
+static void set_key(char *key, int index)
+{
+	strnzcpy(saved_key[index], key, sizeof(*saved_key));
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+static void set_salt(void *salt)
+{
+	pdf_salt = (pdf_salt_type*)salt;
+}
+
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
 	int index = 0;
 
-	if (any_cracked) {
-		memset(cracked, 0, cracked_size);
-		any_cracked = 0;
+	if (any_pdf_cracked) {
+		memset(pdf_cracked, 0, pdf_cracked_size);
+		any_pdf_cracked = 0;
 	}
 
 #ifdef _OPENMP
@@ -636,52 +318,25 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	for (index = 0; index < count; index++) {
 		unsigned char output[32];
 		pdf_compute_user_password((unsigned char*)saved_key[index], output);
-		if (crypt_out->R == 2 || crypt_out->R == 5 || crypt_out->R == 6)
-			if (memcmp(output, crypt_out->u, 32) == 0) {
-				cracked[index] = 1;
+		if (pdf_salt->R == 2 || pdf_salt->R == 5 || pdf_salt->R == 6)
+			if (memcmp(output, pdf_salt->u, 32) == 0) {
+				pdf_cracked[index] = 1;
 #ifdef _OPENMP
 #pragma omp atomic
 #endif
-				any_cracked |= 1;
+				any_pdf_cracked |= 1;
 			}
-		if (crypt_out->R == 3 || crypt_out->R == 4)
-			if (memcmp(output, crypt_out->u, 16) == 0) {
-				cracked[index] = 1;
+		if (pdf_salt->R == 3 || pdf_salt->R == 4)
+			if (memcmp(output, pdf_salt->u, 16) == 0) {
+				pdf_cracked[index] = 1;
 #ifdef _OPENMP
 #pragma omp atomic
 #endif
-				any_cracked |= 1;
+				any_pdf_cracked |= 1;
 			}
 	}
 
 	return count;
-}
-
-static int cmp_all(void *binary, int count)
-{
-	return any_cracked;
-}
-
-static int cmp_one(void *binary, int index)
-{
-	return cracked[index];
-}
-
-static int cmp_exact(char *source, int index)
-{
-	return cracked[index];
-}
-
-/*
- * Report revision as tunable cost, since between revisions 2 and 6,
- * only revisions 3 and 4 seem to have a similar c/s rate.
- */
-static unsigned int pdf_revision(void *salt)
-{
-	struct custom_salt *my_salt;
-
-	my_salt = salt;
-	return (unsigned int) my_salt->R;
 }
 
 struct fmt_main fmt_pdf = {
@@ -702,6 +357,7 @@ struct fmt_main fmt_pdf = {
 		FMT_CASE | FMT_8_BIT | FMT_OMP,
 		{
 			"revision",
+			"key length"
 		},
 		{ FORMAT_TAG, FORMAT_TAG_OLD },
 		pdf_tests
@@ -710,13 +366,14 @@ struct fmt_main fmt_pdf = {
 		init,
 		done,
 		fmt_default_reset,
-		prepare,
-		valid,
+		pdf_prepare,
+		pdf_valid,
 		fmt_default_split,
 		fmt_default_binary,
-		get_salt,
+		pdf_get_salt,
 		{
 			pdf_revision,
+			pdf_keylen
 		},
 		fmt_default_source,
 		{
@@ -725,16 +382,16 @@ struct fmt_main fmt_pdf = {
 		fmt_default_salt_hash,
 		NULL,
 		set_salt,
-		pdf_set_key,
+		set_key,
 		get_key,
 		fmt_default_clear_keys,
 		crypt_all,
 		{
 			fmt_default_get_hash
 		},
-		cmp_all,
-		cmp_one,
-		cmp_exact
+		pdf_cmp_all,
+		pdf_cmp_one,
+		pdf_cmp_exact
 	}
 };
 

--- a/src/pdfcrack_md5.h
+++ b/src/pdfcrack_md5.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2006 Henning Norén
+ * Copyright (c) 2024 magnum
+ * Copyright (c) 2006 Henning Norén
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -17,13 +18,12 @@
  * USA.
  */
 
-#ifndef _MD5_H_
-#define _MD5_H_
+#ifndef __PDFCRACK_MD5_
+#define __PDFCRACK_MD5_
 
 #include <stdint.h>
-
 
 extern void md5x50_40(uint8_t * msg);
 extern void md5x50_128(uint8_t * msg);
 
-#endif /** _MD5_H_ */
+#endif /** __PDFCRACK_MD5_ */

--- a/src/pdfcrack_md5_plug.c
+++ b/src/pdfcrack_md5_plug.c
@@ -1,6 +1,7 @@
 /**
- * Copyright (C) 2006 Henning Norén
- * Copyright (C) 1996-2005 Glyph & Cog, LLC.
+ * Copyright (c) 2024 magnum
+ * Copyright (c) 2006 Henning Norén
+ * Copyright (c) 1996-2005 Glyph & Cog, LLC.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Adds pdf-opencl with device-side mask. Also bugfix in CPU format for rev. 3 documents with RC4-40 as well as added support for rev 2-4 documents with key length other than 40 or 128 bits (spec. allows anything inbetween in multiples of 4).

<s>First</s> Second commit (bugs/workarounds to cryptosafe-opencl) is kind of unrelated but I used that kernel as template so fixed it while at it.
Other separate commits enhances shared RC4 (support for arbitrary length [and unrolled 40-bit] key) and SHA-2 (adds SHA-384) and make corresponding changes to callers (oldoffice-opencl, krb5pa-md5-opencl and krb5tgs-opencl for RC4 and tezos-opencl, pbkdf2-hmac-sha512-opencl for a SHA-512 macro rename).