### PR TITLE
AES-NI build bug fix for gcc version check, and KeePass alloc/free

### DIFF
--- a/.ci/install-dependencies.sh
+++ b/.ci/install-dependencies.sh
@@ -78,7 +78,7 @@ case "$CC" in
 		esac
 		;;
 	clang*)
-		apt_get_install $packages "$CC"
+		apt_get_install $packages "$CC" yasm
 		;;
 	*)
 		apt_get_install $packages

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -71,6 +71,20 @@ LDFLAGS = -g @LDFLAGS@ $(LIBS) @HAVE_MPI@
 OPT_NORMAL = @OPT_NORMAL_FLAGS@
 OPT_INLINE = @OPT_INLINE_FLAGS@
 #
+AES_OK := $(shell expr `$(CC) -dumpversion | cut -d '.' -f 1` \>= 4)
+YASM = @YASM@
+USE_AESNI = @AESNI_OS@
+AESNI_ARCH=@AESNI_ARCH@
+
+ifeq "$(AES_OK)" "1"
+	ifneq "$(YASM)" ""
+		ifdef USE_AESNI
+			ifdef AESNI_ARCH
+				AESNI_DEC = -DAESNI_IN_USE
+			endif
+		endif
+	endif
+endif
 
 PLUGFORMATS_OBJS = @PLUGFORMATS_OBJS@
 
@@ -746,7 +760,7 @@ unrarppm.o:	unrarppm.c arch.h aes.h autoconfig.h aes/aes_func.h unrar.h unrarhlp
 	$(CC) -DAC_BUILT $(CFLAGS) $< -o $@
 
 .c.o:
-	$(CC) $(CFLAGS) $(OPT_NORMAL) $< -o $@
+	$(CC) $(CFLAGS) $(OPT_NORMAL) $(AESNI_DEC) $< -o $@
 
 .S.o:
 	$(AS) $(ASFLAGS) $*.S

--- a/src/aes/Makefile.in
+++ b/src/aes/Makefile.in
@@ -11,7 +11,7 @@ YASM = @YASM@
 AR = @AR@
 FIND = @FIND@
 RM = /bin/rm -f
-GCCV44 := $(shell expr `$(CC) -dumpversion` \>= 4.4)
+GCCV44 := $(shell expr `$(CC) -dumpversion | cut -d '.' -f 1` \>= 4)
 USE_AESNI = @AESNI_OS@
 
 AESIN = aes.o openssl/ossl_aes.o

--- a/src/aes/Makefile.legacy
+++ b/src/aes/Makefile.legacy
@@ -1,5 +1,5 @@
 RM = rm -f
-GCCV44 := $(shell expr `$(CC) -dumpversion 2>/dev/null` \>= 4.4 2>/dev/null)
+GCCV44 := $(shell expr `$(CC) -dumpversion 2>/dev/null | cut -d '.' -f 1` \>= 4)
 YASM := $(shell yasm -f $(YASM_FORMAT) 2>&1 | grep "No input files")
 UNAME := $(shell $(CC) -dumpmachine 2>/dev/null)
 

--- a/src/listconf.c
+++ b/src/listconf.c
@@ -88,6 +88,10 @@
 #include "version.h"
 #include "listconf.h" /* must be included after version.h and misc.h */
 
+#ifdef AESNI_IN_USE
+#include "aes.h"
+#endif
+
 #ifdef NO_JOHN_BLD
 #define JOHN_BLD "unk-build-type"
 #else
@@ -348,6 +352,17 @@ static void listconf_list_build_info(void)
 
 	printf("Terminal locale string: %s\n", john_terminal_locale);
 	printf("Parsed terminal locale: %s\n", cp_id2name(options.terminal_enc));
+
+#ifdef AESNI_IN_USE
+	if (using_aes_asm())
+		printf("AES-NI: available\n");
+	else
+		printf("AES-NI: not supported by CPU\n");
+#elif defined(__i386__) || defined(__x86_64__)
+	printf("AES-NI: not built\n");
+#else
+	printf("AES-NI: not applicable\n");
+#endif
 
 #ifdef __CYGWIN__
 	{


### PR DESCRIPTION
This AES-NI build fix is planned to be obsoleted by #4314 but let's put it in here for relbench checks.

The PR also contains a minor fix for KeePass format: Use the Argon2 region alloc/dealloc functions for the decryption buffer as well. This buffer may be several megabytes and we previously alloced/freed it for each candidate.