### PR TITLE
MD5_std.c: Fix a build error under -std=gnu99 with gcc 4.8.5

### DIFF
--- a/src/MD5_std.c
+++ b/src/MD5_std.c
@@ -496,6 +496,8 @@ extern void MD5_body(MD5_word x[15], MD5_word out[4]);
 #if MD5_std_mt
 #define MD5_body(x, out) \
 	MD5_body_for_thread(t, x, out)
+extern MAYBE_INLINE_BODY void MD5_body_for_thread(int t,
+	MD5_word x[15], MD5_word out[4]);
 MAYBE_INLINE_BODY void MD5_body_for_thread(int t,
 	MD5_word x[15], MD5_word out[4])
 #else
@@ -595,6 +597,9 @@ MAYBE_INLINE_BODY void MD5_body(MD5_word x[15], MD5_word out[4])
 #if MD5_std_mt
 #define MD5_body(x0, x1, out0, out1) \
 	MD5_body_for_thread(t, x0, x1, out0, out1)
+extern MAYBE_INLINE_BODY void MD5_body_for_thread(int t,
+	MD5_word x0[15], MD5_word x1[15],
+	MD5_word out0[4], MD5_word out1[4]);
 MAYBE_INLINE_BODY void MD5_body_for_thread(int t,
 	MD5_word x0[15], MD5_word x1[15],
 	MD5_word out0[4], MD5_word out1[4])


### PR DESCRIPTION
"dynamic_fmt.c:5274: undefined reference to `MD5_body_for_thread'"

Non-static function using "inline" doesn't get external linkage unless also declared with "extern" somewhere.

I'm not 100% sure but this one compiler may actually do the right thing while all the ones not bailing out break the standard (or rather allow non-standard) for compatibility/DWIM reasons.

Closes #5611