### PR TITLE
Keepass KDBX4 and Argon2 support

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -343,6 +343,10 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Add bitlocker2john.py to improve BitLocker hash extraction.  [holly-o; 2024]
 
+- Add KDBX4 support to KeePass formats (and keepass2john).  This means Argon2
+  support as well, and keepass-argon2-opencl is made a separate format.
+  [magnum; 2024]
+
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):
 

--- a/run/opencl/keepass_kernel.cl
+++ b/run/opencl/keepass_kernel.cl
@@ -1,15 +1,16 @@
 /*
- * This software is Copyright (c) 2018-2021 magnum,
+ * This software is Copyright (c) 2018-2024 magnum,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  */
 
-#if MAX_CONT_SIZE >= 0xff00
-#define MAYBE_CONSTANT __global const
+#if MAX_CONTENT_SIZE >= 0xff00
+#define MAYBE_CONSTANT __global const	/* Override setting otherwise decided by opencl_misc.h */
 #endif
 
 #include "opencl_misc.h"
+
 #if gpu_nvidia(DEVICE_INFO)
 /*
  * 'volatile' as a bug workaround for nvidia runtime/driver ver. 435.21 while
@@ -19,10 +20,61 @@
 #define AES_SRC_TYPE volatile const
 #define CHACHA_SRC_TYPE volatile const
 #endif
+
 #include "opencl_aes.h"
-#include "opencl_sha2_ctx.h"
 #include "opencl_chacha.h"
 #include "opencl_twofish.h"
+#include "opencl_sha2_ctx.h"
+#define HMAC_MSG_TYPE	MAYBE_CONSTANT
+#include "opencl_hmac_sha256.h"
+#if KEEPASS_ARGON2_REF // Not present, used for testing
+#include "argon2.h"
+#else
+typedef enum {
+	dummy1 = 0,
+} argon2_type;
+typedef enum {
+	dummy2 = 0,
+} argon2_version;
+#endif
+
+/* This must match argon2-opencl */
+#define ARGON2_SALT_SIZE            64
+
+typedef struct {
+	uint32_t t_cost, m_cost, lanes;
+	uint32_t hash_size;
+	uint32_t salt_length;
+	char salt[ARGON2_SALT_SIZE];
+	argon2_type type;
+	argon2_version version;
+	/* The above must match argon2-opencl salt struct */
+	int kdbx_ver;
+	uint32_t kdf; // 0=AES, 1=Argon2
+	uint32_t cipher; // 0=AES, 1=TwoFish, 2=ChaCha
+	uint32_t key_transf_rounds;
+	uint8_t enc_iv[16];   // KDBX3 and earlier
+	union {
+		uint8_t final_randomseed[32]; // KDBX3 and earlier
+		uint8_t master_seed[32];      // KDBX4 and later
+	};
+	uint8_t transf_randomseed[32];
+	uint8_t expected_bytes[32];    // KDBX3
+	int have_keyfile;
+	uint8_t keyfile[32];
+	union {
+		uint8_t contents_hash[32]; // KDBX3 and earlier
+		uint8_t header_hmac[32];   // KDBX4 and later
+	};
+	union {
+		int content_size; // KDBX3 and earlier
+		int header_size; // KDBX4 and later
+	};
+	union {
+		uint8_t contents[MAX_CONTENT_SIZE]; // KDBX3 and earlier
+		uint8_t header[MAX_CONTENT_SIZE];   // KDBX4 and later
+	};
+} keepass_salt_t;
 
 typedef struct {
 	uint32_t length;
@@ -34,47 +86,52 @@ typedef struct {
 } keepass_result;
 
 typedef struct {
-	uint64_t offset;
-	int version;
-	int isinline;
-	int keyfilesize;
-	int have_keyfile;
-	int contentsize;
-	uint32_t key_transf_rounds;
-	int algorithm;
-	uchar final_randomseed[32];
-	uchar enc_iv[16];
-	uchar keyfile[32];
-	uchar contents_hash[32];
-	uchar transf_randomseed[32];
-	uchar expected_bytes[32];
-	uchar contents[MAX_CONT_SIZE];
-} keepass_salt_t;
-
-typedef struct {
+	uint8_t hash[32];
+#if KEEPASS_AES
 	uint iterations;
-	uchar hash[32];
 	AES_KEY akey;
+#endif
 } keepass_state;
+
+inline void calc_hmac_base_key(const void *master_seed, const void *final_key, void *result)
+{
+	const uint8_t one_le[1] = "\x01";
+	SHA512_CTX ctx;
+
+	SHA512_Init(&ctx);
+	SHA512_Update(&ctx, master_seed, 32);
+	SHA512_Update(&ctx, final_key, 32);
+	SHA512_Update(&ctx, one_le, 1);
+	SHA512_Final(result, &ctx);
+}
+
+inline void calc_hmac_key(const void *block_index, const void *base_key, void *result)
+{
+	SHA512_CTX ctx;
+
+	SHA512_Init(&ctx);
+	SHA512_Update(&ctx, block_index, sizeof(uint64_t));
+	SHA512_Update(&ctx, base_key, 64);
+	SHA512_Final(result, &ctx);
+}
 
 __kernel void keepass_init(__global const keepass_password *masterkey,
                            MAYBE_CONSTANT keepass_salt_t *salt,
                            __global keepass_state *state)
 {
 	uint gid = get_global_id(0);
-	uchar hash[32];
 	uint pwlen = masterkey[gid].length;
-	uchar pbuf[PLAINTEXT_LENGTH];
-	SHA256_CTX ctx;
-	AES_KEY akey;
 
 	// We can afford some safety because only the loop kernel is significant
 	if (pwlen > PLAINTEXT_LENGTH)
 		pwlen = 0;
 
+	uint8_t pbuf[PLAINTEXT_LENGTH];
 	memcpy_macro(pbuf, masterkey[gid].v, pwlen);
 
 	// First, hash the masterkey
+	SHA256_CTX ctx;
+	uint8_t hash[32];
 	SHA256_Init(&ctx);
 	SHA256_Update(&ctx, pbuf, pwlen);
 	SHA256_Final(hash, &ctx);
@@ -85,40 +142,76 @@ __kernel void keepass_init(__global const keepass_password *masterkey,
 		SHA256_Update(&ctx, hash, 32);
 		SHA256_Update(&ctx, pbuf, 32);
 		SHA256_Final(hash, &ctx);
-	} else if (salt->version == 2) {
+	} else if (salt->kdbx_ver > 1) {
 		SHA256_Init(&ctx);
 		SHA256_Update(&ctx, hash, 32);
 		SHA256_Final(hash, &ctx);
 	}
 
-	// Next, encrypt the hash using the random seed as key
-	memcpy_macro(pbuf, salt->transf_randomseed, 32);
-	AES_set_encrypt_key(pbuf, 256, &akey);
+#if KEEPASS_AES
+	// Next, encrypt the hash using the random seed as key (only for AES-KDF)
+	if (salt->kdf == 0) {
+		memcpy_macro(pbuf, salt->transf_randomseed, 32);
+		AES_KEY akey;
+		AES_set_encrypt_key(pbuf, 256, &akey);
 
-	// Save state for loop kernel.
-	state[gid].iterations = salt->key_transf_rounds;
+		// Save state for loop kernel.
+		state[gid].iterations = salt->key_transf_rounds;
+		memcpy_pg(&state[gid].akey, &akey, sizeof(AES_KEY));
+	}
+#endif
+
 	memcpy_macro(state[gid].hash, hash, 32);
-	memcpy_pg(&state[gid].akey, &akey, sizeof(AES_KEY));
 }
 
+#if KEEPASS_AES
 // Here's the heavy part. NOTHING else is significant for performance!
-__kernel void keepass_loop(__global keepass_state *state)
+__kernel void keepass_loop_aes(__global keepass_state *state)
 {
 	uint gid = get_global_id(0);
-	AES_KEY akey;
 	uint i;
-	uchar hash[32];
 
 	i = MIN(state[gid].iterations, HASH_LOOPS);
 	state[gid].iterations -= i;
-	memcpy_macro(hash, state[gid].hash, 32);
+
+	AES_KEY akey;
 	memcpy_gp(&akey, &state[gid].akey, sizeof(AES_KEY));
+	uint8_t hash[32];
+	memcpy_macro(hash, state[gid].hash, 32);
 
 	while (i--)
 		AES_ecb_encrypt(hash, hash, 32, &akey);
 
 	memcpy_macro(state[gid].hash, hash, 32);
 }
+#endif
+
+#if KEEPASS_ARGON2_REF
+__kernel void keepass_argon2(__global keepass_state *state,
+                             MAYBE_CONSTANT keepass_salt_t *salt,
+                             __global uint8_t *argon2_memory_pool,
+                             __constant int *autotune)
+{
+	uint gid = get_global_id(0);
+	uint8_t transf_randomseed[32];
+	uint8_t hash[32];
+	int t_cost = *autotune ? 1 : salt->t_cost;
+
+	memcpy_macro(transf_randomseed, salt->transf_randomseed, 32);
+	memcpy_macro(hash, state[gid].hash, 32);
+
+	argon2_hash(t_cost, salt->m_cost,
+	            salt->lanes, hash, 32, // key
+	            transf_randomseed, 32, // salt
+	            hash, 32, // hash (out)
+	            NULL, 0, // encoded
+	            salt->type,
+	            salt->version,
+	            argon2_memory_pool);
+
+	memcpy_macro(state[gid].hash, hash, 32);
+}
+#endif
 
 __kernel void keepass_final(__global keepass_state *state,
                             MAYBE_CONSTANT keepass_salt_t *salt,
@@ -127,101 +220,124 @@ __kernel void keepass_final(__global keepass_state *state,
 	uint gid = get_global_id(0);
 	SHA256_CTX ctx;
 	AES_KEY akey;
-	uchar pbuf[32];
-	uchar hash[32];
-	uchar iv[16];
+	uint8_t pbuf[32];
+	uint8_t hash[32];
+	uint8_t iv[16];
 
 	memcpy_macro(hash, state[gid].hash, 32);
 
-	// Finally, hash it again...
-	SHA256_Init(&ctx);
-	SHA256_Update(&ctx, hash, 32);
-	SHA256_Final(hash, &ctx);
-
-	// ...and hash the result together with the random seed
-	SHA256_Init(&ctx);
-	if (salt->version == 1) {
-		memcpy_macro(pbuf, salt->final_randomseed, 16);
-		SHA256_Update(&ctx, pbuf, 16);
-	} else {
-		memcpy_macro(pbuf, salt->final_randomseed, 32);
-		SHA256_Update(&ctx, pbuf, 32);
-	}
-	SHA256_Update(&ctx, hash, 32);
-	SHA256_Final(hash, &ctx);
-
-	memcpy_macro(iv, salt->enc_iv, 16);
-
-	if (salt->version == 1) {
-		uchar content[256];
-		int bufsize = (int)sizeof(content);
-		MAYBE_CONSTANT uchar *saltp = salt->contents;
-		int contentsize = (uint)salt->contentsize;
-		int datasize;
-
-		if (contentsize < 16 || contentsize > MAX_CONT_SIZE)
-			contentsize = 16;
-
+#if KEEPASS_AES
+	// Finally, hash it again (only for AES-KDF)...
+	if (salt->kdf == 0) {
 		SHA256_Init(&ctx);
-
-		if (salt->algorithm == 0) {
-			uint pad_byte;
-
-			AES_set_decrypt_key(hash, 256, &akey);
-			while (contentsize > bufsize) {
-				memcpy_macro(content, saltp, bufsize);
-				AES_cbc_decrypt(content, content, bufsize, &akey, iv);
-				SHA256_Update(&ctx, content, bufsize);
-				contentsize -= bufsize;
-				saltp += bufsize;
-			}
-			memcpy_macro(content, saltp, contentsize);
-			AES_cbc_decrypt(content, content, contentsize, &akey, iv);
-			pad_byte = content[contentsize - 1];
-			datasize = contentsize - pad_byte;
-			if (pad_byte > 16 || datasize < 0 || datasize > contentsize)
-				datasize = 0;
-			SHA256_Update(&ctx, content, datasize);
-		} else /* if (salt->algorithm == 1) */ {
-			Twofish_key tkey;
-
-			Twofish_prepare_key(hash, 32, &tkey);
-			while (contentsize > bufsize) {
-				memcpy_macro(content, saltp, bufsize);
-				Twofish_Decrypt(&tkey, content, content, bufsize, iv, 0);
-				SHA256_Update(&ctx, content, bufsize);
-				contentsize -= bufsize;
-				saltp += bufsize;
-			}
-			memcpy_macro(content, saltp, contentsize);
-			datasize = Twofish_Decrypt(&tkey, content, content,
-			                           contentsize, iv, 1);
-			if (datasize < 0 || datasize > contentsize)
-				datasize = 0;
-			SHA256_Update(&ctx, content, datasize);
-		}
-
+		SHA256_Update(&ctx, hash, 32);
 		SHA256_Final(hash, &ctx);
-		result[gid].cracked = !memcmp_pmc(hash, salt->contents_hash, 32);
 	}
-	else if (salt->version == 2) {
-#if gpu_nvidia(DEVICE_INFO)
-		volatile /* See comment near top */
 #endif
-			uchar content[32];
 
-		memcpy_macro(content, salt->contents, 32);
+	if (salt->kdbx_ver == 4) { // KDBX4
+		uint8_t seed[32];
+		memcpy_macro(seed, salt->master_seed, 32);
 
-		if (salt->algorithm == 0) {
-			AES_set_decrypt_key(hash, 256, &akey);
-			AES_cbc_decrypt(content, hash, 32, &akey, iv);
-		} else /* if (salt->algorithm == 2) */ {
-			chacha_ctx ckey;
+		uint8_t hmac_base_key[64];
+		calc_hmac_base_key(seed, hash, hmac_base_key);
 
-			chacha_keysetup(&ckey, hash, 256);
-			chacha_ivsetup(&ckey, iv, 0, 12);
-			chacha_decrypt_bytes(&ckey, content, hash, 32);
-		}
-		result[gid].cracked = !memcmp_pmc(hash, salt->expected_bytes, 32);
+		uint8_t hmac_key[64];
+		const uint8_t uint64_max[8] = "\xff\xff\xff\xff\xff\xff\xff\xff";
+		calc_hmac_key(&uint64_max, hmac_base_key, hmac_key);
+
+		uint8_t calc_hmac[32];
+		hmac_sha256(hmac_key, 64, salt->header, salt->header_size, calc_hmac, 32);
+
+		result[gid].cracked = !memcmp_pmc(calc_hmac, salt->header_hmac, 32);
 	}
+#if KEEPASS_AES
+	else {
+		// ...hash the result together with the random seed
+		SHA256_Init(&ctx);
+		if (salt->kdbx_ver == 1) {
+			memcpy_macro(pbuf, salt->final_randomseed, 16);
+			SHA256_Update(&ctx, pbuf, 16);
+		} else {
+			memcpy_macro(pbuf, salt->final_randomseed, 32);
+			SHA256_Update(&ctx, pbuf, 32);
+		}
+		SHA256_Update(&ctx, hash, 32);
+		SHA256_Final(hash, &ctx);
+
+		memcpy_macro(iv, salt->enc_iv, 16);
+
+		if (salt->kdbx_ver == 1) { // <= KDBX2
+			uint8_t content[256];
+			int bufsize = (int)sizeof(content);
+			MAYBE_CONSTANT uint8_t *saltp = salt->contents;
+			int content_size = (uint)salt->content_size;
+			int data_size;
+
+			if (content_size < 16 || content_size > MAX_CONTENT_SIZE)
+				content_size = 16;
+
+			SHA256_Init(&ctx);
+
+			if (salt->cipher == 0) {
+				uint pad_byte;
+
+				AES_set_decrypt_key(hash, 256, &akey);
+				while (content_size > bufsize) {
+					memcpy_macro(content, saltp, bufsize);
+					AES_cbc_decrypt(content, content, bufsize, &akey, iv);
+					SHA256_Update(&ctx, content, bufsize);
+					content_size -= bufsize;
+					saltp += bufsize;
+				}
+				memcpy_macro(content, saltp, content_size);
+				AES_cbc_decrypt(content, content, content_size, &akey, iv);
+				pad_byte = content[content_size - 1];
+				data_size = content_size - pad_byte;
+				if (pad_byte > 16 || data_size < 0 || data_size > content_size)
+					data_size = 0;
+				SHA256_Update(&ctx, content, data_size);
+			} else /* if (salt->cipher == 1) */ {
+				Twofish_key tkey;
+
+				Twofish_prepare_key(hash, 32, &tkey);
+				while (content_size > bufsize) {
+					memcpy_macro(content, saltp, bufsize);
+					Twofish_Decrypt(&tkey, content, content, bufsize, iv, 0);
+					SHA256_Update(&ctx, content, bufsize);
+					content_size -= bufsize;
+					saltp += bufsize;
+				}
+				memcpy_macro(content, saltp, content_size);
+				data_size = Twofish_Decrypt(&tkey, content, content, content_size, iv, 1);
+				if (data_size < 0 || data_size > content_size)
+					data_size = 0;
+				SHA256_Update(&ctx, content, data_size);
+			}
+
+			SHA256_Final(hash, &ctx);
+			result[gid].cracked = !memcmp_pmc(hash, salt->contents_hash, 32);
+		}
+		else if (salt->kdbx_ver == 2) { // KDBX3
+#if gpu_nvidia(DEVICE_INFO)
+			volatile /* See comment near top */
+#endif
+				uint8_t content[32];
+
+			memcpy_macro(content, salt->contents, 32);
+
+			if (salt->cipher == 0) {
+				AES_set_decrypt_key(hash, 256, &akey);
+				AES_cbc_decrypt(content, hash, 32, &akey, iv);
+			} else /* if (salt->cipher == 2) */ {
+				chacha_ctx ckey;
+
+				chacha_keysetup(&ckey, hash, 256);
+				chacha_ivsetup(&ckey, iv, 0, 12);
+				chacha_decrypt_bytes(&ckey, content, hash, 32);
+			}
+			result[gid].cracked = !memcmp_pmc(hash, salt->expected_bytes, 32);
+		}
+	}
+#endif
 }

--- a/src/keepass_common.h
+++ b/src/keepass_common.h
@@ -1,61 +1,455 @@
 /*
  * This software is
- * Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
- * Copyright (c) 2014 m3g9tr0n (Spiros Fraganastasis),
+ * Copyright (c) 2017-2024 magnum
  * Copyright (c) 2016 Fist0urs <eddy.maaalou at gmail.com>, and
- * Copyright (c) 2017 magnum
+ * Copyright (c) 2014 m3g9tr0n (Spiros Fraganastasis),
+ * Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
  */
+#include "john.h"
+#include "argon2.h"
 
-#define FORMAT_TAG           "$keepass$*"
-#define FORMAT_TAG_LEN       (sizeof(FORMAT_TAG)-1)
-#define BENCHMARK_COMMENT	""
-#define BENCHMARK_LENGTH	0x107
-#define PLAINTEXT_LENGTH	124
-#define BINARY_SIZE		0
-#define BINARY_ALIGN		MEM_ALIGN_NONE
-#define SALT_SIZE		sizeof(keepass_salt_t)
+#define KEEPASS_FORMAT_TAG          "$keepass$*"
+#define KEEPASS_FORMAT_TAG_LEN      (sizeof(KEEPASS_FORMAT_TAG)-1)
+#define KEEPASS_BENCHMARK_COMMENT   ""
+#define KEEPASS_BENCHMARK_LENGTH    0x107
+#define KEEPASS_PLAINTEXT_LENGTH    124
+#define KEEPASS_BINARY_SIZE         0
+#define KEEPASS_BINARY_ALIGN        MEM_ALIGN_NONE
+#define KEEPASS_SALT_SIZE           sizeof(keepass_salt_t)
 #if ARCH_ALLOWS_UNALIGNED
 // Avoid a compiler bug, see #1284
-#define SALT_ALIGN		1
+#define KEEPASS_SALT_ALIGN          1
 #else
-// salt align of 4 was crashing on sparc due to the long long value.
-#define SALT_ALIGN		sizeof(long long)
+#define KEEPASS_SALT_ALIGN          sizeof(uint64_t)
 #endif
-#define MIN_KEYS_PER_CRYPT	1
-#define MAX_KEYS_PER_CRYPT	1
-
-extern struct fmt_tests keepass_tests[];
+#define KEEPASS_MIN_KEYS_PER_CRYPT  1
+#define KEEPASS_MAX_KEYS_PER_CRYPT  1
 
 /* This format should be dyna salt instead! */
-#define MAX_CONT_SIZE 0x1000000
+#define KEEPASS_MAX_CONTENT_SIZE    0x1000000
+
+/* This must match argon2-opencl */
+#define ARGON2_SALT_SIZE            64
 
 typedef struct {
-	long long offset;
-	int version;
-	int isinline;
-	int keyfilesize;
-	int have_keyfile;
-	int contentsize;
+	uint32_t t_cost, m_cost, lanes;
+	uint32_t hash_size;
+	uint32_t salt_length;
+	char salt[ARGON2_SALT_SIZE];
+	argon2_type type;
+	argon2_version version;
+	/* The above must match argon2-opencl salt struct */
+	int kdbx_ver;
+	uint32_t kdf; // 0=AES, 1=Argon2
+	uint32_t cipher; // 0=AES, 1=TwoFish, 2=ChaCha
 	uint32_t key_transf_rounds;
-	int algorithm; // 1 for Twofish
-	unsigned char final_randomseed[32];
-	unsigned char enc_iv[16];
-	unsigned char keyfile[32];
-	unsigned char contents_hash[32];
-	unsigned char transf_randomseed[32];
-	unsigned char expected_bytes[32];
-	unsigned char contents[MAX_CONT_SIZE];
+	uint8_t enc_iv[16];   // KDBX3 and earlier
+	union {
+		uint8_t final_randomseed[32]; // KDBX3 and earlier
+		uint8_t master_seed[32];      // KDBX4 and later
+	};
+	uint8_t transf_randomseed[32];
+	uint8_t expected_bytes[32];    // KDBX3
+	int have_keyfile;
+	uint8_t keyfile[32];
+	union {
+		uint8_t contents_hash[32]; // KDBX3 and earlier
+		uint8_t header_hmac[32];   // KDBX4 and later
+	};
+	union {
+		int content_size; // KDBX3 and earlier
+		int header_size; // KDBX4 and later
+	};
+	union {
+		uint8_t contents[KEEPASS_MAX_CONTENT_SIZE]; // KDBX3 and earlier
+		uint8_t header[KEEPASS_MAX_CONTENT_SIZE];   // KDBX4 and later
+	};
 } keepass_salt_t;
 
-extern char (*keepass_key)[PLAINTEXT_LENGTH + 1];
+#if !KEEPASS_COMMON_CODE
+static struct fmt_tests keepass_tests[] = {
+#if KEEPASS_AES
+	{"$keepass$*1*50000*124*60eed105dac456cfc37d89d950ca846e*72ffef7c0bc3698b8eca65184774f6cd91a9356d338e5140e47e319a87f5e46a*8725bdfd3580cf054a1564dc724aaffe*8e58cc08af2462ddffe2ee39735ad14b15e8cb96dc05ef70d8e64d475eca7bf5*1*752*71d7e65fb3e20b288da8cd582b5c2bc3b63162eef6894e5e92eea73f711fe86e7a7285d5ac9d5ffd07798b83673b06f34180b7f5f3d05222ebf909c67e6580c646bcb64ad039fcdc6f33178fe475739a562dc78012f6be3104da9af69e0e12c2c9c5cd7134bb99d5278f2738a40155acbe941ff2f88db18daf772c7b5fc1855ff9e93ceb35a1db2c30cabe97a96c58b07c16912b2e095e530cc8c24041e7d4876b842f2e7c6df41d08da8c5c4f2402dd3241c3367b6e6e06cd0fa369934e78a6aab1479756a15264af09e3c8e1037f07a58f70f4bf634737ff58725414db10d7b2f61a7ed69878bc0de8bb99f3795bf9980d87992848cd9b9abe0fa6205a117ab1dd5165cf11ffa10b765e8723251ea0907bbc5f3eef8cf1f08bb89e193842b40c95922f38c44d0c3197033a5c7c926a33687aa71c482c48381baa4a34a46b8a4f78715f42eccbc8df80ee3b43335d92bdeb3bb0667cf6da83a018e4c0cd5803004bf6c300b9bee029246d16bd817ff235fcc22bb8c729929499afbf90bf787e98479db5ff571d3d727059d34c1f14454ff5f0a1d2d025437c2d8db4a7be7b901c067b929a0028fe8bb74fa96cb84831ccd89138329708d12c76bd4f5f371e43d0a2d234e5db2b3d6d5164e773594ab201dc9498078b48d4303dd8a89bf81c76d1424084ebf8d96107cb2623fb1cb67617257a5c7c6e56a8614271256b9dd80c76b6d668de4ebe17574ad617f5b1133f45a6d8621e127fcc99d8e788c535da9f557d91903b4e388108f02e9539a681d42e61f8e2f8b06654d4dec308690902a5c76f55b3d79b7c9a0ce994494bc60eff79ff41debc3f2684f40fc912f09035aae022148238ba6f5cfb92f54a5fb28cbb417ff01f39cc464e95929fba5e19be0251bef59879303063e6392c3a49032af3d03d5c9027868d5d6a187698dd75dfc295d2789a0e6cf391a380cc625b0a49f3084f45558ac273b0bbe62a8614db194983b2e207cef7deb1fa6a0bd39b0215d72bf646b599f187ee0009b7b458bb4930a1aea55222099446a0250a975447ff52", "openwall"},
+	{"$keepass$*2*6000*222*e54497d3d9be3e310a817a13515225a87773ba71557a88673c34db824550be7b*d405c4f7e3c7b2b142fda44c3d55d3afab1c91a6aca7c81c1ff7e61b3f03be85*7eb45af0af777ecb57f0159b9ffa528b*0af7d9facefb20378e8666389de7586ea72e9527dc78bf5dfe5f1b455060a3e6*9b0d1893678dea77f88bf66e6986adbc5a8095e4a09c7e9744bad42ac49133a7", "password"},
+	{"$keepass$*1*50000*124*f7465d646bab0a86197fcf2b778ea9c1*ec24a474b0745f9ff1de44ac3e0a274dda83375ecec45eb9ddc40b524fb51df2*f7f17dd2a15c4cf13fb4c8a504298fb3*e7765dba9ed64686a2c0b712de95bd0051a20b331ea0f77133e6afbb9faa1479*1*608*e5802225bf18755620355ad67efa87335532197ce45ee8374a5d23478557414b110426904671c49b266672c02e334c4261d52a9a0723d050329319f8d3b06a6d9507e5b30c78823beea101f52bde5ecdb6b6d0d2627fc254678416b39d2ba43ebce229c0b25f8c530975bc617be602d36e95a6e83c99c7264d5cc994af762460942830ac06b03d30c84c000d01061a938c274d78d383040c8cf5e69e7fbbaf6b46a7061399087f1db2747cd83afdb2b36e6077cecdc3b5c3b3f29f3a1ef537e8c798f8d614f9866a19a53b463aa81632e9aca43ebff9c787ca20a416a4051f16e4ececb84ea853fcc48a988e2d77cb385a2add3b858a18ee73783695a093628a0082d928ffeea39db585a478647e29395fdf2e3e8f54dc5b8277712d8cf5e8a266780944889fb46408b8afb614c3b8e7152b8cc865368d0ae000404234c11c8a77ebc521326683c00967a474cf82336afd1cb8f867db5f6cc7f5c9ae755c0fd0b4c9554ad26bef0b10f0c70978746090034e16922ee9cf38eb251515117cc62da3a62a6fd8a5dab0c10e857b2e2489d2521e1903d6b107c16fd1bf6565fc2953ea3206481ab6c466dba43777076c58ada7cb1883043f4747b2b80731476057598054ea9ec9de1645b4034f6569f579e70a021cc0a490dfa703def725846d0693d7cb02dea430905470db56663953b81b72f7543d6db7713afbcc91919b23cff80290a1053f34516c0b2c7a1f4bec1718994563ae188c2f65e20378537f88be2ebc6c47fbadabbd33414ffa30f115be0abdc89182e0a77d8d5c258d9ec5005415890218eb456fdcb79f1b15031289a0909fc6d8ae48ca6d2d699b6e0cd2e76462", "crackthis"},
+	{"$keepass$*1*50000*124*e144905f9aa746e1b2c382c807125d02*dd08f46898a3e75c458a44f34ec5391d3f3eb62b24dbda3d5e486e36312168cc*376ae8d5e8430d0a18e7bb4a0baddf75*5fa8dfc2f440ad296f1562683d06bf2717ae7e8ed343a279f54292f9fc8229ab*1*608*3ce1e03a1452e44b609ebe7326db4ef133ca25c325cc7cc5795ef92358011e2d32a1cb7cadc6f412b1d0a09f67f1444dfec73ed770507683360962d26b0c2b0384bcf9aba2cf1b3e4b5d7083ceaf5f941a2b99ec68d574eb58fe79e94d90b81c8f1f0ccfd35b16d415e8e203c06138eb6a1144520ef98bcdb33d669d2ab4aef2ab739e6dbc3f2ea5c6eef8410ca1555262181d8379b516551eb9d6a23eeb515bd8ef12735a635b25743c1188642486dd1fa4544138a361bcfc108f689bfb90f81d9808adcbd509f057cdbfd1cd31ee8b542956292f9bcca21fabeacc9ba96b335223103a72f94d9b04bcba9d74fada62e0d5bf2da142e413a373ea3c97ff1d50109532f5d041c5f77bea28cdea00388ab9dd3afc72bc266ff44c34221d751738545056e83d7558cf02ffc6f5a57163526ffff9a7de1c6276d4815a812c165ef0293bb951bcbc2cf389d20e188a6c24d1bc5322ee0bc6972b765fb199b28d6e14c3b795bd5d7d4f0672352dfed4870cf59480bab0f39f2a20ac162e8365b6e3dcb4a7fec1baafcb8c806726a777c7a5832a0d1c12568c2d9cad8dc04b1ce3506dbc1bf9663d625cfccb2d3c1cb6b96eee0f34e019b0145e903feed4683abe2568f2c0007c02c57b43f4ee585f9760d5b04c8581e25421b6b5bb370a5b48965b64584b1ed444ea52101af2b818b71eb0f9ae7942117273a3aff127641e17779580b48168c5575a8d843a87dee1088e0fde62bb2100e5b2e178daa463aeaeb1d4ff0544445aab09a7bdc684bd948f21112004dcc678e9c5f8cf8ba6113244b7c72d544f37cbc6baed6ddc76b9ccba6480abfb79a80dda4cdf7e218f396a749b4e5f", "password"},
+	/* CMIYC 2013 "pro" hard hash */
+	{"$keepass$*2*6000*222*a279e37c38b0124559a83fa452a0269d56dc4119a5866d18e76f1f3fd536d64d*7ec7a06bc975ea2ae7c8dcb99e826a308564849b6b25d858cbbc78475af3733f*d477c849bf2278b7a1f626c81e343553*e61db922e9b77a161e9b674ddadfb8c660d61b5f68d97a3b1596ae94cfa9d169*7c80c7db9de77f176e86ba11697152c4c8f182bdb8133ad1bca22e9ec5bc275b", "Sh4RK%nAD0*"},
+	/* twofish version 1 hash from http://openwall.info/wiki/john/sample-non-hashes#KeePass */
+	{"$keepass$*1*50000*1*1ff21bd79aa8e9c3f439281a4ce6a97b*cfbdb00057ee0c9e889ca9d93b069ab5ae19f78852bc21aae4f60d0d325e0034*c1a7e6138a49a2dcfb3a84afbc1d918b*a704f9d060f0de5a070155d1d5a8727da92f404242cb3aa2b9aa53a145f87474*1*608*c2d3d18e416af56788d1c3e4257da9ce6e5dcad4db012d7422d17b4527bbb2bb994d9db03907ae01cc1565f5fd0729b930c9ee352426c57de5dee7e941e1d6aedeaf2b0e6509819385de9b4dd6a09979b3edfa0959a7186c422031e426f18d295c55ac616aabeec99f89e696be1d585950ef16a94ae610f2449cc3964bb63ec6043ef36c89117bc78e99e5fbf083b48cb84f85a964e8a037018b3afc2cc55fbe7d74cbdb53d5a54bcd202a1d0a342dbf48a8f7a24264cde8d800a506bf134008b1d8d9b8dd80c19511d9f43b3c23b19eb4a7dcf584f80c49961f73dcba3d2d0390a39a683ddcc8771b49cc3c673ea0aa902d075e25bc814608e2e6d1d6218a6379fd677bc5daaa18b6f5a021d2f661338ca8cc3645dc6cddb860af222a5cdb59a5e2a2c1921203344ced4e2154446239f6c1af8c1bace8207e0f519ea9c08db2f5d0bde0416b09ef6c530213e648641ae56c9af9fbdcb0a286cc4de121655697b9eb00c0fd89ed7269c3859eca20e0c7b60be8d2a1323eb915139cf90c55f9cff01a5bdf757e09ee6d64c2de9aec8d3ea42feeb67caf51b9ba1a80b435e271fdb7f9144ca31e41671768b2c5e8adf70245fdf52005de418efbe2a156d19eeb2ed9e97a0ddb133d11bd8655356d9d3edbbdbf9d0db345b2eb2c1f550ce070f5b0f8f8e58a6ffd52ae8089627dc4a0dac4b4846349066bfa0d2f395d2cb3871e57e353d622e0904a9f54a3e4706797d95b34619f792c15ab8efb3ac523becc3023f01aaad169bc08db8d01e2dd22eff8f6b4f7b741d196bc3de466590011e6d5c9703a19c07d96d26fe1ad93d0931454730ee1f3146428a126d1ed02763f827ff4", "twofish"},
+	/* keyfile test cases*/
+	{"$keepass$*1*6000*0*1a1d38235ccbeae4ca2a9edfbd3b290c*8e1e81b37a6161b6033fbd6dd350aaeaa0712cf2649fe40e3fbbaa4b61684f54*d9517d352aea00c2b7f57f1154b9c0a0*0a8ae9b13347402c242d7cde4d58d01f1e129287eaf62df768856bbb9d0633a1*1*1360*6555a7e9eca9d5a2c9504a5c888846f0a8902fa31e3dc90f8fcc118856d5daabcaaf4316c4d589e11cce5b9a209e9a7ec1db5b848a706c78f7c7dfac4fd9ea86ac15af500518766dbf4525ee7c1b477a8fec4abdd6f4ad36894ec5aee0c9a5662c5091ceb61b3aa99ff3eacd687ed797b0a1e8ceecd5c51456cb1f70dadf0fda190752e4efe4fb101d5fc5d7745ff01d68cb4c0cc32c6003f85c310e43d7d659748bfc260cbb329c4076c2c9948386c74bb967362a98d6490dbe340f5d440b557b105edd5561836fbb6894f4a1d9a5cd0182536a28f60ca268d682065f8f5226e24a07d635a3c4f04760094cee033fb2f7c3a0cbdf7f174d31c827f6911a75ca95b21332bb47ea6359aa2d70ff4b16e8481cd536e0ec4ba90963edda754b6e0e694855e4f266899b3dd2b0f74c3e688caa376b22810945249ac4e1c38e8d1093ce272ed45d26037a1fd6e0cfcdbdf096c8b2795ba736641bafe9938b6eb2b40ea347f9c49952c118d86ec671c065e3c94f0de2409fec2fde318ad7e6dd0189baf4fa0044fc1d2974b9dafb1608f4bca525706e44ca6af09e305ad29f5e4ba0831145713d5d8b6d6d955c4b5ca031e34b4292aee5383179e1e0afe92ee6565e69825c90bb5e79612a4ad4a3babbd4a75b5481ea710c93595781b71532c17730409482e6b59bb9831be4efadadf36eda5bc5fcf0f3541aaba6662807e531a3e28078f5960e50f80e624c5434b545c1232fdd64359f53b90d6635107f4f005ac02110eebdbdda4f2c92addd686059e9d799a55902526f87f78b8844e2000f82e7b5c8ba3a19fe26117c43f69ba26eee75cc385737791ca4554ce935af26c50331963e500605e87ac3602a76669bf6318e797ef01fe1c25e567cc864de11bd00f555fdf188648bf4179658e325be39a4050b7b01553422e5cd1bbaf5e8f75ce34f0e92f1253c880d4e77f484f14817e288f01efbfe1a8f8b90e9d18b86898856bdf3ee6b5754853cb99a746fa0b753f1a49f529a89d9a0c2fbd5365477be829190dbf491bc886f66ae1bfe014a7e23a420f76a4a0d0d5ebcea51dc0021651a6cdbe5c89a7ae8bfdae2e30d404c31790c0aba8791793ce3072adf21e5a3c5b5e4f9cea82ebff5070e13f94300d5688523ba2a142ae8f82f6ef940e69beba1d665ab17a2ae471500fc48ded336b27450f08dfe07fa5e556963f035a01950f43b2f649bf7f552e9ee7154f5ffdec109fd5bdf0e879d044ef4b78e590ac769efcdd7dad74228872af966d2e8d976336de1ee4289e933288b5b0b43195df1c248176ac944f5e99918dbc067f93d15e95602c9cb8246f378377785b7ebfee44f81b385a3e1c9c5276e4b477c4841af871e6b0e3f4387c58cea01fe2aff04df0f51ac93757172d7537ee0df51ec931564ed2c8a11a45da8c03644d0bc93a14d9f79555250b9c8245690bc1c72ea7e9104a9f570680f704c1f8759a65e210e1b9a855b46ed6801354175b27fc288a7bc39a2003f4400c124ec41d7f54f67be99f778895d9c3e33623a346021215a369487457e78322dbd71a3d969b3e22dfea987ac93d5c4f8252142824f5a67e54a2b1b78ea928fbb63653e122555f6c76150f2541bdad6524f69964c91e9175406d0b824e175e63c7677d990341ee69c4ca9612a05e3bd2ed304c45cd97051aaf0b63c0d917af8d01723e215bb93f816b51d79e29e4e885b98f8ca8320443503c07e67b4d546f544ffced62ef7298a8ac6175f77c180900f638466cd15d6511d7b16992a8e0674563c02fe7776079ee92739bc142a1e601b3aaee284f6f828656e43e58b93bcfd5f69b6aa8c003788d1ae88f569f64402d64e18cb8ffc2268013fe4da9ba7da557da3e259623168b7fd57cf0e4c8327bae66e02bc12978725022ef4cc03b4021d3a*1*64*3a96fb77fbbbca7336ee699f17be31fde552191128553c6d89bfce4035dc0af0", "choupinette"},
+	{"$keepass$*2*6000*222*aa511591cb50394d044f31abb2febdb2788c9ee41d78a53f3efe0f83fdd64e81*7ceab79302a794cef818d9426e53a78458f82e72575967c4fb3788d4bc685874*1c5c1c0c475ee2f22bd56e9c75cfd67c*e7bf79115c83a0236260c71c17a816f9bd9288a683eb4b5e0d48666c66e97774*53f26838a293b392bfde1ad21b444b834cf5c02155a1378ac496653b2f3779ec*1*64*98df4f35fe74c031992d81a639305c4520f303fd1ca4bb09b53e33032b44c46a", "kukudanlaplace"},
+	// KDBX 3.x with ChaCha20
+	{"$keepass$*2*6000*2*e852737a797fb642a2814e5965aba3473644a56ea67998526ce5e6f0e256a56a*fb300459b1e8c52fefa8e72676b57563565475b1c1306c266a48ccc2010e6a94*03027f86819941d1d0f3f2f5*af0f6c5e4319e6c10fdb95f44ded70f3115ae7dc28ec83fd3676c92076505ded*e0ab7f438903eb91dd8bc13c52c5a1c02e34b107ae16710bc57858c8c85fecd0", "openwall"},
+	// KDBX3 AES
+	{"$keepass$*2*60000*0*580eb0ec652b3960f20bab8f423b4518d9a52522019545969ace411400ad34d2*59bd2b8f15104441b35d00ee557a28a0652d0c86a130635baca2d3f41335bb50*aabd203f8eac9d46e0669a4eadcdef57*85d5e97c493e47ee127cd78805ff3082b6b16c4e457ef73de144c049ccb00720*3aade536d101ab46c2e14f49257010a0e44f893ec408e072f05e4fcfa08fa958", "testtest"},
+	{"$keepass$*2*60000*0*c145bf587802cc2b2996ba91e1d52b07afda60dfef0c2453c8e022d8cfc6526d*fac5b174572808549423887642c90f697a0cb653f4297b6b7cc5df5451cb3587*c4a0d9470ea3c19eb52e2ac39cf100a3*0f9f4392594bfa77597574202ecf2649d4faee488464a9034066b56d8ac0cb20*8828a87c16558ad8ad330834bf7bb538acef12d479d6b522c0be05c4bcbb982d", "tst"},
+	{"$keepass$*2*60000*0*3beafb2ea5d451f2d2fad3b9956420e540bce9b9d7091c25d292702bf0d5202b*45028183645ca4f6a83eafcb645e3681aa936806d94ddab03768da08d6d17b01*2c2c74b6794b267ae94b32a26af3661d*5599f845b9d82287d07a6d045c194e533abff631a25b581dfe9d7b9969f296af*e059ddf5d0227f7d6e7f9a80657adfd3e50777441a7799f80bf91ba104a39b0e", "test"},
+	// KDBX4 with AESKDF (has ChaCha cipher but we don't need to dwelve that deep to verify KDBX4)
+	{"$keepass$*4*60000*c9d9f39a*0*0*0*a9cc92ffb93f86a31655c9e85d5adb234f54f9ba3a8f98794ad22b711e726d57*14c7023eb53c968c1d3bca3b84db9bec2925d8b7566348ccadf01d0e5f0dc3cc*03d9a29a67fb4bb5000004000210000000d6038a2b8b6f4cb5a524339a31dbb59a0304000000010000000420000000a9cc92ffb93f86a31655c9e85d5adb234f54f9ba3a8f98794ad22b711e726d570b5d00000000014205000000245555494410000000c9d9f39a628a4460bf740d08c18a4fea0501000000520800000060ea0000000000004201000000532000000014c7023eb53c968c1d3bca3b84db9bec2925d8b7566348ccadf01d0e5f0dc3cc00070c000000097631e2f4277a20fc37a63a00040000000d0a0d0a*8ecfeca776357075ad05ec3258b40a6f8657687621777b960fb3cd9cc81fcc26", "test"},
+#if KEEPASS_REAL_COST_TEST_VECTORS
+	/* KDBX4 AES with IRL cost, this may take a second on CPU */
+	{"$keepass$*4*31250000*c9d9f39a*0*0*0*f987ed7cf6e452a09396fe0e01030fb63a371eded9b203d5c1b3d9fe3aca364e*804fa969a4699fd547848b76195b0a6d07628d58393ea749f415687151567849*03d9a29a67fb4bb500000400021000000031c1f2e6bf714350be5805216afc5aff0304000000010000000420000000f987ed7cf6e452a09396fe0e01030fb63a371eded9b203d5c1b3d9fe3aca364e0710000000a84de656932fb857e26a07619e526d720b5d00000000014205000000245555494410000000c9d9f39a628a4460bf740d08c18a4fea0501000000520800000050d6dc010000000042010000005320000000804fa969a4699fd547848b76195b0a6d07628d58393ea749f4156871515678490000040000000d0a0d0a*6f0a50e14a063a8a33c8e071340ad309a0a46b90fb12b28b3262c899bffa09b6", "magnum"},
+#endif	/* KEEPASS_REAL_COST_TEST_VECTORS */
+#endif	/* KEEPASS_AES */
+#if KEEPASS_ARGON2
+	// KDBX4 with Argon2d
+	{"$keepass$*4*3*ef636ddf*4194304*19*1*bd6f0e6ec93972d914de695e36c4eddc3d6b8d83631ee94fef266f432de8430a*f168ad8b74c3b622bcff63eecc1b6e55d4e12a43415a1217840e26deb4148313*03d9a29a67fb4bb500000400021000000031c1f2e6bf714350be5805216afc5aff0304000000010000000420000000bd6f0e6ec93972d914de695e36c4eddc3d6b8d83631ee94fef266f432de8430a0710000000854d57af8a9531fe6e0a57a3702108390b8b00000000014205000000245555494410000000ef636ddf8c29444b91f7a9a403e30a0c05010000004908000000030000000000000005010000004d080000000000400000000000040100000050040000000100000042010000005320000000f168ad8b74c3b622bcff63eecc1b6e55d4e12a43415a1217840e26deb414831304010000005604000000130000000000040000000d0a0d0a*4d4b2788051f903f5fccd314f2bf3b5ec267c24bbe430e5670d83eba7a0761fc", "password"},
+	// KDBX4 with Argon2id
+	{"$keepass$*4*2*9e298b19*1048576*19*2*5f2e9d0f98c4c51ae3490fc08960f07a0de805dcc9180c6d1e6ae5eaeb076062*52f236326dc51fd9c96ae7a2122ebb7ae7141f3932f7369fffd7c51813683262*03d9a29a67fb4bb500000400021000000031c1f2e6bf714350be5805216afc5aff03040000000100000004200000005f2e9d0f98c4c51ae3490fc08960f07a0de805dcc9180c6d1e6ae5eaeb076062071000000089a178d96eb84c541f1d071ea644edf50b8b000000000142050000002455554944100000009e298b1956db4773b23dfc3ec6f0a1e605010000004908000000020000000000000005010000004d08000000000010000000000004010000005004000000020000004201000000532000000052f236326dc51fd9c96ae7a2122ebb7ae7141f3932f7369fffd7c5181368326204010000005604000000130000000000040000000d0a0d0a*ff66269c324c5b12207660b30f203eea854f4d72153ec5a044ec3bcae2df2187", "rippermagnum"},
+#if KEEPASS_REAL_COST_TEST_VECTORS
+	// KDBX4 with Argon2d and IRL costs, these together may take several seconds on CPU
+	{"$keepass$*4*10*ef636ddf*67108864*19*2*ee1798a1e51cb6d69121403d6290afee11616d267b51f43a009bd9ce2c8d3f70*5dbfd5f816b436e7176b6403629fcc09b29170107391d5c27b20f68d4bf91da6*03d9a29a67fb4bb500000400021000000031c1f2e6bf714350be5805216afc5aff0304000000010000000420000000ee1798a1e51cb6d69121403d6290afee11616d267b51f43a009bd9ce2c8d3f700710000000a74b6808e29ec2fbb5b4f0137264baa50b8b00000000014205000000245555494410000000ef636ddf8c29444b91f7a9a403e30a0c050100000049080000000a0000000000000005010000004d0800000000000004000000000401000000500400000002000000420100000053200000005dbfd5f816b436e7176b6403629fcc09b29170107391d5c27b20f68d4bf91da604010000005604000000130000000000040000000d0a0d0a*4ada97aa9c7292a3adef5899eb7889e4c1a24257c4944322d8ce6f3289fd845c", "magnum"},
+	// KDBX4 with Argon2id and IRL costs, these together may take several seconds on CPU
+	{"$keepass$*4*34*9e298b19*67108864*19*2*91babb4b82f26157924bd40232f6d0fe0eb69442153dab643ca900b7f104ab87*d801db234e733c12d888c5526424dd0a9b1d637848ff6e61a57acfcb20f92d7f*03d9a29a67fb4bb500000400021000000031c1f2e6bf714350be5805216afc5aff030400000001000000042000000091babb4b82f26157924bd40232f6d0fe0eb69442153dab643ca900b7f104ab87071000000036699748b272e362775269f7a13cd73a0b8b000000000142050000002455554944100000009e298b1956db4773b23dfc3ec6f0a1e605010000004908000000220000000000000005010000004d080000000000000400000000040100000050040000000200000042010000005320000000d801db234e733c12d888c5526424dd0a9b1d637848ff6e61a57acfcb20f92d7f04010000005604000000130000000000040000000d0a0d0a*1e0e29b13e107b90558ef35262f9a19709fbeb4b6725d61ba6b3c795ec121da9", "magnum"},
+#endif	/* KEEPASS_REAL_COST_TEST_VECTORS */
+#endif	/* KEEPASS_ARGON2 */
+	{NULL}
+};
+
+static int keepass_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy;
+	char *keeptr;
+	char *p;
+	int kdbx_ver, res, extra;
+
+	if (strncmp(ciphertext, KEEPASS_FORMAT_TAG, KEEPASS_FORMAT_TAG_LEN))
+		return 0;
+	ctcopy = xstrdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += KEEPASS_FORMAT_TAG_LEN;
+	if ((p = strtokm(ctcopy, "*")) == NULL)	/* version */
+		goto err;
+	kdbx_ver = atoi(p);
+	if (kdbx_ver < 1 || kdbx_ver == 3 || kdbx_ver > 4)
+		goto err;
+#if !KEEPASS_AES
+	if (kdbx_ver != 4)
+		goto err;
+#endif
+	if ((p = strtokm(NULL, "*")) == NULL)	/* rounds or Argon2_T */
+		goto err;
+	if (!isdec(p))
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* cipher or kdf_uuid */
+		goto err;
+	if (kdbx_ver == 4) {
+		res = hexlenl(p, &extra);
+		if (extra || res != 8)
+			goto err;
+#if !KEEPASS_ARGON2
+		if (!strcmp(p, "ef636ddf") || !strcmp(p, "9e298b19")) {
+			static int warned;
+
+			if (!ldr_in_pot && john_main_process && !warned) {
+				fprintf(stderr, "%s: Argon2 hash(es) not supported, skipping.\n",
+				        self->params.label);
+				warned = 1;
+			}
+			goto err;
+		}
+#endif
+#if !KEEPASS_AES
+		if (!strcmp(p, "c9d9f39a")) {
+			static int warned;
+
+			if (!ldr_in_pot && john_main_process && !warned) {
+				fprintf(stderr, "%s: AES hash(es) not supported, skipping.\n",
+				        self->params.label);
+				warned = 1;
+			}
+			goto err;
+		}
+#endif
+		if ((p = strtokm(NULL, "*")) == NULL)	/* Argon2_M */
+			goto err;
+		if (!isdec(p))
+			goto err;
+		if ((p = strtokm(NULL, "*")) == NULL)	/* Argon2_V */
+			goto err;
+		if (!isdec(p))
+			goto err;
+		if ((p = strtokm(NULL, "*")) == NULL)	/* Argon2_P */
+			goto err;
+		if (!isdec(p))
+			goto err;
+	}
+#if KEEPASS_AES
+	else {
+		if (!isdec(p))
+			goto err;
+		int cipher = atoi(p);
+		if (cipher < 0 || cipher > 2)
+			cipher = 0;
+		if (kdbx_ver == 1 && cipher > 1) /* Unsupported combo */
+			goto err;
+		if (kdbx_ver == 2 && cipher == 1) /* TODO, v2 w/ Twofish */
+			goto err;
+	}
+#endif
+	if ((p = strtokm(NULL, "*")) == NULL)	/* final/master seed */
+		goto err;
+	res = hexlenl(p, &extra);
+	if (extra || (res != 32 && res != 64))
+		goto err;
+	if (kdbx_ver == 4) {
+		if ((p = strtokm(NULL, "*")) == NULL)	/* expected start bytes*/
+			goto err;
+		if (hexlenl(p, &extra) != 64 || extra)
+			goto err;
+		if ((p = strtokm(NULL, "*")) == NULL)	/* header */
+			goto err;
+		uint32_t header_size = hexlenl(p, &extra) / 2;
+		if (extra)
+			goto err;
+		if (header_size > KEEPASS_MAX_CONTENT_SIZE) {
+			static int warned;
+
+			if (!ldr_in_pot && john_main_process && warned < header_size) {
+				fprintf(stderr,
+				        "%s: Input rejected due to larger size than compile-time limit.\n"
+				        "Bump KEEPASS_MAX_CONTENT_SIZE in keepass_common.h to >= 0x%x, and rebuild\n",
+				        self->params.label, header_size);
+				warned = header_size;
+			}
+			goto err;
+		}
+		if ((p = strtokm(NULL, "*")) == NULL)	/* header HMAC */
+			goto err;
+		res = hexlenl(p, &extra);
+		if (res != 64 || extra)
+			goto err;
+	}
+#if KEEPASS_AES
+	else {
+		if ((p = strtokm(NULL, "*")) == NULL)	/* transf random seed */
+			goto err;
+		if (hexlenl(p, &extra) != 64 || extra)
+			goto err;
+		if ((p = strtokm(NULL, "*")) == NULL)	/* env_iv */
+			goto err;
+		res = hexlenl(p, &extra);
+		if ((res != 32 && res != 24) || extra)
+			goto err;
+		if ((p = strtokm(NULL, "*")) == NULL)	/* hash or expected bytes*/
+			goto err;
+		if (hexlenl(p, &extra) != 64 || extra)
+			goto err;
+		if (kdbx_ver == 1) {
+			if ((p = strtokm(NULL, "*")) == NULL)	/* inline flag */
+				goto err;
+			res = atoi(p);
+			if (res != 1)
+				goto err;
+			if ((p = strtokm(NULL, "*")) == NULL)	/* content size */
+				goto err;
+			int content_size = atoi(p);
+			if (content_size > KEEPASS_MAX_CONTENT_SIZE) {
+				static int warned;
+
+				if (!ldr_in_pot && john_main_process && warned < content_size) {
+					fprintf(stderr,
+					        "%s: Input rejected due to larger size than compile-time limit.\n"
+					        "Bump KEEPASS_MAX_CONTENT_SIZE in keepass_common.h to >= 0x%x, and rebuild\n",
+					        self->params.label, content_size);
+					warned = content_size;
+				}
+				goto err;
+			}
+			if ((p = strtokm(NULL, "*")) == NULL)	/* content */
+				goto err;
+			if (!content_size || hexlenl(p, &extra) / 2 != content_size || extra)
+				goto err;
+		}
+		else {
+			if ((p = strtokm(NULL, "*")) == NULL)
+				/* content */
+				goto err;
+			if (hexlenl(p, &extra) != 64 || extra)
+				goto err;
+		}
+	}
+#endif
+	p = strtokm(NULL, "*");
+	// keyfile handling
+	if (p) {
+		res = atoi(p);
+		if (res == 1) {
+			if ((p = strtokm(NULL, "*")) == NULL)
+				goto err;
+			res = atoi(p);
+			if ((p = strtokm(NULL, "*")) == NULL)
+				goto err;
+			if (res != 64 || strlen(p) != 64 || !ishexlc(p))
+				goto err;
+		}
+		else
+			goto err;
+	}
+
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+static void *keepass_get_salt(char *ciphertext)
+{
+	char *ctcopy = xstrdup(ciphertext);
+	char *keeptr = ctcopy;
+	char *p;
+	int i;
+	static keepass_salt_t cs;
+
+	memset(&cs, 0, sizeof(cs));
+	ctcopy += KEEPASS_FORMAT_TAG_LEN;	/* skip over "$keepass$*" */
+
+	p = strtokm(ctcopy, "*");
+	cs.kdbx_ver = atoi(p);
+#if KEEPASS_AES
+	if (cs.kdbx_ver == 1) { // KDBX < 3
+		cs.kdf = 0;
+		p = strtokm(NULL, "*");
+		cs.key_transf_rounds = atoi(p);
+		p = strtokm(NULL, "*");
+		cs.cipher = atoi(p);
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 16; i++)
+			cs.final_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.transf_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 16; i++)
+			cs.enc_iv[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.contents_hash[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		if (atoi(p) == 1) {
+			p = strtokm(NULL, "*");
+			cs.content_size = atoi(p);
+			p = strtokm(NULL, "*");
+			for (i = 0; i < cs.content_size; i++)
+				cs.contents[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+					+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		}
+	} else if (cs.kdbx_ver == 2) { // KDBX3
+		cs.kdf = 0;
+		p = strtokm(NULL, "*");
+		cs.key_transf_rounds = atoi(p);
+		p = strtokm(NULL, "*");
+		cs.cipher = atoi(p);
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.final_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.transf_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 16; i++)
+			cs.enc_iv[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.expected_bytes[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.contents[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	} else
+#endif
+	{ // KDBX4
+		cs.cipher = 0;
+		p = strtokm(NULL, "*");
+		int iter = atoi(p);
+		p = strtokm(NULL, "*");
+		if (!strcmp(p, "ef636ddf")) {
+			cs.kdf = 1;
+			cs.type = Argon2_d;
+			cs.t_cost = iter;
+		} else if (!strcmp(p, "9e298b19")) {
+			cs.kdf = 1;
+			cs.type = Argon2_id;
+			cs.t_cost = iter;
+		}
+#if KEEPASS_AES
+		else {
+			cs.kdf = 0;
+			cs.key_transf_rounds = iter;
+		}
+#endif
+		p = strtokm(NULL, "*");
+		cs.m_cost = atoi(p) / 1024;
+		p = strtokm(NULL, "*");
+		cs.version = atoi(p);
+		p = strtokm(NULL, "*");
+		cs.lanes = atoi(p);
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.master_seed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.transf_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		cs.header_size = strlen(p) / 2;
+		for (i = 0; i < cs.header_size; i++)
+			cs.header[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < 32; i++)
+			cs.header_hmac[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	}
+
+	p = strtokm(NULL, "*");
+	if (p) { /* keyfile handling */
+		p = strtokm(NULL, "*");
+		int keyfilesize = atoi(p);
+		if (keyfilesize != 64)
+			fprintf(stderr, "Warning: keepass possible bug indication %s:%d size %d\n",
+			        __FILE__, __LINE__, keyfilesize);
+		p = strtokm(NULL, "*");
+		for (i = 0; i < keyfilesize / 2; i++)
+			cs.keyfile[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		cs.have_keyfile = 1;
+	}
+
+	MEM_FREE(keeptr);
+
+#if KEEPASS_AES
+	if (cs.kdbx_ver < 4 && cs.cipher != 0 && cs.cipher != 1 && cs.cipher != 2)  // offset hijacking!
+		cs.cipher = 0;  // AES
+#endif
+
+	return (void *)&cs;
+}
+#endif	/* !KEEPASS_COMMON_CODE */
+
+extern char (*keepass_key)[KEEPASS_PLAINTEXT_LENGTH + 1];
 extern keepass_salt_t *keepass_salt;
-extern int keepass_valid(char *ciphertext, struct fmt_main *self);
-extern void *keepass_get_salt(char *ciphertext);
+
 extern void keepass_set_key(char *key, int index);
 extern char *keepass_get_key(int index);
-extern unsigned int keepass_iteration_count(void *salt);
-extern unsigned int keepass_version(void *salt);
-extern unsigned int keepass_algorithm(void *salt);
+
+extern unsigned int keepass_cost_t(void *salt);
+extern unsigned int keepass_cost_m(void *salt);
+extern unsigned int keepass_cost_p(void *salt);
+extern unsigned int keepass_kdf(void *salt);

--- a/src/keepass_common_plug.c
+++ b/src/keepass_common_plug.c
@@ -1,12 +1,59 @@
 /*
  * This software is
- * Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
- * Copyright (c) 2014 m3g9tr0n (Spiros Fraganastasis),
- * Copyright (c) 2016 Fist0urs <eddy.maaalou at gmail.com>, and
- * Copyright (c) 2017 magnum
+ *  Copyright (c) 2017-2024 magnum
+ *  Copyright (c) 2016 Fist0urs <eddy.maaalou at gmail.com>, and
+ *  Copyright (c) 2014 m3g9tr0n (Spiros Fraganastasis),
+ *  Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted.
+ *
+ * Really old keepass apparently used RC4, or an "Arcfour variant".  We never got
+ * support for it. There are also references to Salsa20 (predecessor of ChaCha).
+ *
+ * NOTE: Any of the three formats below can be appended with "*1*64*<32_bytes_hex>"
+ *       which then is either the contents of a keyfile or the SHA-256 hash of it.
+ *
+ * KDBX2
+ * $keepass$*1*<rounds>*<cipher>*<final_seed>*<trans_seed>*<iv>*<hash>*1*<data_size>*<data>
+ *                      0 AES
+ *                      1 TwoFish
+ * KDBX3
+ * $keepass$*2*<rounds>*<cipher>*<master_seed>*<trans_seed>*<iv>*<expected_start_bytes>*<data>
+ *                      2 ChaCha
+ *
+ * KDBX4
+ * $keepass$*4*<Argon2_T>*<kdf_uuid>*<Argon2_M>*<Argon2_V>*<Argon2_P>*<master_seed>*<trans_seed>*<header>*<header_hmac>
+ *                       c9d9f39a AES
+ *                       ef636ddf Argon2d
+ *                       9e298b19 Argon2id
+ *
+ * KeePassXC 2.7.6 KDBX4
+ * Default KDF is Argon2d, eg. ~10-35 rounds (aims for 1 sec), 64 MiB, 2 threads.
+ * Defaults for Argon2id are same as for Argon2d.
+ * Defaults for AES256 is eg. ~32M rounds (aims for 1 sec) rather than eg. 6000.
+ *
+ * KeePass' Argon2 implementation supports all parameters that are defined in the
+ * official specification, but only the number of iterations, the memory size and
+ * the degree of parallelism can be configured by the user in the database settings
+ * dialog. For the other parameters, KeePass chooses reasonable defaults: a 256-bit
+ * salt is generated each time the database is saved, the tag length is 256 bits,
+ * no secret key or associated data. KeePass uses version 1.3 of Argon2.
+ *
+ * argon2_t == time == iterations == ~30
+ * argon2_m == memory: Note that this field is in bytes (67108864 for 64 MB) but
+ *             when given to the argon2 function it's expressed as KiB (65536 KB).
+ * argon2_p == lanes == parallelism == threads == 2
+ * argon2_v == version, 19 == 0x13 == 1.3
+ *
+ *****************************
+ * Argon2d t=10 p=2 m=65536:
+ *****************************
+ *  2080ti              ~30 ms
+ *  CPU                 ~83 ms
+ *  Radeon Pro Vega 20 ~150 ms
+ *  UHD Graphics 630   ~273 ms
+ *****************************
  */
 
 #include <string.h>
@@ -26,288 +73,53 @@
 #include "formats.h"
 #include "params.h"
 #include "options.h"
+
+#define KEEPASS_COMMON_CODE	1
 #include "keepass_common.h"
-#include "sha2.h"
-#include "aes.h"
-#include "twofish.h"
 
-struct fmt_tests keepass_tests[] = {
-	{"$keepass$*1*50000*124*60eed105dac456cfc37d89d950ca846e*72ffef7c0bc3698b8eca65184774f6cd91a9356d338e5140e47e319a87f5e46a*8725bdfd3580cf054a1564dc724aaffe*8e58cc08af2462ddffe2ee39735ad14b15e8cb96dc05ef70d8e64d475eca7bf5*1*752*71d7e65fb3e20b288da8cd582b5c2bc3b63162eef6894e5e92eea73f711fe86e7a7285d5ac9d5ffd07798b83673b06f34180b7f5f3d05222ebf909c67e6580c646bcb64ad039fcdc6f33178fe475739a562dc78012f6be3104da9af69e0e12c2c9c5cd7134bb99d5278f2738a40155acbe941ff2f88db18daf772c7b5fc1855ff9e93ceb35a1db2c30cabe97a96c58b07c16912b2e095e530cc8c24041e7d4876b842f2e7c6df41d08da8c5c4f2402dd3241c3367b6e6e06cd0fa369934e78a6aab1479756a15264af09e3c8e1037f07a58f70f4bf634737ff58725414db10d7b2f61a7ed69878bc0de8bb99f3795bf9980d87992848cd9b9abe0fa6205a117ab1dd5165cf11ffa10b765e8723251ea0907bbc5f3eef8cf1f08bb89e193842b40c95922f38c44d0c3197033a5c7c926a33687aa71c482c48381baa4a34a46b8a4f78715f42eccbc8df80ee3b43335d92bdeb3bb0667cf6da83a018e4c0cd5803004bf6c300b9bee029246d16bd817ff235fcc22bb8c729929499afbf90bf787e98479db5ff571d3d727059d34c1f14454ff5f0a1d2d025437c2d8db4a7be7b901c067b929a0028fe8bb74fa96cb84831ccd89138329708d12c76bd4f5f371e43d0a2d234e5db2b3d6d5164e773594ab201dc9498078b48d4303dd8a89bf81c76d1424084ebf8d96107cb2623fb1cb67617257a5c7c6e56a8614271256b9dd80c76b6d668de4ebe17574ad617f5b1133f45a6d8621e127fcc99d8e788c535da9f557d91903b4e388108f02e9539a681d42e61f8e2f8b06654d4dec308690902a5c76f55b3d79b7c9a0ce994494bc60eff79ff41debc3f2684f40fc912f09035aae022148238ba6f5cfb92f54a5fb28cbb417ff01f39cc464e95929fba5e19be0251bef59879303063e6392c3a49032af3d03d5c9027868d5d6a187698dd75dfc295d2789a0e6cf391a380cc625b0a49f3084f45558ac273b0bbe62a8614db194983b2e207cef7deb1fa6a0bd39b0215d72bf646b599f187ee0009b7b458bb4930a1aea55222099446a0250a975447ff52", "openwall"},
-	{"$keepass$*2*6000*222*e54497d3d9be3e310a817a13515225a87773ba71557a88673c34db824550be7b*d405c4f7e3c7b2b142fda44c3d55d3afab1c91a6aca7c81c1ff7e61b3f03be85*7eb45af0af777ecb57f0159b9ffa528b*0af7d9facefb20378e8666389de7586ea72e9527dc78bf5dfe5f1b455060a3e6*9b0d1893678dea77f88bf66e6986adbc5a8095e4a09c7e9744bad42ac49133a7", "password"},
-	{"$keepass$*1*50000*124*f7465d646bab0a86197fcf2b778ea9c1*ec24a474b0745f9ff1de44ac3e0a274dda83375ecec45eb9ddc40b524fb51df2*f7f17dd2a15c4cf13fb4c8a504298fb3*e7765dba9ed64686a2c0b712de95bd0051a20b331ea0f77133e6afbb9faa1479*1*608*e5802225bf18755620355ad67efa87335532197ce45ee8374a5d23478557414b110426904671c49b266672c02e334c4261d52a9a0723d050329319f8d3b06a6d9507e5b30c78823beea101f52bde5ecdb6b6d0d2627fc254678416b39d2ba43ebce229c0b25f8c530975bc617be602d36e95a6e83c99c7264d5cc994af762460942830ac06b03d30c84c000d01061a938c274d78d383040c8cf5e69e7fbbaf6b46a7061399087f1db2747cd83afdb2b36e6077cecdc3b5c3b3f29f3a1ef537e8c798f8d614f9866a19a53b463aa81632e9aca43ebff9c787ca20a416a4051f16e4ececb84ea853fcc48a988e2d77cb385a2add3b858a18ee73783695a093628a0082d928ffeea39db585a478647e29395fdf2e3e8f54dc5b8277712d8cf5e8a266780944889fb46408b8afb614c3b8e7152b8cc865368d0ae000404234c11c8a77ebc521326683c00967a474cf82336afd1cb8f867db5f6cc7f5c9ae755c0fd0b4c9554ad26bef0b10f0c70978746090034e16922ee9cf38eb251515117cc62da3a62a6fd8a5dab0c10e857b2e2489d2521e1903d6b107c16fd1bf6565fc2953ea3206481ab6c466dba43777076c58ada7cb1883043f4747b2b80731476057598054ea9ec9de1645b4034f6569f579e70a021cc0a490dfa703def725846d0693d7cb02dea430905470db56663953b81b72f7543d6db7713afbcc91919b23cff80290a1053f34516c0b2c7a1f4bec1718994563ae188c2f65e20378537f88be2ebc6c47fbadabbd33414ffa30f115be0abdc89182e0a77d8d5c258d9ec5005415890218eb456fdcb79f1b15031289a0909fc6d8ae48ca6d2d699b6e0cd2e76462", "crackthis"},
-	{"$keepass$*1*50000*124*e144905f9aa746e1b2c382c807125d02*dd08f46898a3e75c458a44f34ec5391d3f3eb62b24dbda3d5e486e36312168cc*376ae8d5e8430d0a18e7bb4a0baddf75*5fa8dfc2f440ad296f1562683d06bf2717ae7e8ed343a279f54292f9fc8229ab*1*608*3ce1e03a1452e44b609ebe7326db4ef133ca25c325cc7cc5795ef92358011e2d32a1cb7cadc6f412b1d0a09f67f1444dfec73ed770507683360962d26b0c2b0384bcf9aba2cf1b3e4b5d7083ceaf5f941a2b99ec68d574eb58fe79e94d90b81c8f1f0ccfd35b16d415e8e203c06138eb6a1144520ef98bcdb33d669d2ab4aef2ab739e6dbc3f2ea5c6eef8410ca1555262181d8379b516551eb9d6a23eeb515bd8ef12735a635b25743c1188642486dd1fa4544138a361bcfc108f689bfb90f81d9808adcbd509f057cdbfd1cd31ee8b542956292f9bcca21fabeacc9ba96b335223103a72f94d9b04bcba9d74fada62e0d5bf2da142e413a373ea3c97ff1d50109532f5d041c5f77bea28cdea00388ab9dd3afc72bc266ff44c34221d751738545056e83d7558cf02ffc6f5a57163526ffff9a7de1c6276d4815a812c165ef0293bb951bcbc2cf389d20e188a6c24d1bc5322ee0bc6972b765fb199b28d6e14c3b795bd5d7d4f0672352dfed4870cf59480bab0f39f2a20ac162e8365b6e3dcb4a7fec1baafcb8c806726a777c7a5832a0d1c12568c2d9cad8dc04b1ce3506dbc1bf9663d625cfccb2d3c1cb6b96eee0f34e019b0145e903feed4683abe2568f2c0007c02c57b43f4ee585f9760d5b04c8581e25421b6b5bb370a5b48965b64584b1ed444ea52101af2b818b71eb0f9ae7942117273a3aff127641e17779580b48168c5575a8d843a87dee1088e0fde62bb2100e5b2e178daa463aeaeb1d4ff0544445aab09a7bdc684bd948f21112004dcc678e9c5f8cf8ba6113244b7c72d544f37cbc6baed6ddc76b9ccba6480abfb79a80dda4cdf7e218f396a749b4e5f", "password"},
-	/* CMIYC 2013 "pro" hard hash */
-	{"$keepass$*2*6000*222*a279e37c38b0124559a83fa452a0269d56dc4119a5866d18e76f1f3fd536d64d*7ec7a06bc975ea2ae7c8dcb99e826a308564849b6b25d858cbbc78475af3733f*d477c849bf2278b7a1f626c81e343553*e61db922e9b77a161e9b674ddadfb8c660d61b5f68d97a3b1596ae94cfa9d169*7c80c7db9de77f176e86ba11697152c4c8f182bdb8133ad1bca22e9ec5bc275b", "Sh4RK%nAD0*"},
-	/* twofish version 1 hash from http://openwall.info/wiki/john/sample-non-hashes#KeePass */
-	{"$keepass$*1*50000*1*1ff21bd79aa8e9c3f439281a4ce6a97b*cfbdb00057ee0c9e889ca9d93b069ab5ae19f78852bc21aae4f60d0d325e0034*c1a7e6138a49a2dcfb3a84afbc1d918b*a704f9d060f0de5a070155d1d5a8727da92f404242cb3aa2b9aa53a145f87474*1*608*c2d3d18e416af56788d1c3e4257da9ce6e5dcad4db012d7422d17b4527bbb2bb994d9db03907ae01cc1565f5fd0729b930c9ee352426c57de5dee7e941e1d6aedeaf2b0e6509819385de9b4dd6a09979b3edfa0959a7186c422031e426f18d295c55ac616aabeec99f89e696be1d585950ef16a94ae610f2449cc3964bb63ec6043ef36c89117bc78e99e5fbf083b48cb84f85a964e8a037018b3afc2cc55fbe7d74cbdb53d5a54bcd202a1d0a342dbf48a8f7a24264cde8d800a506bf134008b1d8d9b8dd80c19511d9f43b3c23b19eb4a7dcf584f80c49961f73dcba3d2d0390a39a683ddcc8771b49cc3c673ea0aa902d075e25bc814608e2e6d1d6218a6379fd677bc5daaa18b6f5a021d2f661338ca8cc3645dc6cddb860af222a5cdb59a5e2a2c1921203344ced4e2154446239f6c1af8c1bace8207e0f519ea9c08db2f5d0bde0416b09ef6c530213e648641ae56c9af9fbdcb0a286cc4de121655697b9eb00c0fd89ed7269c3859eca20e0c7b60be8d2a1323eb915139cf90c55f9cff01a5bdf757e09ee6d64c2de9aec8d3ea42feeb67caf51b9ba1a80b435e271fdb7f9144ca31e41671768b2c5e8adf70245fdf52005de418efbe2a156d19eeb2ed9e97a0ddb133d11bd8655356d9d3edbbdbf9d0db345b2eb2c1f550ce070f5b0f8f8e58a6ffd52ae8089627dc4a0dac4b4846349066bfa0d2f395d2cb3871e57e353d622e0904a9f54a3e4706797d95b34619f792c15ab8efb3ac523becc3023f01aaad169bc08db8d01e2dd22eff8f6b4f7b741d196bc3de466590011e6d5c9703a19c07d96d26fe1ad93d0931454730ee1f3146428a126d1ed02763f827ff4", "twofish"},
-	/* keyfile test cases*/
-    {"$keepass$*1*6000*0*1a1d38235ccbeae4ca2a9edfbd3b290c*8e1e81b37a6161b6033fbd6dd350aaeaa0712cf2649fe40e3fbbaa4b61684f54*d9517d352aea00c2b7f57f1154b9c0a0*0a8ae9b13347402c242d7cde4d58d01f1e129287eaf62df768856bbb9d0633a1*1*1360*6555a7e9eca9d5a2c9504a5c888846f0a8902fa31e3dc90f8fcc118856d5daabcaaf4316c4d589e11cce5b9a209e9a7ec1db5b848a706c78f7c7dfac4fd9ea86ac15af500518766dbf4525ee7c1b477a8fec4abdd6f4ad36894ec5aee0c9a5662c5091ceb61b3aa99ff3eacd687ed797b0a1e8ceecd5c51456cb1f70dadf0fda190752e4efe4fb101d5fc5d7745ff01d68cb4c0cc32c6003f85c310e43d7d659748bfc260cbb329c4076c2c9948386c74bb967362a98d6490dbe340f5d440b557b105edd5561836fbb6894f4a1d9a5cd0182536a28f60ca268d682065f8f5226e24a07d635a3c4f04760094cee033fb2f7c3a0cbdf7f174d31c827f6911a75ca95b21332bb47ea6359aa2d70ff4b16e8481cd536e0ec4ba90963edda754b6e0e694855e4f266899b3dd2b0f74c3e688caa376b22810945249ac4e1c38e8d1093ce272ed45d26037a1fd6e0cfcdbdf096c8b2795ba736641bafe9938b6eb2b40ea347f9c49952c118d86ec671c065e3c94f0de2409fec2fde318ad7e6dd0189baf4fa0044fc1d2974b9dafb1608f4bca525706e44ca6af09e305ad29f5e4ba0831145713d5d8b6d6d955c4b5ca031e34b4292aee5383179e1e0afe92ee6565e69825c90bb5e79612a4ad4a3babbd4a75b5481ea710c93595781b71532c17730409482e6b59bb9831be4efadadf36eda5bc5fcf0f3541aaba6662807e531a3e28078f5960e50f80e624c5434b545c1232fdd64359f53b90d6635107f4f005ac02110eebdbdda4f2c92addd686059e9d799a55902526f87f78b8844e2000f82e7b5c8ba3a19fe26117c43f69ba26eee75cc385737791ca4554ce935af26c50331963e500605e87ac3602a76669bf6318e797ef01fe1c25e567cc864de11bd00f555fdf188648bf4179658e325be39a4050b7b01553422e5cd1bbaf5e8f75ce34f0e92f1253c880d4e77f484f14817e288f01efbfe1a8f8b90e9d18b86898856bdf3ee6b5754853cb99a746fa0b753f1a49f529a89d9a0c2fbd5365477be829190dbf491bc886f66ae1bfe014a7e23a420f76a4a0d0d5ebcea51dc0021651a6cdbe5c89a7ae8bfdae2e30d404c31790c0aba8791793ce3072adf21e5a3c5b5e4f9cea82ebff5070e13f94300d5688523ba2a142ae8f82f6ef940e69beba1d665ab17a2ae471500fc48ded336b27450f08dfe07fa5e556963f035a01950f43b2f649bf7f552e9ee7154f5ffdec109fd5bdf0e879d044ef4b78e590ac769efcdd7dad74228872af966d2e8d976336de1ee4289e933288b5b0b43195df1c248176ac944f5e99918dbc067f93d15e95602c9cb8246f378377785b7ebfee44f81b385a3e1c9c5276e4b477c4841af871e6b0e3f4387c58cea01fe2aff04df0f51ac93757172d7537ee0df51ec931564ed2c8a11a45da8c03644d0bc93a14d9f79555250b9c8245690bc1c72ea7e9104a9f570680f704c1f8759a65e210e1b9a855b46ed6801354175b27fc288a7bc39a2003f4400c124ec41d7f54f67be99f778895d9c3e33623a346021215a369487457e78322dbd71a3d969b3e22dfea987ac93d5c4f8252142824f5a67e54a2b1b78ea928fbb63653e122555f6c76150f2541bdad6524f69964c91e9175406d0b824e175e63c7677d990341ee69c4ca9612a05e3bd2ed304c45cd97051aaf0b63c0d917af8d01723e215bb93f816b51d79e29e4e885b98f8ca8320443503c07e67b4d546f544ffced62ef7298a8ac6175f77c180900f638466cd15d6511d7b16992a8e0674563c02fe7776079ee92739bc142a1e601b3aaee284f6f828656e43e58b93bcfd5f69b6aa8c003788d1ae88f569f64402d64e18cb8ffc2268013fe4da9ba7da557da3e259623168b7fd57cf0e4c8327bae66e02bc12978725022ef4cc03b4021d3a*1*64*3a96fb77fbbbca7336ee699f17be31fde552191128553c6d89bfce4035dc0af0", "choupinette"},
-    {"$keepass$*2*6000*222*aa511591cb50394d044f31abb2febdb2788c9ee41d78a53f3efe0f83fdd64e81*7ceab79302a794cef818d9426e53a78458f82e72575967c4fb3788d4bc685874*1c5c1c0c475ee2f22bd56e9c75cfd67c*e7bf79115c83a0236260c71c17a816f9bd9288a683eb4b5e0d48666c66e97774*53f26838a293b392bfde1ad21b444b834cf5c02155a1378ac496653b2f3779ec*1*64*98df4f35fe74c031992d81a639305c4520f303fd1ca4bb09b53e33032b44c46a", "kukudanlaplace"},
-    // KDBX 3.x with ChaCha20
-    {"$keepass$*2*6000*2*e852737a797fb642a2814e5965aba3473644a56ea67998526ce5e6f0e256a56a*fb300459b1e8c52fefa8e72676b57563565475b1c1306c266a48ccc2010e6a94*03027f86819941d1d0f3f2f5*af0f6c5e4319e6c10fdb95f44ded70f3115ae7dc28ec83fd3676c92076505ded*e0ab7f438903eb91dd8bc13c52c5a1c02e34b107ae16710bc57858c8c85fecd0", "openwall"},
-    {NULL}
-};
-
-char (*keepass_key)[PLAINTEXT_LENGTH + 1];
+char (*keepass_key)[KEEPASS_PLAINTEXT_LENGTH + 1];
 keepass_salt_t *keepass_salt;
 
-int keepass_valid(char *ciphertext, struct fmt_main *self)
+// Iterations, or Argon2 t
+unsigned int keepass_cost_t(void *salt)
 {
-	char *ctcopy;
-	char *keeptr;
-	char *p;
-	long long algo;
-	int version, res, contentsize, extra;
+	keepass_salt_t *ksalt = salt;
 
-	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+	if (ksalt->kdf == 0)
+		return ksalt->key_transf_rounds;
+	else
+		return ksalt->t_cost;
+}
+
+// Argon2 m
+// 67108864 (64 MiB) in the "hash" means 65536 (KiB) as argument to argon2_hash()
+// and is the actual memory use per parallel calculation
+unsigned int keepass_cost_m(void *salt)
+{
+	keepass_salt_t *ksalt = salt;
+
+	if (ksalt->kdbx_ver < 4)
 		return 0;
-	ctcopy = xstrdup(ciphertext);
-	keeptr = ctcopy;
-	ctcopy += FORMAT_TAG_LEN;
-	if ((p = strtokm(ctcopy, "*")) == NULL)	/* version */
-		goto err;
-	version = atoi(p);
-	if (version != 1 && version != 2)
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* rounds */
-		goto err;
-	if (!isdec(p))
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* offset */
-		goto err;
-	if (!isdec(p))  /* this field contained file offsets in the past, this is hard to validate */
-		goto err;
-	algo = atoll(p);
-	if (algo < 0 || algo > 2)
-		algo = 0;
-	if (version == 1 && algo > 1) /* Unsupported combo */
-		goto err;
-	if (version == 2 && algo == 1) /* TODO, v2 w/ Twofish */
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* final random seed */
-		goto err;
-	res = hexlenl(p, &extra);
-	if (extra || (res != 32 && res != 64))
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* transf random seed */
-		goto err;
-	if (hexlenl(p, &extra) != 64 || extra)
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* env_iv */
-		goto err;
-	res = hexlenl(p, &extra);
-	if ((res != 32 && res != 24) || extra)
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* hash or expected bytes*/
-		goto err;
-	if (hexlenl(p, &extra) != 64 || extra)
-		goto err;
-	if (version == 1) {
-		if ((p = strtokm(NULL, "*")) == NULL)	/* inline flag */
-			goto err;
-		res = atoi(p);
-		if (res != 1)
-			goto err;
-		if ((p = strtokm(NULL, "*")) == NULL)	/* content size */
-			goto err;
-		contentsize = atoi(p);
-		if (contentsize > MAX_CONT_SIZE) {
-			static int warned;
-
-			if (!ldr_in_pot && warned < contentsize) {
-				fprintf(stderr,
-				        "%s: Input rejected due to larger size than compile-time limit.\n"
-				        "Bump MAX_CONT_SIZE in keepass_common.h to >= 0x%x, and rebuild\n",
-				        self->params.label, contentsize);
-				warned = contentsize;
-			}
-			goto err;
-		}
-		if ((p = strtokm(NULL, "*")) == NULL)	/* content */
-			goto err;
-		if (!contentsize || hexlenl(p, &extra) / 2 != contentsize || extra)
-			goto err;
-		p = strtokm(NULL, "*");
-		// keyfile handling
-		if (p) {
-			res = atoi(p);
-			if (res == 1) {
-				if ((p = strtokm(NULL, "*")) == NULL)
-					goto err;
-				res = atoi(p);
-				if ((p = strtokm(NULL, "*")) == NULL)
-					goto err;
-				if (res != 64 || strlen(p) != 64 || !ishexlc(p))
-					goto err;
-			}
-			else
-				goto err;
-		}
-	}
-	else {
-		if ((p = strtokm(NULL, "*")) == NULL)
-			/* content */
-			goto err;
-		if (hexlenl(p, &extra) != 64 || extra)
-			goto err;
-		p = strtokm(NULL, "*");
-		// keyfile handling
-		if (p) {
-			res = atoi(p);
-			if (res == 1) {
-				if ((p = strtokm(NULL, "*")) == NULL)
-					goto err;
-				res = atoi(p);
-				if ((p = strtokm(NULL, "*")) == NULL)
-					goto err;
-				if (res != 64 || strlen(p) != 64 || !ishexlc(p))
-					goto err;
-			}
-			else
-				goto err;
-		}
-	}
-
-	MEM_FREE(keeptr);
-	return 1;
-
-err:
-	MEM_FREE(keeptr);
-	return 0;
+	return ksalt->m_cost;
 }
 
-void *keepass_get_salt(char *ciphertext)
+// Argon2 p
+unsigned int keepass_cost_p(void *salt)
 {
-	char *ctcopy = xstrdup(ciphertext);
-	char *keeptr = ctcopy;
-	char *p;
-	int i;
-	static keepass_salt_t cs;
+	keepass_salt_t *ksalt = salt;
 
-	memset(&cs, 0, sizeof(cs));
-	ctcopy += FORMAT_TAG_LEN;	/* skip over "$keepass$*" */
-	p = strtokm(ctcopy, "*");
-	cs.version = atoi(p);
-	if (cs.version == 1) {
-		p = strtokm(NULL, "*");
-		cs.key_transf_rounds = atoi(p);
-		p = strtokm(NULL, "*");
-		// cs.offset = atoll(p); // Twofish handling hack!
-		cs.algorithm = atoll(p);
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 16; i++)
-			cs.final_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 32; i++)
-			cs.transf_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 16; i++)
-			cs.enc_iv[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 32; i++)
-			cs.contents_hash[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		cs.isinline = atoi(p);
-		if (cs.isinline == 1) {
-			p = strtokm(NULL, "*");
-			cs.contentsize = atoi(p);
-			p = strtokm(NULL, "*");
-			for (i = 0; i < cs.contentsize; i++)
-				cs.contents[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-					+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		}
-		p = strtokm(NULL, "*");
-		if (p) { /* keyfile handling */
-			p = strtokm(NULL, "*");
-			cs.keyfilesize = atoi(p);
-			p = strtokm(NULL, "*");
-			for (i = 0; i < 32; i++)
-				cs.keyfile[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-					+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-			cs.have_keyfile = 1;
-		}
-	}
-	else {
-		p = strtokm(NULL, "*");
-		cs.key_transf_rounds = atoi(p);
-		p = strtokm(NULL, "*");
-		// cs.offset = atoll(p);  // Twofish handling hack
-		cs.algorithm = atoll(p);
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 32; i++)
-			cs.final_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 32; i++)
-			cs.transf_randomseed[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 16; i++)
-			cs.enc_iv[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 32; i++)
-			cs.expected_bytes[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		for (i = 0; i < 32; i++)
-			cs.contents[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		if (p) { /* keyfile handling */
-			p = strtokm(NULL, "*");
-			cs.keyfilesize = atoi(p);
-			p = strtokm(NULL, "*");
-			for (i = 0; i < 32; i++)
-				cs.keyfile[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-					+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-			cs.have_keyfile = 1;
-		}
-	}
-	MEM_FREE(keeptr);
-
-	if (cs.algorithm != 0 && cs.algorithm != 1 && cs.algorithm != 2)  // offset hijacking!
-		cs.algorithm = 0;  // AES
-
-	return (void *)&cs;
+	if (ksalt->kdbx_ver < 4)
+		return 0;
+	return ksalt->lanes;
 }
 
-void keepass_set_key(char *key, int index)
+// 0=Argon2d 2=Argon2id 3=AES
+unsigned int keepass_kdf(void *salt)
 {
-	strnzcpy(keepass_key[index], key, PLAINTEXT_LENGTH + 1);
-}
+	keepass_salt_t *ksalt = salt;
 
-char *keepass_get_key(int index)
-{
-	return keepass_key[index];
-}
-
-unsigned int keepass_iteration_count(void *salt)
-{
-	keepass_salt_t *my_salt = salt;
-
-	return (unsigned int)my_salt->key_transf_rounds;
-}
-
-/*
- * The version shouldn't have a significant impact
- * on performance. Nevertless, report it as the 2nd
- * "tunable cost".
- */
-unsigned int keepass_version(void *salt)
-{
-	keepass_salt_t *my_salt = salt;
-
-	return (unsigned int)my_salt->version;
-}
-
-unsigned int keepass_algorithm(void *salt)
-{
-	keepass_salt_t *my_salt = salt;
-
-	return (unsigned int)my_salt->algorithm;
+	if (ksalt->kdf == 0)
+		return 3;
+	else
+		return ksalt->type;
 }

--- a/src/keepass_fmt_plug.c
+++ b/src/keepass_fmt_plug.c
@@ -9,10 +9,10 @@
  * added by Fist0urs <eddy.maaalou at gmail.com>
  *
  * This software is
- * Copyright (c) 2012 Dhiru Kholia <dhiru.kholia at gmail.com>,
- * Copyright (c) 2014 m3g9tr0n (Spiros Fraganastasis),
+ * Copyright (c) 2017-2024 magnum,
  * Copyright (c) 2016 Fist0urs <eddy.maaalou at gmail.com>, and
- * Copyright (c) 2017 magnum,
+ * Copyright (c) 2014 m3g9tr0n (Spiros Fraganastasis),
+ * Copyright (c) 2012 Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -29,6 +29,11 @@ john_register_one(&fmt_KeePass);
 
 #ifdef _OPENMP
 #include <omp.h>
+#define THREAD_NUMBER omp_get_thread_num()
+#define NUM_THREADS   omp_get_max_threads()
+#else
+#define THREAD_NUMBER 0
+#define NUM_THREADS   1
 #endif
 
 #include "arch.h"
@@ -37,105 +42,129 @@ john_register_one(&fmt_KeePass);
 #include "formats.h"
 #include "params.h"
 #include "options.h"
-#include "keepass_common.h"
 #include "sha2.h"
 #include "aes.h"
 #include "twofish.h"
 #include "chacha.h"
+#include "hmac_sha.h"
+#include "argon2.h"
+
+#define KEEPASS_AES                     1
+#define KEEPASS_ARGON2                  1
+#define KEEPASS_REAL_COST_TEST_VECTORS  0
+#include "keepass_common.h"
 
 #ifndef OMP_SCALE
-#define OMP_SCALE               4 // This and MKPC tuned for core i7
+#define OMP_SCALE               1
 #endif
 
 #define FORMAT_LABEL            "KeePass"
 #define FORMAT_NAME             ""
-#define ALGORITHM_NAME          "SHA256 AES 32/" ARCH_BITS_STR
+#if !defined (JOHN_NO_SIMD) && defined(__AVX512F__)
+#define ALGORITHM_NAME          "AES/Argon2 512/512 AVX512F"
+#elif !defined (JOHN_NO_SIMD) && defined(__AVX2__)
+#define ALGORITHM_NAME          "AES/Argon2 256/256 AVX2"
+#elif !defined (JOHN_NO_SIMD) && defined(__XOP__)
+#define ALGORITHM_NAME          "AES/Argon2 128/128 XOP"
+#elif !defined (JOHN_NO_SIMD) && defined(__SSE2__)
+#define ALGORITHM_NAME          "AES/Argon2 128/128 SSE2"
+#else
+#define ALGORITHM_NAME          "AES/Argon2 32/" ARCH_BITS_STR
+#endif
+
+struct argon2_memory {
+	region_t region;
+	int used;
+	char padding[MEM_ALIGN_CACHE - sizeof(region_t) - sizeof(int)];
+};
+
+static struct argon2_memory *thread_mem;
 
 static keepass_salt_t *cur_salt;
 static int any_cracked, *cracked;
 static size_t cracked_size;
 
-// GenerateKey32 from CompositeKey.cs
-static void transform_key(char *masterkey, keepass_salt_t *csp,
-                          unsigned char *final_key)
-{
-	SHA256_CTX ctx;
-	unsigned char hash[32];
-	int i;
-	AES_KEY akey;
-
-	// First, hash the masterkey
-	SHA256_Init(&ctx);
-	SHA256_Update(&ctx, masterkey, strlen(masterkey));
-	SHA256_Final(hash, &ctx);
-
-	if (csp->version == 2 && cur_salt->have_keyfile == 0) {
-		SHA256_Init(&ctx);
-		SHA256_Update(&ctx, hash, 32);
-		SHA256_Final(hash, &ctx);
-	}
-
-	if (cur_salt->have_keyfile) {
-		SHA256_Init(&ctx);
-		SHA256_Update(&ctx, hash, 32);
-		SHA256_Update(&ctx, cur_salt->keyfile, 32);
-		SHA256_Final(hash, &ctx);
-	}
-
-	// Next, encrypt the created hash
-	AES_set_encrypt_key(csp->transf_randomseed, 256, &akey);
-	i = csp->key_transf_rounds >> 2;
-	while (i--) {
-		AES_encrypt(hash, hash, &akey);
-		AES_encrypt(hash, hash, &akey);
-		AES_encrypt(hash, hash, &akey);
-		AES_encrypt(hash, hash, &akey);
-		AES_encrypt(hash+16, hash+16, &akey);
-		AES_encrypt(hash+16, hash+16, &akey);
-		AES_encrypt(hash+16, hash+16, &akey);
-		AES_encrypt(hash+16, hash+16, &akey);
-	}
-	i = csp->key_transf_rounds & 3;
-	while (i--) {
-		AES_encrypt(hash, hash, &akey);
-		AES_encrypt(hash+16, hash+16, &akey);
-	}
-
-	// Finally, hash it again...
-	SHA256_Init(&ctx);
-	SHA256_Update(&ctx, hash, 32);
-	SHA256_Final(hash, &ctx);
-
-	// ...and hash the result together with the random seed
-	SHA256_Init(&ctx);
-	if (csp->version == 1) {
-		SHA256_Update(&ctx, csp->final_randomseed, 16);
-	}
-	else {
-		SHA256_Update(&ctx, csp->final_randomseed, 32);
-	}
-	SHA256_Update(&ctx, hash, 32);
-	SHA256_Final(final_key, &ctx);
-}
-
 static void init(struct fmt_main *self)
 {
+	int i;
 
 	omp_autotune(self, OMP_SCALE);
 
-	keepass_key = mem_calloc(self->params.max_keys_per_crypt,
-				sizeof(*keepass_key));
-	any_cracked = 0;
+	thread_mem = mem_calloc(NUM_THREADS, sizeof(struct argon2_memory));
+	keepass_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*keepass_key));
 	cracked_size = sizeof(*cracked) * self->params.max_keys_per_crypt;
 	cracked = mem_calloc(cracked_size, 1);
+	any_cracked = 0;
+
+	for (i = 0; i < NUM_THREADS; i++)
+		init_region_t(&thread_mem[i].region);
 
 	Twofish_initialise();
 }
 
 static void done(void)
 {
+	int i;
+
 	MEM_FREE(cracked);
 	MEM_FREE(keepass_key);
+	for (i = 0; i < NUM_THREADS; i++)
+		free_region_t(&thread_mem[i].region);
+	MEM_FREE(thread_mem);
+}
+
+static int allocate(uint8_t **memory, size_t size)
+{
+	if (THREAD_NUMBER < 0 || THREAD_NUMBER > NUM_THREADS) {
+		fprintf(stderr, "Error: KeePass: Thread number %d out of range\n", THREAD_NUMBER);
+		goto fail;
+	}
+	if (thread_mem[THREAD_NUMBER].used) {
+		fprintf(stderr, "Error: KeePass: Thread %d: Memory allocated twice\n", THREAD_NUMBER);
+		goto fail;
+	}
+
+	if (thread_mem[THREAD_NUMBER].region.aligned_size < size) {
+		if (free_region_t(&thread_mem[THREAD_NUMBER].region) ||
+		    !alloc_region_t(&thread_mem[THREAD_NUMBER].region, size))
+			goto fail;
+	}
+
+	thread_mem[THREAD_NUMBER].used = 1;
+	*memory = thread_mem[THREAD_NUMBER].region.aligned;
+
+	return 0;
+
+fail:
+	*memory = NULL;
+	return -1;
+}
+
+static void deallocate(uint8_t *memory, size_t size)
+{
+	if (THREAD_NUMBER < 0 || THREAD_NUMBER > NUM_THREADS) {
+		fprintf(stderr, "Error: KeePass: Thread number %d out of range\n", THREAD_NUMBER);
+		return;
+	}
+
+	if (!thread_mem[THREAD_NUMBER].used)
+		fprintf(stderr, "Error: KeePass: Thread %d: Freed memory not in use\n", THREAD_NUMBER);
+
+	if (thread_mem[THREAD_NUMBER].region.aligned_size < size)
+		fprintf(stderr, "Error: KeePass: Thread %d: Freeing incorrect size %zu, was %zu\n",
+		    THREAD_NUMBER, size, thread_mem[THREAD_NUMBER].region.aligned_size);
+
+	thread_mem[THREAD_NUMBER].used = 0;
+}
+
+static void set_key(char *key, int index)
+{
+	strnzcpy(keepass_key[index], key, KEEPASS_PLAINTEXT_LENGTH + 1);
+}
+
+static char *get_key(int index)
+{
+	return keepass_key[index];
 }
 
 static void set_salt(void *salt)
@@ -143,9 +172,111 @@ static void set_salt(void *salt)
 	cur_salt = (keepass_salt_t*)salt;
 }
 
+// GenerateKey32 from CompositeKey.cs
+static int transform_key(char *masterkey, unsigned char *final_key)
+{
+	SHA256_CTX ctx;
+	unsigned char hash[32];
+	int ret = 0;
+
+	// First, hash the masterkey
+	SHA256_Init(&ctx);
+	SHA256_Update(&ctx, masterkey, strlen(masterkey));
+	SHA256_Final(hash, &ctx);
+
+	// Add the keyfile, hash again to get the composite key
+	if (cur_salt->have_keyfile) {
+		SHA256_Init(&ctx);
+		SHA256_Update(&ctx, hash, 32);
+		SHA256_Update(&ctx, cur_salt->keyfile, 32);
+		SHA256_Final(hash, &ctx);
+	} else if (cur_salt->kdbx_ver > 1) {
+		SHA256_Init(&ctx);
+		SHA256_Update(&ctx, hash, 32);
+		SHA256_Final(hash, &ctx);
+	}
+
+	// Next, encrypt the composite key to get the transformed key (only for AES-KDF)
+	if (cur_salt->kdf == 0) {
+		AES_KEY akey;
+		AES_set_encrypt_key(cur_salt->transf_randomseed, 256, &akey);
+
+		unsigned int rounds = cur_salt->key_transf_rounds;
+		while (rounds--) {
+			AES_encrypt(hash, hash, &akey);
+			AES_encrypt(hash+16, hash+16, &akey);
+		}
+
+		// Finally, hash it again to get the master key
+		SHA256_Init(&ctx);
+		SHA256_Update(&ctx, hash, 32);
+		SHA256_Final(final_key, &ctx);
+
+		if (cur_salt->kdbx_ver < 4) {
+			// ...and hash the result together with the random seed
+			SHA256_Init(&ctx);
+			if (cur_salt->kdbx_ver == 1)
+				SHA256_Update(&ctx, cur_salt->final_randomseed, 16);
+			else
+				SHA256_Update(&ctx, cur_salt->final_randomseed, 32);
+			SHA256_Update(&ctx, final_key, 32);
+			SHA256_Final(final_key, &ctx);
+		}
+	} else if (cur_salt->kdf == 1) { // Argon2
+		argon2_error_codes error_code;
+		argon2_context context = {
+			.out = (uint8_t*)final_key,
+			.outlen = 32,
+			.pwd = (uint8_t*)hash,
+			.pwdlen = 32,
+			.salt = (uint8_t*)cur_salt->transf_randomseed,
+			.saltlen = 32,
+			.t_cost = cur_salt->t_cost,
+			.m_cost = cur_salt->m_cost,
+			.lanes = cur_salt->lanes,
+			.threads = cur_salt->lanes,
+			.allocate_cbk = &allocate,
+			.free_cbk = &deallocate,
+			.flags = ARGON2_DEFAULT_FLAGS,
+			.version = ARGON2_VERSION_13
+		};
+		error_code = argon2_ctx(&context, cur_salt->type);
+		if (error_code != ARGON2_OK) {
+			ret = -1;
+			fprintf(stderr, "Error: Keepass: Argon2 failed: %s\n",
+			        argon2_error_message(error_code));
+		}
+	}
+
+	return ret;
+}
+
+static void hmacBaseKey(const void *master_seed, const void *finalKey, void *result)
+{
+	SHA512_CTX ctx;
+
+	SHA512_Init(&ctx);
+	SHA512_Update(&ctx, master_seed, 32);
+	SHA512_Update(&ctx, finalKey, 32);
+	SHA512_Update(&ctx, "\x01", 1);
+	SHA512_Final(result, &ctx);
+}
+
+static void hmacKey(uint64_t blockIndex, const void *basekey, void *result)
+{
+	const void *indexBytes = &blockIndex;
+	SHA512_CTX ctx;
+
+	SHA512_Init(&ctx);
+	SHA512_Update(&ctx, indexBytes, sizeof(uint64_t));
+	SHA512_Update(&ctx, basekey, 64);
+	SHA512_Final(result, &ctx);
+}
+
 static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
+	int failed = 0;
 	int index = 0;
 
 	if (any_cracked) {
@@ -158,88 +289,67 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 #endif
 	for (index = 0; index < count; index++) {
 		unsigned char final_key[32];
-		unsigned char *decrypted_content;
-		SHA256_CTX ctx;
-		unsigned char iv[16];
-		unsigned char out[32];
-		int pad_byte;
-		int datasize;
-		AES_KEY akey;
-		Twofish_key tkey;
-		struct chacha_ctx ckey;
 
 		// derive and set decryption key
-		transform_key(keepass_key[index], cur_salt, final_key);
-		if (cur_salt->algorithm == 0) {
-			/* AES decrypt cur_salt->contents with final_key */
-			memcpy(iv, cur_salt->enc_iv, 16);
-			AES_set_decrypt_key(final_key, 256, &akey);
-		} else if (cur_salt->algorithm == 1) {
-			memcpy(iv, cur_salt->enc_iv, 16);
-			memset(&tkey, 0, sizeof(Twofish_key));
-			Twofish_prepare_key(final_key, 32, &tkey);
-		} else if (cur_salt->algorithm == 2) { // ChaCha20
-			memcpy(iv, cur_salt->enc_iv, 16);
-			chacha_keysetup(&ckey, final_key, 256);
-			chacha_ivsetup(&ckey, iv, NULL, 12);
+		if (transform_key(keepass_key[index], final_key)) {
+			failed = -1;
+#ifndef _OPENMP
+			break;
+#endif
 		}
 
-		if (cur_salt->version == 1 && cur_salt->algorithm == 0) {
-			decrypted_content = mem_alloc(cur_salt->contentsize);
-			AES_cbc_encrypt(cur_salt->contents, decrypted_content,
-			                cur_salt->contentsize, &akey, iv, AES_DECRYPT);
-			pad_byte = decrypted_content[cur_salt->contentsize - 1];
-			datasize = cur_salt->contentsize - pad_byte;
-			SHA256_Init(&ctx);
-			SHA256_Update(&ctx, decrypted_content, datasize);
-			SHA256_Final(out, &ctx);
-			MEM_FREE(decrypted_content);
-			if (!memcmp(out, cur_salt->contents_hash, 32)) {
+		if (cur_salt->kdbx_ver == 4) {
+			uint8_t hmac_base_key[64];
+			hmacBaseKey(cur_salt->master_seed, final_key, hmac_base_key);
+
+			uint8_t hmac_key[64];
+			hmacKey(UINT64_MAX, hmac_base_key, hmac_key);
+
+			uint8_t calc_hmac[32];
+			hmac_sha256(hmac_key, 64, cur_salt->header, cur_salt->header_size, calc_hmac, 32);
+
+			if (!memcmp(cur_salt->header_hmac, calc_hmac, 32)) {
 				cracked[index] = 1;
 #ifdef _OPENMP
 #pragma omp atomic
 #endif
 				any_cracked |= 1;
 			}
-		}
-		else if (cur_salt->version == 2 && cur_salt->algorithm == 0) {
-			unsigned char dec_buf[32];
+		} else {
+			unsigned char *decrypted_content;
+			SHA256_CTX ctx;
+			unsigned char iv[16];
+			unsigned char out[32];
+			int pad_byte;
+			int datasize;
+			AES_KEY akey;
+			Twofish_key tkey;
+			struct chacha_ctx ckey;
 
-			AES_cbc_encrypt(cur_salt->contents, dec_buf, 32,
-			                &akey, iv, AES_DECRYPT);
-			if (!memcmp(dec_buf, cur_salt->expected_bytes, 32)) {
-				cracked[index] = 1;
-#ifdef _OPENMP
-#pragma omp atomic
-#endif
-				any_cracked |= 1;
+			if (cur_salt->cipher == 0) {
+				/* AES decrypt cur_salt->contents with final_key */
+				memcpy(iv, cur_salt->enc_iv, 16);
+				AES_set_decrypt_key(final_key, 256, &akey);
+			} else if (cur_salt->cipher == 1) {
+				memcpy(iv, cur_salt->enc_iv, 16);
+				memset(&tkey, 0, sizeof(Twofish_key));
+				Twofish_prepare_key(final_key, 32, &tkey);
+			} else if (cur_salt->cipher == 2) { // ChaCha20
+				memcpy(iv, cur_salt->enc_iv, 16);
+				chacha_keysetup(&ckey, final_key, 256);
+				chacha_ivsetup(&ckey, iv, NULL, 12);
 			}
-		}
-		else if (cur_salt->version == 2 && cur_salt->algorithm == 2) {
-			unsigned char dec_buf[32];
 
-			chacha_decrypt_bytes(&ckey, cur_salt->contents, dec_buf, 32, 20);
-			if (!memcmp(dec_buf, cur_salt->expected_bytes, 32)) {
-				cracked[index] = 1;
-#ifdef _OPENMP
-#pragma omp atomic
-#endif
-				any_cracked |= 1;
-			}
-
-		}
-		else if (cur_salt->version == 1 && cur_salt->algorithm == 1) { /* KeePass 1.x with Twofish */
-			int crypto_size;
-
-			decrypted_content = mem_alloc(cur_salt->contentsize);
-			crypto_size = Twofish_Decrypt(&tkey, cur_salt->contents,
-			                              decrypted_content,
-			                              cur_salt->contentsize, iv);
-			datasize = crypto_size;  // awesome, right?
-			if (datasize <= cur_salt->contentsize && datasize > 0) {
+			if (cur_salt->kdbx_ver == 1 && cur_salt->cipher == 0) {
+				decrypted_content = mem_alloc(cur_salt->content_size);
+				AES_cbc_encrypt(cur_salt->contents, decrypted_content,
+				                cur_salt->content_size, &akey, iv, AES_DECRYPT);
+				pad_byte = decrypted_content[cur_salt->content_size - 1];
+				datasize = cur_salt->content_size - pad_byte;
 				SHA256_Init(&ctx);
 				SHA256_Update(&ctx, decrypted_content, datasize);
 				SHA256_Final(out, &ctx);
+				MEM_FREE(decrypted_content);
 				if (!memcmp(out, cur_salt->contents_hash, 32)) {
 					cracked[index] = 1;
 #ifdef _OPENMP
@@ -248,12 +358,62 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 					any_cracked |= 1;
 				}
 			}
-			MEM_FREE(decrypted_content);
-		} else {
-			// KeePass version 2 with Twofish is TODO. Twofish support under KeePass version 2
-			// requires a third-party plugin. See http://keepass.info/plugins.html for details.
-			error_msg("KeePass v2 w/ Twofish not supported yet");
+			else if (cur_salt->kdbx_ver == 2 && cur_salt->cipher == 0) {
+				unsigned char dec_buf[32];
+
+				AES_cbc_encrypt(cur_salt->contents, dec_buf, 32,
+				                &akey, iv, AES_DECRYPT);
+				if (!memcmp(dec_buf, cur_salt->expected_bytes, 32)) {
+					cracked[index] = 1;
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+					any_cracked |= 1;
+				}
+			}
+			else if (cur_salt->kdbx_ver == 2 && cur_salt->cipher == 2) {
+				unsigned char dec_buf[32];
+
+				chacha_decrypt_bytes(&ckey, cur_salt->contents, dec_buf, 32, 20);
+				if (!memcmp(dec_buf, cur_salt->expected_bytes, 32)) {
+					cracked[index] = 1;
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+					any_cracked |= 1;
+				}
+
+			}
+			else { //if (cur_salt->kdbx_ver == 1 && cur_salt->cipher == 1)
+				/* KeePass 1.x with Twofish */
+				int crypto_size;
+
+				decrypted_content = mem_alloc(cur_salt->content_size);
+				crypto_size = Twofish_Decrypt(&tkey, cur_salt->contents,
+				                              decrypted_content,
+				                              cur_salt->content_size, iv);
+				datasize = crypto_size;  // awesome, right?
+				if (datasize <= cur_salt->content_size && datasize > 0) {
+					SHA256_Init(&ctx);
+					SHA256_Update(&ctx, decrypted_content, datasize);
+					SHA256_Final(out, &ctx);
+					if (!memcmp(out, cur_salt->contents_hash, 32)) {
+						cracked[index] = 1;
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+						any_cracked |= 1;
+					}
+				}
+				MEM_FREE(decrypted_content);
+			}
 		}
+	}
+	if (failed) {
+#ifdef _OPENMP
+		fprintf(stderr, "Error: Keepass: Argon2 failed in some threads\n");
+#endif
+		error();
 	}
 	return count;
 }
@@ -278,23 +438,24 @@ struct fmt_main fmt_KeePass = {
 		FORMAT_LABEL,
 		FORMAT_NAME,
 		ALGORITHM_NAME,
-		BENCHMARK_COMMENT,
-		BENCHMARK_LENGTH,
+		KEEPASS_BENCHMARK_COMMENT,
+		KEEPASS_BENCHMARK_LENGTH,
 		0,
-		PLAINTEXT_LENGTH,
-		BINARY_SIZE,
-		BINARY_ALIGN,
-		SALT_SIZE,
-		SALT_ALIGN,
-		MIN_KEYS_PER_CRYPT,
-		MAX_KEYS_PER_CRYPT,
+		KEEPASS_PLAINTEXT_LENGTH,
+		KEEPASS_BINARY_SIZE,
+		KEEPASS_BINARY_ALIGN,
+		KEEPASS_SALT_SIZE,
+		KEEPASS_SALT_ALIGN,
+		KEEPASS_MIN_KEYS_PER_CRYPT,
+		KEEPASS_MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
 		{
-			"iteration count",
-			"version",
-			"algorithm [0=AES 1=TwoFish 2=ChaCha]",
+			"t (rounds)",
+			"m",
+			"p",
+			"KDF [0=Argon2d 2=Argon2id 3=AES]",
 		},
-		{ FORMAT_TAG },
+		{ KEEPASS_FORMAT_TAG },
 		keepass_tests
 	}, {
 		init,
@@ -306,9 +467,10 @@ struct fmt_main fmt_KeePass = {
 		fmt_default_binary,
 		keepass_get_salt,
 		{
-			keepass_iteration_count,
-			keepass_version,
-			keepass_algorithm,
+			keepass_cost_t,
+			keepass_cost_m,
+			keepass_cost_p,
+			keepass_kdf,
 		},
 		fmt_default_source,
 		{
@@ -317,8 +479,8 @@ struct fmt_main fmt_KeePass = {
 		fmt_default_salt_hash,
 		NULL,
 		set_salt,
-		keepass_set_key,
-		keepass_get_key,
+		set_key,
+		get_key,
 		fmt_default_clear_keys,
 		crypt_all,
 		{

--- a/src/opencl_argon2_fmt_plug.c
+++ b/src/opencl_argon2_fmt_plug.c
@@ -227,6 +227,7 @@ static int run_kernel_on_gpu(uint32_t count)
 			HANDLE_CLERROR(clSetKernelArg(kernels[selected_type], 5, sizeof(slice), &slice), "Error setting kernel argument");
 			BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], kernels[selected_type], 2, NULL, global_range, local_range, 0, NULL, NULL), "Run loop kernel");
 			HANDLE_CLERROR(clFlush(queue[gpu_id]), "clFlush");
+			opencl_process_event();
 		}
 	} else { // Argon2_d || Argon2_i
 		// Find the autotune params
@@ -255,6 +256,7 @@ static int run_kernel_on_gpu(uint32_t count)
 			HANDLE_CLERROR(clSetKernelArg(kernels[argon2_type], 5, sizeof(slice), &slice), "Error setting kernel argument");
 			BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], kernels[argon2_type], 2, NULL, global_range, local_range, 0, NULL, NULL), "Run loop kernel");
 			HANDLE_CLERROR(clFlush(queue[gpu_id]), "clFlush");
+			opencl_process_event();
 		}
 	}
 

--- a/src/opencl_helper_macros.h
+++ b/src/opencl_helper_macros.h
@@ -1,0 +1,100 @@
+/*
+ * This software is Copyright (c) 2024 magnum and it is hereby released to the
+ * general public under the following terms:  Redistribution and use in source
+ * and binary forms, with or without modification, are permitted.
+ */
+#ifndef OPENCL_HELPER_MACROS_H
+#define OPENCL_HELPER_MACROS_H
+
+#define CL_RO    CL_MEM_READ_ONLY
+#define CL_WO    CL_MEM_WRITE_ONLY
+#define CL_RW    CL_MEM_READ_WRITE
+#define CL_ALLOC CL_MEM_ALLOC_HOST_PTR
+#define CL_COPY  CL_MEM_COPY_HOST_PTR
+
+/*
+ * This creates a pinned (non pageable, can't be swapped) buffer, ensuring
+ * fastest possible DMA transfer.  When not using pinned memory, an extra
+ * step will happen in the background, where your (pageable) buffer is first
+ * transfered to a temporary pinned buffer, then to GPU by means of DMA. When
+ * your buffer is already using pinned memory, the extra step doesn't occur.
+ *
+ * It assumes you have defined three buffer variables with the same base
+ * name. Example:
+ *
+ * unsigned char *data_blob;
+ * cl_mem pinned_data_blob, cl_data_blob;
+ * CLCREATEPINNED(data_blob, CL_RO, gws * some_size);
+ * (...)
+ * CLKERNELARG(crypt_kernel, 0, cl_data_blob);
+ * (...)
+ * CLWRITE(cl_data_blob, FALSE, 0, gws * some_size, data_blob, NULL);
+ *
+ * If the buffer can't be pinned, we silently fallback to a normal buffer.
+ */
+#define CLCREATEPINNED(var, flags, size)	  \
+	do { \
+		pinned_##var = clCreateBuffer(context[gpu_id], flags | CL_ALLOC, size, NULL, &ret_code); \
+		if (ret_code != CL_SUCCESS) { \
+			var = mem_alloc(size); \
+			if (var == NULL) \
+				HANDLE_CLERROR(ret_code, "Error allocating pinned buffer"); \
+		} else { \
+			var = clEnqueueMapBuffer(queue[gpu_id], pinned_##var, CL_TRUE, \
+			                         CL_MAP_READ | CL_MAP_WRITE, 0, size, 0, NULL, NULL, &ret_code); \
+			HANDLE_CLERROR(ret_code, "Error mapping buffer"); \
+			cl_##var = clCreateBuffer(context[gpu_id], flags, size, NULL, &ret_code); \
+			HANDLE_CLERROR(ret_code, "Error creating device buffer"); \
+		} \
+	} while(0)
+
+#define CLCREATEBUFFER(var, flags, size)	  \
+	do { var = clCreateBuffer(context[gpu_id], flags, size, NULL, &ret_code); \
+		HANDLE_CLERROR(ret_code, "Error allocating GPU memory"); } while(0)
+
+#define CLCREATEBUFCOPY(var, flags, size, _hostbuf)	  \
+	do { var = clCreateBuffer(context[gpu_id], flags | CL_COPY, size, _hostbuf, &ret_code); \
+		HANDLE_CLERROR(ret_code, "Error copying host pointer for GPU"); } while(0)
+
+#define CLKERNELARG(kernel, id, arg)	  \
+	HANDLE_CLERROR(clSetKernelArg(kernel, id, sizeof(arg), &arg), \
+	               "Error setting kernel argument")
+
+#define CLKRNARGLOC(kernel, id, arg)	  \
+	HANDLE_CLERROR(clSetKernelArg(kernel, id, sizeof(arg), NULL), \
+	               "Error setting kernel argument for local memory")
+
+#define CLWRITE(gpu_var, wait, offset, size, host_var, event)	  \
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], gpu_var, wait, offset, size, host_var, 0, NULL, event), \
+	               "Failed writing buffer")
+
+#define CLWRITE_CRYPT(gpu_var, wait, offset, size, host_var, event)	  \
+	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], gpu_var, wait, offset, size, host_var, 0, NULL, event), \
+	              "Failed writing buffer")
+
+#define CLREAD_CRYPT(gpu_var, wait, offset, size, host_var, event)	  \
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], gpu_var, wait, offset, size, host_var, 0, NULL, event),\
+	              "failed reading buffer")
+
+#define RELEASEPINNED(var)	  \
+	do { \
+		if (pinned_##var) { \
+			HANDLE_CLERROR(clEnqueueUnmapMemObject(queue[gpu_id], pinned_##var, var, 0, NULL, NULL), \
+			               "Error Unmapping buffer"); \
+			HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error releasing memory mapping"); var = NULL; \
+		} else \
+			MEM_FREE(var); \
+		HANDLE_CLERROR(clReleaseMemObject(pinned_##var), "Error releasing pinned buffer"); \
+		pinned_##var = NULL; \
+		HANDLE_CLERROR(clReleaseMemObject(cl_##var), "Error releasing buffer"); \
+		cl_##var = NULL; \
+	} while(0);
+
+#define RELEASEBUFFER(var)	\
+	do { HANDLE_CLERROR(clReleaseMemObject(var), "Release buffer"); var = NULL; } while(0)
+
+#define CREATEKERNEL(kernel, name)	  \
+	do { kernel = clCreateKernel(program[gpu_id], name, &ret_code); \
+		HANDLE_CLERROR(ret_code, name); } while(0);
+
+#endif	/* OPENCL_HELPER_MACROS_H */


### PR DESCRIPTION
Including KDBX4 updates to keepass2john.

Keepass-opencl now supports KDBX4 but only with AES. A new separate keepass-argon2-opencl format now lives within the argon2-opencl source file.

Keepass default costs are now hard. The new KeePass test vectors are made with lower-than-default costs (even for KDBX4/AES, which now has to AES-encrypt about a gigabyte with default settings).