### PR TITLE
--list=build-info fixes

### DIFF
--- a/src/listconf.c
+++ b/src/listconf.c
@@ -155,12 +155,22 @@ static void listconf_list_build_info(void)
 #endif
 	puts("Version: " JTR_GIT_VERSION);
 	puts("Build: " JOHN_BLD _MP_VERSION OCL_STRING ZTEX_STRING DEBUG_STRING ASAN_STRING UBSAN_STRING);
+
 #ifdef SIMD_COEF_32
 	printf("SIMD: %s, interleaving: MD4:%d MD5:%d SHA1:%d SHA256:%d SHA512:%d\n",
 	       SIMD_TYPE,
 	       SIMD_PARA_MD4, SIMD_PARA_MD5, SIMD_PARA_SHA1,
 	       SIMD_PARA_SHA256, SIMD_PARA_SHA512);
 #endif
+	printf("AES hardware acceleration: %s\n",
+#if defined(MBEDTLS_AESNI_HAVE_CODE)
+	       mbedtls_aesni_has_support(MBEDTLS_AESNI_AES) ? "AES-NI" :
+#endif
+#if defined(MBEDTLS_AESCE_HAVE_CODE)
+	       MBEDTLS_AESCE_HAS_SUPPORT() ? "AES-CE" :
+#endif
+	       "no");
+
 #if JOHN_SYSTEMWIDE
 	puts("System-wide exec: " JOHN_SYSTEMWIDE_EXEC);
 	puts("System-wide home: " JOHN_SYSTEMWIDE_HOME);
@@ -355,15 +365,6 @@ static void listconf_list_build_info(void)
 
 	printf("Terminal locale string: %s\n", john_terminal_locale);
 	printf("Parsed terminal locale: %s\n", cp_id2name(options.terminal_enc));
-
-	printf("AES hardware acceleration: %s\n",
-#if defined(MBEDTLS_AESNI_HAVE_CODE)
-	       mbedtls_aesni_has_support(MBEDTLS_AESNI_AES) ? "AES-NI" :
-#endif
-#if defined(MBEDTLS_AESCE_HAVE_CODE)
-	       MBEDTLS_AESCE_HAS_SUPPORT() ? "AES-CE" :
-#endif
-	       "no");
 
 #ifdef __CYGWIN__
 	{


### PR DESCRIPTION
Moves AES hardware acceleration info to near SIMD. Also merges some short lines within same context, output now 10 lines shorter.

Before (37 lines)
```
Version: 1.9.0-jumbo-1+bleeding-b40a1a2bf9 2024-11-30 02:05:44 +0100
Build: darwin24.1.0 64-bit x86_64 AVX2 AC OMP OPENCL
SIMD: AVX2, interleaving: MD4:3 MD5:3 SHA1:1 SHA256:1 SHA512:1
CPU tests: AVX2
$JOHN is ../run/
Format interface version: 14
Max. number of reported tunable costs: 4
Rec file version: REC4
Charset file version: CHR3
CHARSET_MIN: 1 (0x01)
CHARSET_MAX: 255 (0xff)
CHARSET_LENGTH: 24
SALT_HASH_SIZE: 1048576
SINGLE_IDX_MAX: 2147483648
SINGLE_BUF_MAX: 4294967295
Effective limit: Number of salts vs. SingleMaxBufferSize
Max. Markov mode level: 400
Max. Markov mode password length: 30
gcc version: 14.2.0
OpenCL headers version: 1.2
Crypto library: OpenSSL
OpenSSL library version: 030400000
OpenSSL 3.4.0 22 Oct 2024
GMP library version: 6.3.0
File locking: fcntl()
fseek(): fseek
ftell(): ftell
fopen(): fopen
memmem(): System's
times(2) sysconf(_SC_CLK_TCK) is 100
Using times(2) for timers, resolution 10 ms
HR timer: mach_absolute_time(), latency 31 ns
Total physical host memory: 32 GiB
Available physical host memory: 18177 MiB
Terminal locale string: en_US.UTF-8
Parsed terminal locale: UTF-8
AES hardware acceleration: AES-NI
```

After (27 lines)
```
Version: 1.9.0-jumbo-1+bleeding-d1c2d2bf33 2024-11-30 03:00:41 +0100
Build: darwin24.1.0 64-bit x86_64 AVX2 AC OMP OPENCL
SIMD: AVX2, interleaving: MD4:3 MD5:3 SHA1:1 SHA256:1 SHA512:1
AES hardware acceleration: AES-NI
CPU tests: AVX2
$JOHN is ../run/
Format interface version: 14
Max. number of reported tunable costs: 4
Rec file version: REC4, charset file version: CHR3
CHARSET_MIN: 1 (0x01), CHARSET_MAX: 255 (0xff), CHARSET_LENGTH: 24
SALT_HASH_SIZE: 1048576
SINGLE_IDX_MAX: 2147483648, SINGLE_BUF_MAX: 4294967295
Effective limit: Number of salts vs. SingleMaxBufferSize
Markov mode max. level: 400, length 30
gcc version: 14.2.0
OpenCL headers version: 1.2
Crypto library: OpenSSL 3.4.0 22 Oct 2024
GMP library version: 6.3.0
File locking: fcntl()
fseek(): fseek, ftell(): ftell, fopen(): fopen, memmem(): System's
times(2) sysconf(_SC_CLK_TCK) is 100
Using times(2) for timers, resolution 10 ms
HR timer: mach_absolute_time(), latency 29 ns
Total physical host memory: 32 GiB
Available physical host memory: 18423 MiB
Terminal locale string: en_US.UTF-8
Parsed terminal locale: UTF-8
```
There are also things in there that we could drop entirely, many added while tweaking specific stuff such as "use 64-bit fseek if available" and now not very interesting. OTOH this is very subjective... For some reason I love the timer information, must be some kind of fetish.