### PR TITLE
Mute warnings from pkcs12_plug.c

### DIFF
--- a/src/pkcs12.h
+++ b/src/pkcs12.h
@@ -26,8 +26,8 @@
  *  JtR changes placed in public domain.
  */
 
-#ifndef MBEDTLS_PKCS12_H
-#define MBEDTLS_PKCS12_H
+#ifndef JOHN_PKCS12_H
+#define JOHN_PKCS12_H
 
 #define MBEDTLS_PKCS12_DERIVE_KEY       1   /**< encryption/decryption key */
 #define MBEDTLS_PKCS12_DERIVE_IV        2   /**< initialization vector     */

--- a/src/pkcs12_plug.c
+++ b/src/pkcs12_plug.c
@@ -36,7 +36,7 @@
 #define PKCS12_MAX_PWDLEN 128
 
 
-static int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen, const
+static int pkcs12_derivation( unsigned char *data, size_t datalen, const
 		unsigned char *pwd, size_t pwdlen, const unsigned char *salt,
 		size_t saltlen, int md_type, int id, int iterations );
 
@@ -59,7 +59,7 @@ int pkcs12_pbe_derive_key( int md_type, int iterations, int id, const unsigned
 	// 2  => BestCrypt specific PKCS12 Whirlpool-512, hack
 	// 10 => BestCrypt specific PKCS12 SHA-512, hack
 	if (md_type == 1 || md_type == 256 || md_type == 512 || md_type == 224 || md_type == 384 || md_type == 2 || md_type == 10)
-		mbedtls_pkcs12_derivation(key, keylen, unipwd.c, pwdlen, salt,
+		pkcs12_derivation(key, keylen, unipwd.c, pwdlen, salt,
 				saltlen, md_type, id, iterations);
     return 0;
 }
@@ -79,7 +79,7 @@ static void pkcs12_fill_buffer( unsigned char *data, size_t data_len,
     }
 }
 
