### PR TITLE
Streebog*crypt formats: Disable for BE builds

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -328,6 +328,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Added support for SM3.  [SamuraiOcto; 2024]
 
+- Added support for Astra Linux crypt variants using GOST R 34.11-94 or GOST R
+  34.11-2012.  [magnum; 2024]
+
 - More optimal bitslice DES S-box expressions for NVIDIA GPUs and AVX-512.
   [Sovyn Y., Solar; 2024]
 

--- a/src/gost12256hash_fmt_plug.c
+++ b/src/gost12256hash_fmt_plug.c
@@ -9,6 +9,8 @@
  * modification, are permitted.
  */
 
+#if ARCH_LITTLE_ENDIAN
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_gost12256hash;
 #elif FMT_REGISTERS_H
@@ -442,3 +444,12 @@ struct fmt_main fmt_gost12256hash = {
 };
 
 #endif /* plugin stanza */
+#else
+#if !defined(FMT_EXTERNS_H) && !defined(FMT_REGISTERS_H)
+#ifdef __GNUC__
+#warning streebog256crypt CPU format requires little-endian, format disabled
+#elif _MSC_VER
+#pragma message(": warning streebog256crypt CPU format requires little-endian, format disabled:")
+#endif
+#endif
+#endif /* ARCH_LITTLE_ENDIAN */

--- a/src/gost12512hash_fmt_plug.c
+++ b/src/gost12512hash_fmt_plug.c
@@ -9,6 +9,8 @@
  * modification, are permitted.
  */
 
+#if ARCH_LITTLE_ENDIAN
+
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_gost12512hash;
 #elif FMT_REGISTERS_H
@@ -442,3 +444,12 @@ struct fmt_main fmt_gost12512hash = {
 };
 
 #endif /* plugin stanza */
+#else
+#if !defined(FMT_EXTERNS_H) && !defined(FMT_REGISTERS_H)
+#ifdef __GNUC__
+#warning streebog512crypt CPU format requires little-endian, format disabled
+#elif _MSC_VER
+#pragma message(": warning streebog512crypt CPU format requires little-endian, format disabled:")
+#endif
+#endif
+#endif /* ARCH_LITTLE_ENDIAN */


### PR DESCRIPTION
The problem is not in these formats but in our shared Streebog code. It has clauses for BE but apparently they don't cut it.

Closes #5535