### PR TITLE
OpenCL: Double the performance of shared AES-CBC-decrypt

### DIFF
--- a/run/opencl/cryptsha256_kernel_DEFAULT.cl
+++ b/run/opencl/cryptsha256_kernel_DEFAULT.cl
@@ -266,7 +266,9 @@ inline void sha256_digest_move(sha256_ctx * ctx,
                                uint32_t   * result,
                                const int size) {
 
+#if !__POCL__
     #pragma unroll
+#endif
     for (int i = 0; i < size; i++)
         result[i] = SWAP32(ctx->H[i]);
 }

--- a/run/opencl/cryptsha512_kernel_DEFAULT.cl
+++ b/run/opencl/cryptsha512_kernel_DEFAULT.cl
@@ -244,7 +244,7 @@ inline void sha512_digest_move(sha512_ctx * ctx,
                                uint64_t   * result,
                                const int size) {
 
-#ifdef UNROLL
+#if defined UNROLL && !__POCL__
     #pragma unroll
 #endif
     for (int i = 0; i < size; i++)

--- a/run/opencl/opencl_aes_bitslice.h
+++ b/run/opencl/opencl_aes_bitslice.h
@@ -1007,6 +1007,11 @@ typedef AES_CTX  AES_KEY;
 #define AES_encrypt(in, out, ctx)           AES_Encrypt(ctx, in, out)
 #define AES_decrypt(in, out, ctx)           AES_Decrypt(ctx, in, out)
 
+#define AES_ecb_encrypt_pp(in, out, len, ctx)	  \
+	AES_Encrypt_ECB_pp(ctx, in, out, (len) / AES_BLOCK_SIZE)
+#define AES_ecb_decrypt_pp(in, out, len, ctx)	  \
+	AES_Decrypt_ECB_pp(ctx, in, out, (len) / AES_BLOCK_SIZE)
+
 #if DO_MEMCPY
 #define AES_ecb_encrypt(in, out, len, ctx)	  \
 	AES_Encrypt_ECB(ctx, in, out, (len) / AES_BLOCK_SIZE)

--- a/run/opencl/opencl_gost94.h
+++ b/run/opencl/opencl_gost94.h
@@ -119,7 +119,7 @@ inline void gost94_init(gost94_ctx *ctx)
  * @param hash intermediate message hash
  * @param block the message block to process
  */
-static void rhash_gost94_block_compress(gost94_ctx *ctx, const uint* block, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
+inline void rhash_gost94_block_compress(gost94_ctx *ctx, const uint* block, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
 {
 	uint i;
 	uint key[8], u[8], v[8], w[8], s[8];
@@ -261,7 +261,7 @@ static void rhash_gost94_block_compress(gost94_ctx *ctx, const uint* block, MAYB
  * @param ctx algorithm context
  * @param block the 256-bit message block to process
  */
-static void rhash_gost94_compute_sum_and_hash(gost94_ctx * ctx, const uint* block, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
+inline void rhash_gost94_compute_sum_and_hash(gost94_ctx * ctx, const uint* block, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
 {
 #if !__ENDIAN_LITTLE__
 	uint block_le[8]; /* tmp buffer for little endian number */
@@ -334,7 +334,7 @@ inline void gost94_update(gost94_ctx *ctx, const uchar* msg, uint size, MAYBE_LO
 }
 
 #if !__ENDIAN_LITTLE__
-static void rhash_u32_swap_copy(void* to, const void* from, uint length) {
+inline void rhash_u32_swap_copy(void* to, const void* from, uint length) {
 	uint i;
 	uint *pO, *pI;
 	pO = (uint *)to;

--- a/run/opencl/opencl_streebog.h
+++ b/run/opencl/opencl_streebog.h
@@ -948,7 +948,13 @@ GOST34112012Update(GOST34112012Context *CTX, const uchar *data, uint len, __loca
 }
 
 inline void
-GOST34112012Final(GOST34112012Context *CTX, uint512_u *digest, __local localbuf *loc_buf)
+GOST34112012Final(GOST34112012Context *CTX,
+#if STREEBOG512CRYPT
+                  uint512_u
+#else
+                  uint256_u
+#endif
+                  *digest, __local localbuf *loc_buf)
 {
 	stage3(CTX, loc_buf);
 


### PR DESCRIPTION
Ensure AES_cbc_decrypt() utilizes the parallel capability of the bitsliced AES code when more than one block is decrypted at once.  For encryption this is not possible as the IV for block n is unknown until block n-1 has been encrypted.

The potential boost is great (over 2x seen with AES-ECB) but none of our current formats use AES-CBC enough for this to make a significant difference, at least not with their (often small) test vectors.

See #5594.

Also a few commits that gets rid of OpenCL build warnings.