-static int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen, const
+static int pkcs12_derivation( unsigned char *data, size_t datalen, const
 		unsigned char *pwd, size_t pwdlen, const unsigned char *salt,
 		size_t saltlen, int md_type, int id, int iterations )
 {
@@ -100,7 +100,7 @@ static int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen, const
 
     // This version only allows max of 48 bytes of password or salt
     if ( datalen > 128 || pwdlen > 48*2+2 || saltlen > 64 )
-        return -1; // MBEDTLS_ERR_PKCS12_BAD_INPUT_DATA
+        return -1; // ERR_PKCS12_BAD_INPUT_DATA
 
     switch (md_type) {
 	//case 0:
@@ -294,11 +294,11 @@ static int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen, const
 #endif
 
 
-static int mbedtls_pkcs12_derivation_simd_sha1( unsigned char *data[SSE_GROUP_SZ_SHA1],
+static int pkcs12_derivation_simd_sha1( unsigned char *data[SSE_GROUP_SZ_SHA1],
 	        size_t datalen, const unsigned char *pwd[SSE_GROUP_SZ_SHA1],
 	        size_t pwdlen[SSE_GROUP_SZ_SHA1], const unsigned char *salt, size_t saltlen,
 	        int id, int iterations );
-static int mbedtls_pkcs12_derivation_simd_sha256( unsigned char *data[SSE_GROUP_SZ_SHA256],
+static int pkcs12_derivation_simd_sha256( unsigned char *data[SSE_GROUP_SZ_SHA256],
                 size_t datalen, const unsigned char *pwd[SSE_GROUP_SZ_SHA256],
                 size_t pwdlen[SSE_GROUP_SZ_SHA256], const unsigned char *salt, size_t saltlen,
                 int id, int iterations );
@@ -342,7 +342,7 @@ int pkcs12_pbe_derive_key_simd_sha1( int iterations, int id, const unsigned char
 
 		pwdlen[j] = 2 * (len + 1);
 	}
-	mbedtls_pkcs12_derivation_simd_sha1(key, keylen, unipwd, pwdlen, salt, saltlen, id, iterations);
+	pkcs12_derivation_simd_sha1(key, keylen, unipwd, pwdlen, salt, saltlen, id, iterations);
 	return 0;
 }
 
@@ -367,7 +367,7 @@ int pkcs12_pbe_derive_key_simd_sha256( int iterations, int id, const unsigned ch
 
 		pwdlen[j] = 2 * (len + 1);
 	}
-	mbedtls_pkcs12_derivation_simd_sha256(key, keylen, unipwd, pwdlen, salt, saltlen, id, iterations);
+	pkcs12_derivation_simd_sha256(key, keylen, unipwd, pwdlen, salt, saltlen, id, iterations);
 	return 0;
 }
 
@@ -416,7 +416,7 @@ static void pkcs12_fill_buffer_simd(unsigned char *data[SIMD_MAX_GROUP_PFX], siz
 	}
 }
 
-static int mbedtls_pkcs12_derivation_simd_sha1( unsigned char *data[SSE_GROUP_SZ_SHA1], size_t datalen,
+static int pkcs12_derivation_simd_sha1( unsigned char *data[SSE_GROUP_SZ_SHA1], size_t datalen,
 	        const unsigned char *pwd[SSE_GROUP_SZ_SHA1], size_t pwdlen[SSE_GROUP_SZ_SHA1],
 	        const unsigned char *salt, size_t saltlen, int id, int iterations )
 {
@@ -524,7 +524,7 @@ static int mbedtls_pkcs12_derivation_simd_sha1( unsigned char *data[SSE_GROUP_SZ
 	return 0;
 }
 
-static int mbedtls_pkcs12_derivation_simd_sha256( unsigned char *data[SSE_GROUP_SZ_SHA256], size_t datalen,
+static int pkcs12_derivation_simd_sha256( unsigned char *data[SSE_GROUP_SZ_SHA256], size_t datalen,
 	        const unsigned char *pwd[SSE_GROUP_SZ_SHA256], size_t pwdlen[SSE_GROUP_SZ_SHA256],
 	        const unsigned char *salt, size_t saltlen, int id, int iterations )
 {
@@ -645,7 +645,7 @@ static int mbedtls_pkcs12_derivation_simd_sha256( unsigned char *data[SSE_GROUP_
 #define GETPOS4(i, index)        ( (index&(SIMD_COEF_64-1))*8 + ((i)&(0xffffffff-7))*SIMD_COEF_64 + ((i)&7) + (unsigned int)index/SIMD_COEF_64*SHA_BUF_SIZ*SIMD_COEF_64*8 )
 #endif
 
-static int mbedtls_pkcs12_derivation_simd_sha512( unsigned char *data[SSE_GROUP_SZ_SHA512], size_t datalen,
+static int pkcs12_derivation_simd_sha512( unsigned char *data[SSE_GROUP_SZ_SHA512], size_t datalen,
 	        const unsigned char *pwd[SSE_GROUP_SZ_SHA512], size_t pwdlen[SSE_GROUP_SZ_SHA512],
 	        const unsigned char *salt, size_t saltlen, int id, int iterations );
 
@@ -670,11 +670,11 @@ int pkcs12_pbe_derive_key_simd_sha512(int iterations, int id, const unsigned cha
 
 		pwdlen[j] = 2 * (len + 1);
 	}
-	mbedtls_pkcs12_derivation_simd_sha512(key, keylen, unipwd, pwdlen, salt, saltlen, id, iterations);
+	pkcs12_derivation_simd_sha512(key, keylen, unipwd, pwdlen, salt, saltlen, id, iterations);
 	return 0;
 }
 
-static int mbedtls_pkcs12_derivation_simd_sha512( unsigned char *data[SSE_GROUP_SZ_SHA512], size_t datalen,
+static int pkcs12_derivation_simd_sha512( unsigned char *data[SSE_GROUP_SZ_SHA512], size_t datalen,
 	        const unsigned char *pwd[SSE_GROUP_SZ_SHA512], size_t pwdlen[SSE_GROUP_SZ_SHA512],
 	        const unsigned char *salt, size_t saltlen, int id, int iterations )
 {

--- a/src/pkcs12_plug.c
+++ b/src/pkcs12_plug.c
@@ -372,7 +372,7 @@ int pkcs12_pbe_derive_key_simd_sha256( int iterations, int id, const unsigned ch
 }
 
 
-static void pkcs12_fill_salt_buffer_simd(unsigned char *data[SIMD_MAX_GROUP_PFX], size_t data_len,
+static void pkcs12_fill_salt_buffer_simd(unsigned char *data[], size_t data_len,
                                     const unsigned char *filler, size_t fill_len, int fill_count)
 {
 	int j;
@@ -393,9 +393,9 @@ static void pkcs12_fill_salt_buffer_simd(unsigned char *data[SIMD_MAX_GROUP_PFX]
 	}
 }
 
-static void pkcs12_fill_buffer_simd(unsigned char *data[SIMD_MAX_GROUP_PFX], size_t data_len,
-                                    const unsigned char *filler[SIMD_MAX_GROUP_PFX],
-				    size_t fill_len[SIMD_MAX_GROUP_PFX], int fill_count)
+static void pkcs12_fill_buffer_simd(unsigned char *data[], size_t data_len,
+                                    const unsigned char *filler[],
+				    size_t fill_len[], int fill_count)
 {
 	int j;
 	unsigned char *p;


### PR DESCRIPTION
See #5154. Also drop misleading `mbedtls_` from that file and its header.