### PR TITLE
mbedtls/aes.c: Fix whitespace errors introduced during code import

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,11 @@ tab_width = 8
 indent_style = space
 indent_size = 2
 
+# Neither does mbedtls
+[src/mbedtls/*.[ch]]
+indent_style = space
+indent_size = 4
+
 [7z2john.pl]
 indent_style = space
 indent_size = 2

--- a/src/mbedtls/aes.c
+++ b/src/mbedtls/aes.c
@@ -1102,13 +1102,13 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context *ctx,
     }
 
     if (length % 16) {
-	    ret = MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
-	    /*
-	     * For bug compatibility, chug along and return the error afterwards.
-	     * Our old code (and eg. OpenSSL) would read and write past buffers
-	     * just like we do here.  - magnum
-	     */
-	    length = (length + 15) / 16 * 16;
+        ret = MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH;
+        /*
+         * For bug compatibility, chug along and return the error afterwards.
+         * Our old code (and eg. OpenSSL) would read and write past buffers
+         * just like we do here.  - magnum
+         */
+        length = (length + 15) / 16 * 16;
     }
 
 #if defined(MBEDTLS_VIA_PADLOCK_HAVE_CODE)


### PR DESCRIPTION
The mbedtls files use spaces instead of tabs.