### PR TITLE
Argon2 format: Custom malloc/free using callbacks

### DIFF
--- a/src/argon2_fmt_plug.c
+++ b/src/argon2_fmt_plug.c
@@ -62,9 +62,9 @@ john_register_one(&fmt_argon2);
 #define SALT_ALIGN              sizeof(uint32_t)
 
 #define MIN_KEYS_PER_CRYPT      1
-#define MAX_KEYS_PER_CRYPT      2
+#define MAX_KEYS_PER_CRYPT      1
 
-#define OMP_SCALE               8 // tuned w/ MKPC for core i7m
+#define OMP_SCALE               1
 
 #ifdef _OPENMP
 #define THREAD_NUMBER omp_get_thread_num()


### PR DESCRIPTION
We never free memory except in format's done(), instead we reuse the allocations per thread, and realloc if needed.

We also got rid of a small malloc/free per call for a temporary buffer, by moving away from argon2_hash() in favor of argon2_ctx().

Closes #5558