### PR TITLE
Dynamic salt formats: Drop a redundant and very confusing pointer copy

### DIFF
--- a/src/7z_common_plug.c
+++ b/src/7z_common_plug.c
@@ -253,16 +253,11 @@ err:
 void *sevenzip_get_salt(char *ciphertext)
 {
 	sevenzip_salt_t cs;
-	sevenzip_salt_t *psalt;
-	static void *ptr;
 	char *ctcopy = xstrdup(ciphertext);
 	char *keeptr = ctcopy;
 	int i;
 	char *p;
 
-	if (!ptr)
-		ptr = mem_alloc_tiny(sizeof(sevenzip_salt_t*),
-		                     sizeof(sevenzip_salt_t*));
 	memset(&cs, 0, sizeof(cs));
 	ctcopy += TAG_LENGTH;
 	p = strtokm(ctcopy, "$");
@@ -285,6 +280,9 @@ void *sevenzip_get_salt(char *ciphertext)
 		cs.crc = atou(p); /* unsigned function */
 	p = strtokm(NULL, "$");
 	cs.aes_length = atoll(p);
+
+	/* Now we know the size of the dyna salt, so we can allocate */
+	static sevenzip_salt_t *psalt;
 	psalt = mem_alloc(sizeof(sevenzip_salt_t) + cs.aes_length - 1);
 	memcpy(psalt, &cs, sizeof(cs));
 	p = strtokm(NULL, "$");
@@ -314,8 +312,7 @@ void *sevenzip_get_salt(char *ciphertext)
 	psalt->dsalt.salt_cmp_size = SALT_CMP_SIZE(sevenzip_salt_t, aes_length, data, psalt->aes_length);
 	psalt->dsalt.salt_alloc_needs_free = 1;
 
-	memcpy(ptr, &psalt, sizeof(void*));
-	return ptr;
+	return &psalt;
 }
 
 int sevenzip_salt_compare(const void *x, const void *y)

--- a/src/gpg_common_plug.c
+++ b/src/gpg_common_plug.c
@@ -859,11 +859,9 @@ void *gpg_common_get_salt(char *ciphertext)
 	char *keeptr = ctcopy;
 	int i;
 	char *p;
-	struct gpg_common_custom_salt cs, *psalt;
-	static unsigned char *ptr;
+	struct gpg_common_custom_salt cs;
 
 	memset(&cs, 0, sizeof(cs));
-	if (!ptr) ptr = mem_alloc_tiny(sizeof(struct gpg_common_custom_salt*),sizeof(struct gpg_common_custom_salt*));
 	ctcopy += FORMAT_TAG_LEN;	/* skip over "$gpg$" marker and first '*' */
 	p = strtokm(ctcopy, "*");
 	cs.pk_algorithm = atoi(p);
@@ -875,6 +873,7 @@ void *gpg_common_get_salt(char *ciphertext)
 
 	/* Ok, now we 'know' the size of the dyna salt, so we can allocate */
 	/* note the +64 is due to certain algo's reading dirty data, up to 64 bytes past end */
+	static struct gpg_common_custom_salt *psalt;
 	psalt = mem_calloc(sizeof(struct gpg_common_custom_salt) + cs.datalen + 64, 1);
 	psalt->pk_algorithm = cs.pk_algorithm;
 	psalt->symmetric_mode = cs.symmetric_mode;
@@ -1047,8 +1046,7 @@ void *gpg_common_get_salt(char *ciphertext)
 	psalt->dsalt.salt_cmp_offset = SALT_CMP_OFF(struct gpg_common_custom_salt, datalen);
 	psalt->dsalt.salt_cmp_size = SALT_CMP_SIZE(struct gpg_common_custom_salt, datalen, data, psalt->datalen);
 
-	memcpy(ptr, &psalt, sizeof(struct gpg_common_custom_salt*));
-	return (void*)ptr;
+	return &psalt;
 }
 
 static unsigned int length_of_multi_precision_integer(const unsigned char *buf)

--- a/src/pkzip.c
+++ b/src/pkzip.c
@@ -188,13 +188,9 @@ char *winzip_common_split(char *ciphertext, int index, struct fmt_main *self)
 void *winzip_common_get_salt(char *ciphertext)
 {
 	uint64_t i;
-	winzip_salt salt, *psalt;
-	static unsigned char *ptr;
+	winzip_salt salt;
 	c8 *copy_mem = xstrdup(ciphertext);
 	c8 *cp, *p;
-
-	if (!ptr)
-		ptr = mem_alloc_tiny(sizeof(winzip_salt*),sizeof(winzip_salt*));
 
 	p = copy_mem + WINZIP_TAG_LENGTH + 1; /* skip over "$zip2$*" */
 	memset(&salt, 0, sizeof(salt));
@@ -215,7 +211,8 @@ void *winzip_common_get_salt(char *ciphertext)
 
 	// Ok, now create the allocated salt record we are going to return back to John, using the dynamic
 	// sized data buffer.
-	psalt = (winzip_salt*)mem_calloc(1, sizeof(winzip_salt) + salt.comp_len);
+	static winzip_salt *psalt;
+	psalt = mem_calloc(1, sizeof(winzip_salt) + salt.comp_len);
 	psalt->v.type = salt.v.type;
 	psalt->v.mode = salt.v.mode;
 	psalt->comp_len = salt.comp_len;
@@ -234,8 +231,7 @@ void *winzip_common_get_salt(char *ciphertext)
 
 	MEM_FREE(copy_mem);
 
-	memcpy(ptr, &psalt, sizeof(winzip_salt*));
-	return (void*)ptr;
+	return &psalt;
 }
 
 void *winzip_common_binary(char *ciphertext) {


### PR DESCRIPTION
Similar (yet different, and relevant) code is used in other formats where we don't copy just a pointer but a complete salt.