### PR TITLE
OpenCL AES: Don't bother using local memory on CPU devices

### DIFF
--- a/run/opencl/opencl_aes_plain.h
+++ b/run/opencl/opencl_aes_plain.h
@@ -20,7 +20,7 @@
 /*
  * Copy tables to local memory.
  */
-#ifndef AES_LOCAL_TABLES
+#if gpu(DEVICE_INFO)
 #define AES_LOCAL_TABLES
 #endif
 


### PR DESCRIPTION
Not very important (makes little/no difference) but I like having the different code paths "in use" to catch future problems.