### PR TITLE
OpenCL: Show ptxas info from verbosity 4 (was 5)

### DIFF
--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1142,7 +1142,7 @@ static char *get_build_opts(int sequential_id, const char *opts)
 #ifdef __APPLE__
 	        "-D__OS_X__ ",
 #else
-	        (options.verbosity >= VERB_MAX &&
+	        (options.verbosity >= VERB_LEGACY &&
 	         gpu_nvidia(device_info[sequential_id])) ?
 	         "-cl-nv-verbose " : "",
 #endif


### PR DESCRIPTION
Level 5 would also show autotune stats, which is not always what I want. Also, we now get compiler warnings and ptxas at the same verbosity level which is logical (to me, at least).