### PR TITLE
OpenCL gostcrypt/streebogcrypt formats bugfixes

### DIFF
--- a/run/opencl/gost12256hash_kernel.cl
+++ b/run/opencl/gost12256hash_kernel.cl
@@ -201,7 +201,6 @@ __kernel void gost12256loop(__global inbuf *in,
 #endif
 
 	/* Repeatedly run the collected hash value through Streebog to burn CPU cycles.  */
-#pragma unroll HASH_LOOPS
 	for (cnt = 0; cnt < HASH_LOOPS; ++cnt) {
 		/* New context. */
 		GOST34112012Init(&ctx, 256);

--- a/run/opencl/gost12256hash_kernel.cl
+++ b/run/opencl/gost12256hash_kernel.cl
@@ -12,7 +12,6 @@
 #define STREEBOG_LOCAL_AX       1
 #define STREEBOG_VECTOR         1
 #define STREEBOG_UNROLL         0
-#define STREEBOG_MANUAL_UNROLL  0
 #include "opencl_streebog.h"
 
 #define SALT_LENGTH                 16

--- a/run/opencl/gost12256hash_kernel.cl
+++ b/run/opencl/gost12256hash_kernel.cl
@@ -9,7 +9,9 @@
 #include "opencl_misc.h"
 
 #define STREEBOG256CRYPT        1
+#if gpu(DEVICE_INFO)
 #define STREEBOG_LOCAL_AX       1
+#endif
 #define STREEBOG_VECTOR         1
 #define STREEBOG_UNROLL         0
 #include "opencl_streebog.h"
@@ -249,13 +251,13 @@ __kernel void gost12256final(__global inbuf *in,
 
 	memcpy256(&(result), &(out[gid]));
 
-#if STREEBOG_LOCAL_AX
 	if (rounds) {
 		saltlen = ssalt->len;
 		len = in[gid].len;
 		memcpy_gp(p_bytes, state[gid].p_bytes, len);
 		memcpy_gp(s_bytes, state[gid].s_bytes, saltlen);
 
+#if STREEBOG_LOCAL_AX
 		uint ls = get_local_size(0);
 		uint lid = get_local_id(0);
 
@@ -264,8 +266,8 @@ __kernel void gost12256final(__global inbuf *in,
 				loc_buf->Ax[j][i] = Ax[j][i];
 		}
 		barrier(CLK_LOCAL_MEM_FENCE);
-	}
 #endif
+	}
 
 	/* Repeatedly run the collected hash value through Streebog to burn CPU cycles.  */
 	for (cnt = 0; cnt < rounds; ++cnt) {

--- a/run/opencl/gost12512hash_kernel.cl
+++ b/run/opencl/gost12512hash_kernel.cl
@@ -205,7 +205,6 @@ __kernel void gost12512loop(__global inbuf *in,
 #endif
 
 	/* Repeatedly run the collected hash value through Streebog to burn CPU cycles.  */
-#pragma unroll HASH_LOOPS
 	for (cnt = 0; cnt < HASH_LOOPS; ++cnt) {
 		/* New context. */
 		GOST34112012Init(&ctx, 512);

--- a/run/opencl/gost12512hash_kernel.cl
+++ b/run/opencl/gost12512hash_kernel.cl
@@ -16,7 +16,6 @@
  * Manual unroll:  Build time: 4 min 26.142 s, binary size 5961490, 9959 c/s
  */
 #define STREEBOG_UNROLL         0
-#define STREEBOG_MANUAL_UNROLL  0
 #include "opencl_streebog.h"
 
 #define SALT_LENGTH                 16

--- a/run/opencl/gost12512hash_kernel.cl
+++ b/run/opencl/gost12512hash_kernel.cl
@@ -12,11 +12,6 @@
 #define STREEBOG_LOCAL_AX       1
 #endif
 #define STREEBOG_VECTOR         1
-/*
- * Without unroll: Build time: 45.125 s, binary size 2542391, 10402 c/s
- * Pragma unroll:  Build time: 21 min 14.788 s, binary size 11502092, 10051 c/s
- * Manual unroll:  Build time: 4 min 26.142 s, binary size 5961490, 9959 c/s
- */
 #define STREEBOG_UNROLL         0
 #include "opencl_streebog.h"
 

--- a/run/opencl/gost94hash_kernel.cl
+++ b/run/opencl/gost94hash_kernel.cl
@@ -196,7 +196,6 @@ __kernel void gost94loop(__global inbuf *in,
 	memcpy_gp(s_bytes, state[gid].s_bytes, saltlen);
 
 	/* Repeatedly run the collected hash value through GOST94 to burn CPU cycles.  */
-#pragma unroll HASH_LOOPS
 	for (cnt = 0; cnt < HASH_LOOPS; ++cnt) {
 		/* New context. */
 		gost94_init(&ctx);

--- a/run/opencl/gost94hash_kernel.cl
+++ b/run/opencl/gost94hash_kernel.cl
@@ -8,7 +8,9 @@
 
 #include "opencl_misc.h"
 
+#if gpu(DEVICE_INFO)
 #define GOST94_USE_LOCAL      1
+#endif
 #define GOST94_FLAT_INIT      1
 #include "opencl_gost94.h"
 

--- a/run/opencl/opencl_gost94.h
+++ b/run/opencl/opencl_gost94.h
@@ -300,7 +300,7 @@ inline void rhash_gost94_compute_sum_and_hash(gost94_ctx * ctx, const uint* bloc
  * @param msg message chunk
  * @param size length of the message chunk
  */
-inline void gost94_update(gost94_ctx *ctx, const uchar* msg, uint size, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
+__attribute__((noinline)) void gost94_update(gost94_ctx *ctx, const uchar* msg, uint size, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
 {
 	uint index = ctx->length & 31;
 	ctx->length += size;
@@ -361,7 +361,7 @@ inline void rhash_u32_swap_copy(void* to, const void* from, uint length) {
  * @param ctx the algorithm context containing current hashing state
  * @param result calculated hash in binary form
  */
-inline void gost94_final(gost94_ctx *ctx, uchar *result, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
+__attribute__((noinline)) void gost94_final(gost94_ctx *ctx, uchar *result, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
 {
 	uint  index = ctx->length & 31;
 	uint* msg32 = (uint*)ctx->message;

--- a/run/opencl/opencl_gost94.h
+++ b/run/opencl/opencl_gost94.h
@@ -380,7 +380,7 @@ inline void gost94_final(gost94_ctx *ctx, uchar *result, MAYBE_LOCAL const rhash
 }
 
 /* ROTL macros rotate a 32-bit word left by n bits */
-#define ROTL32(dword, n) ((dword) << (n) ^ ((dword) >> (32 - (n))))
+#define ROTL32(dword, n) rotate(dword, (uint)(n))
 
 #if GOST94_FLAT_INIT
 __constant uint precomp_table[1024] = {

--- a/run/opencl/opencl_streebog.h
+++ b/run/opencl/opencl_streebog.h
@@ -797,7 +797,6 @@ g(uint512_u *h, const uint512_u *N, const uint512_u *m, __local localbuf *loc_bu
 	XLPS(&Ki, m, &data);
 
 #if STREEBOG_UNROLL
-#if STREEBOG_MANUAL_UNROLL
 	ROUND(0, &Ki, &data);
 	ROUND(1, &Ki, &data);
 	ROUND(2, &Ki, &data);
@@ -810,10 +809,6 @@ g(uint512_u *h, const uint512_u *N, const uint512_u *m, __local localbuf *loc_bu
 	ROUND(9, &Ki, &data);
 	ROUND(10, &Ki, &data);
 #else
-#pragma unroll 11
-#endif
-#endif
-#if !STREEBOG_MANUAL_UNROLL
 	for (uint i = 0; i < 11; i++)
 		ROUND(i, &Ki, &data);
 #endif
@@ -838,7 +833,6 @@ g0(uint512_u *h, const uint512_u *m, __local localbuf *loc_buf)
 	XLPS(&Ki, m, &data);
 
 #if STREEBOG_UNROLL
-#if STREEBOG_MANUAL_UNROLL
 	ROUND(0, &Ki, &data);
 	ROUND(1, &Ki, &data);
 	ROUND(2, &Ki, &data);
@@ -851,10 +845,6 @@ g0(uint512_u *h, const uint512_u *m, __local localbuf *loc_buf)
 	ROUND(9, &Ki, &data);
 	ROUND(10, &Ki, &data);
 #else
-#pragma unroll 11
-#endif
-#endif
-#if !STREEBOG_MANUAL_UNROLL
 	for (uint i = 0; i < 11; i++)
 		ROUND(i, &Ki, &data);
 #endif

--- a/run/opencl/opencl_streebog.h
+++ b/run/opencl/opencl_streebog.h
@@ -906,7 +906,7 @@ stage3(GOST34112012Context *CTX, __local localbuf *loc_buf)
 	g0(&(CTX->h), &(CTX->Sigma), loc_buf);
 }
 
-inline void
+__attribute__((noinline)) void
 GOST34112012Update(GOST34112012Context *CTX, const uchar *data, uint len, __local localbuf *loc_buf)
 {
 	if (CTX->bufsize) {
@@ -937,7 +937,7 @@ GOST34112012Update(GOST34112012Context *CTX, const uchar *data, uint len, __loca
 	}
 }
 
-inline void
+__attribute__((noinline)) void
 GOST34112012Final(GOST34112012Context *CTX,
 #if STREEBOG512CRYPT
                   uint512_u

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1271,8 +1271,6 @@ void opencl_build(int sequential_id, const char *opts, int save, const char *fil
 
 	uint64_t end = john_get_nano();
 	log_event("- build time: %ss", ns2string(end - start));
-	if (options.verbosity >= VERB_MAX)
-		fprintf(stderr, "Build time: %ss\n", ns2string(end - start));
 
 	// Report build errors and warnings
 	if (build_code != CL_SUCCESS) {
@@ -1280,6 +1278,7 @@ void opencl_build(int sequential_id, const char *opts, int save, const char *fil
 		if (options.verbosity <= VERB_LEGACY)
 			fprintf(stderr, "Options used: %s %s\n",
 			        build_opts, kernel_source_file);
+		fprintf(stderr, "Build time: %ss\n", ns2string(end - start));
 		if (strlen(build_log) > 1)
 			fprintf(stderr, "Build log: %s\n", build_log);
 		fprintf(stderr, "Error building kernel %s. DEVICE_INFO=%d\n",
@@ -1287,8 +1286,11 @@ void opencl_build(int sequential_id, const char *opts, int save, const char *fil
 		HANDLE_CLERROR(build_code, "clBuildProgram");
 	}
 	// Nvidia may return a single '\n' that we ignore
-	else if (options.verbosity >= LOG_VERB && strlen(build_log) > 1)
-		fprintf(stderr, "Build log: %s\n", build_log);
+	else if (options.verbosity >= LOG_VERB) {
+		fprintf(stderr, "Build time: %ss\n", ns2string(end - start));
+		if (strlen(build_log) > 1)
+			fprintf(stderr, "Build log: %s\n", build_log);
+	}
 
 	MEM_FREE(build_log);
 	MEM_FREE(build_opts);

--- a/src/opencl_gost12256hash_fmt_plug.c
+++ b/src/opencl_gost12256hash_fmt_plug.c
@@ -95,8 +95,7 @@ typedef struct {
 
 #define STEP			0
 #define SEED			128
-#define HASH_LOOPS		(42 * 4) /* Kernel is hardcoded for multiple of 42 for optimizations */
-#define LOOP_CALLS		(5000 + (HASH_LOOPS - 1) / HASH_LOOPS)
+#define HASH_LOOPS		(21 * 8)
 #define ITERATIONS		5004
 
 static inbuf *inbuffer;
@@ -222,7 +221,7 @@ static void reset(struct db_main *db)
 	                       sizeof(mem_state), 0, db);
 
 	// Auto tune execution from shared/included code.
-	autotune_run(self, LOOP_CALLS, 0, 200);
+	autotune_run(self, ITERATIONS, 0, 200);
 }
 
 static void done(void)

--- a/src/opencl_gost12512hash_fmt_plug.c
+++ b/src/opencl_gost12512hash_fmt_plug.c
@@ -95,8 +95,7 @@ typedef struct {
 
 #define STEP			0
 #define SEED			128
-#define HASH_LOOPS		(42 * 4) /* Kernel is hardcoded for multiple of 42 for optimizations */
-#define LOOP_CALLS		(5000 + (HASH_LOOPS - 1) / HASH_LOOPS)
+#define HASH_LOOPS		(21 * 4)
 #define ITERATIONS		5004
 
 static inbuf *inbuffer;
@@ -222,7 +221,7 @@ static void reset(struct db_main *db)
 	                       sizeof(mem_state), 0, db);
 
 	// Auto tune execution from shared/included code.
-	autotune_run(self, LOOP_CALLS, 0, 200);
+	autotune_run(self, ITERATIONS, 0, 200);
 }
 
 static void done(void)

--- a/src/opencl_gost94hash_fmt_plug.c
+++ b/src/opencl_gost94hash_fmt_plug.c
@@ -91,8 +91,7 @@ typedef struct {
 
 #define STEP			0
 #define SEED			128
-#define HASH_LOOPS		(42 * 4) /* Kernel is hardcoded for multiple of 42 for optimizations */
-#define LOOP_CALLS		(5000 + (HASH_LOOPS - 1) / HASH_LOOPS)
+#define HASH_LOOPS		(21 * 8)
 #define ITERATIONS		5004
 
 static inbuf *inbuffer;
@@ -218,7 +217,7 @@ static void reset(struct db_main *db)
 	                       sizeof(mem_state), 0, db);
 
 	// Auto tune execution from shared/included code.
-	autotune_run(self, LOOP_CALLS, 0, 200);
+	autotune_run(self, ITERATIONS, 0, 200);
 }
 
 static void done(void)


### PR DESCRIPTION
Stop unrolling the Drepper crypt loop and fix weird autotune bugs that led to excessive work sizes being tried for no good.

Closes #5626 (I'm assuming the mod operations are insignificant until someone optimizes the basic GOST code a lot).