### PR TITLE
OpenCL: Minor tweaks of format sort order

### DIFF
--- a/src/opencl_DES_bs.h
+++ b/src/opencl_DES_bs.h
@@ -64,7 +64,7 @@ extern unsigned int CC_CACHE_ALIGN opencl_DES_bs_index768[0x300];
 
 struct fmt_main;
 
-extern struct fmt_main fmt_opencl_DES;
+extern struct fmt_main fmt_opencl_cryptdes;
 extern unsigned char opencl_DES_E[48];
 
 extern void opencl_DES_bs_b_register_functions(struct fmt_main *);

--- a/src/opencl_DES_bs_b_plug.c
+++ b/src/opencl_DES_bs_b_plug.c
@@ -317,10 +317,10 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 
 	/* for hash_ids[2*x + 1], 27 bits for storing gid and 5 bits for bs depth. */
 	//assert(global_work_size <= ((1U << 28) - 1));
-	fmt_opencl_DES.params.max_keys_per_crypt =
+	fmt_opencl_cryptdes.params.max_keys_per_crypt =
 		global_work_size << des_log_depth;
 
-	fmt_opencl_DES.params.min_keys_per_crypt =
+	fmt_opencl_cryptdes.params.min_keys_per_crypt =
 		opencl_calc_min_kpc(local_work_size, global_work_size,
 		                    1 << des_log_depth);
 }
@@ -622,7 +622,7 @@ static void reset(struct db_main *db)
 
 		if (mask_mode) {
 			release_kernel();
-			auto_tune_all(100, &fmt_opencl_DES, salt_val, mask_mode, extern_lws_limit);
+			auto_tune_all(100, &fmt_opencl_cryptdes, salt_val, mask_mode, extern_lws_limit);
 		}
 
 		set_kernel_args_kpc();
@@ -639,14 +639,14 @@ static void reset(struct db_main *db)
 
 		build_salt(0);
 		i = 0;
-		while (fmt_opencl_DES.params.tests[i].ciphertext) {
-			char *ciphertext = fmt_opencl_DES.methods.split(fmt_opencl_DES.params.tests[i].ciphertext, 0, &fmt_opencl_DES);
-			salt_val = *(WORD *)fmt_opencl_DES.methods.salt(ciphertext);
+		while (fmt_opencl_cryptdes.params.tests[i].ciphertext) {
+			char *ciphertext = fmt_opencl_cryptdes.methods.split(fmt_opencl_cryptdes.params.tests[i].ciphertext, 0, &fmt_opencl_cryptdes);
+			salt_val = *(WORD *)fmt_opencl_cryptdes.methods.salt(ciphertext);
 			build_salt(salt_val);
 			i++;
 		}
 
-		auto_tune_all(300, &fmt_opencl_DES, salt_val, 0, extern_lws_limit);
+		auto_tune_all(300, &fmt_opencl_cryptdes, salt_val, 0, extern_lws_limit);
 
 		set_kernel_args_kpc();
 

--- a/src/opencl_DES_bs_f_plug.c
+++ b/src/opencl_DES_bs_f_plug.c
@@ -380,10 +380,10 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 
 	/* for hash_ids[2*x + 1], 27 bits for storing gid and 5 bits for bs depth. */
 	//assert(global_work_size <= ((1U << 28) - 1));
-	fmt_opencl_DES.params.max_keys_per_crypt =
+	fmt_opencl_cryptdes.params.max_keys_per_crypt =
 		global_work_size << des_log_depth;
 
-	fmt_opencl_DES.params.min_keys_per_crypt =
+	fmt_opencl_cryptdes.params.min_keys_per_crypt =
 		opencl_calc_min_kpc(local_work_size, global_work_size,
 		                    1 << des_log_depth);
 }
@@ -689,7 +689,7 @@ static void reset(struct db_main *db)
 			} while ((salt = salt->next));
 
 			forced_global_keys = 0;
-			auto_tune_all(100, &fmt_opencl_DES, test_salt, mask_mode, extern_lws_limit, &forced_global_keys);
+			auto_tune_all(100, &fmt_opencl_cryptdes, test_salt, mask_mode, extern_lws_limit, &forced_global_keys);
 		}
 
 		salt = db->salts;
@@ -734,15 +734,15 @@ static void reset(struct db_main *db)
 		for (i = 0; i < 4096; i++)
 			build_salt((WORD)i);
 
-		salt_val = *(WORD *)fmt_opencl_DES.methods.salt(fmt_opencl_DES.methods.split(
-			fmt_opencl_DES.params.tests[0].ciphertext, 0, &fmt_opencl_DES));
+		salt_val = *(WORD *)fmt_opencl_cryptdes.methods.salt(fmt_opencl_cryptdes.methods.split(
+			fmt_opencl_cryptdes.params.tests[0].ciphertext, 0, &fmt_opencl_cryptdes));
 
-		auto_tune_all(300, &fmt_opencl_DES, salt_val, 0, extern_lws_limit, &forced_global_keys);
+		auto_tune_all(300, &fmt_opencl_cryptdes, salt_val, 0, extern_lws_limit, &forced_global_keys);
 
 		i = 0;
-		while (fmt_opencl_DES.params.tests[i].ciphertext) {
-			ciphertext = fmt_opencl_DES.methods.split(fmt_opencl_DES.params.tests[i].ciphertext, 0, &fmt_opencl_DES);
-			salt_val = *(WORD *)fmt_opencl_DES.methods.salt(ciphertext);
+		while (fmt_opencl_cryptdes.params.tests[i].ciphertext) {
+			ciphertext = fmt_opencl_cryptdes.methods.split(fmt_opencl_cryptdes.params.tests[i].ciphertext, 0, &fmt_opencl_cryptdes);
+			salt_val = *(WORD *)fmt_opencl_cryptdes.methods.salt(ciphertext);
 			init_kernel(salt_val, gpu_id, 1, 0, forced_global_keys ? 0 :local_work_size);
 			i++;
 		}

--- a/src/opencl_DES_bs_h_plug.c
+++ b/src/opencl_DES_bs_h_plug.c
@@ -393,10 +393,10 @@ static void gws_tune(size_t gws_init, long double kernel_run_ms, int gws_tune_fl
 
 	/* for hash_ids[2*x + 1], 27 bits for storing gid and 5 bits for bs depth. */
 	//assert(global_work_size <= ((1U << 28) - 1));
-	fmt_opencl_DES.params.max_keys_per_crypt =
+	fmt_opencl_cryptdes.params.max_keys_per_crypt =
 		global_work_size << des_log_depth;
 
-	fmt_opencl_DES.params.min_keys_per_crypt =
+	fmt_opencl_cryptdes.params.min_keys_per_crypt =
 		opencl_calc_min_kpc(local_work_size,
 		                    global_work_size,
 		                    1 << des_log_depth);
@@ -703,7 +703,7 @@ static void reset(struct db_main *db)
 			} while ((salt = salt->next));
 
 			forced_global_keys = 0;
-			auto_tune_all(100, &fmt_opencl_DES, test_salt, mask_mode, extern_lws_limit, &forced_global_keys);
+			auto_tune_all(100, &fmt_opencl_cryptdes, test_salt, mask_mode, extern_lws_limit, &forced_global_keys);
 		}
 
 		salt = db->salts;
@@ -748,15 +748,15 @@ static void reset(struct db_main *db)
 		for (i = 0; i < 4096; i++)
 			build_salt((WORD)i);
 
-		salt_val = *(WORD *)fmt_opencl_DES.methods.salt(fmt_opencl_DES.methods.split(
-			fmt_opencl_DES.params.tests[0].ciphertext, 0, &fmt_opencl_DES));
+		salt_val = *(WORD *)fmt_opencl_cryptdes.methods.salt(fmt_opencl_cryptdes.methods.split(
+			fmt_opencl_cryptdes.params.tests[0].ciphertext, 0, &fmt_opencl_cryptdes));
 
-		auto_tune_all(300, &fmt_opencl_DES, salt_val, 0, extern_lws_limit, &forced_global_keys);
+		auto_tune_all(300, &fmt_opencl_cryptdes, salt_val, 0, extern_lws_limit, &forced_global_keys);
 
 		i = 0;
-		while (fmt_opencl_DES.params.tests[i].ciphertext) {
-			ciphertext = fmt_opencl_DES.methods.split(fmt_opencl_DES.params.tests[i].ciphertext, 0, &fmt_opencl_DES);
-			salt_val = *(WORD *)fmt_opencl_DES.methods.salt(ciphertext);
+		while (fmt_opencl_cryptdes.params.tests[i].ciphertext) {
+			ciphertext = fmt_opencl_cryptdes.methods.split(fmt_opencl_cryptdes.params.tests[i].ciphertext, 0, &fmt_opencl_cryptdes);
+			salt_val = *(WORD *)fmt_opencl_cryptdes.methods.salt(ciphertext);
 			init_kernel(salt_val, gpu_id, 1, 0, forced_global_keys ? 0 :local_work_size);
 			i++;
 		}

--- a/src/opencl_DES_bs_plug.c
+++ b/src/opencl_DES_bs_plug.c
@@ -282,8 +282,8 @@ static void fill_buffer_self_test(unsigned int *max_uncracked_hashes, unsigned i
 	OFFSET_TABLE_WORD *offset_table = NULL;
 	DES_hash_check_params temp_param;
 
-	while (fmt_opencl_DES.params.tests[*max_uncracked_hashes].ciphertext) {
-		ciphertext = fmt_opencl_DES.methods.split(fmt_opencl_DES.params.tests[*max_uncracked_hashes].ciphertext, 0, &fmt_opencl_DES);
+	while (fmt_opencl_cryptdes.params.tests[*max_uncracked_hashes].ciphertext) {
+		ciphertext = fmt_opencl_cryptdes.methods.split(fmt_opencl_cryptdes.params.tests[*max_uncracked_hashes].ciphertext, 0, &fmt_opencl_cryptdes);
 		(*max_uncracked_hashes)++;
 	}
 
@@ -291,10 +291,10 @@ static void fill_buffer_self_test(unsigned int *max_uncracked_hashes, unsigned i
 	uncracked_hashes_t = (WORD *) mem_calloc(2 * *max_uncracked_hashes, sizeof(WORD));
 
 	i = 0;
-	while (fmt_opencl_DES.params.tests[i].ciphertext) {
-		ciphertext = fmt_opencl_DES.methods.split(fmt_opencl_DES.params.tests[i].ciphertext, 0, &fmt_opencl_DES);
-		binary = (WORD *)fmt_opencl_DES.methods.binary(ciphertext);
-		salt_val = *(WORD *)fmt_opencl_DES.methods.salt(ciphertext);
+	while (fmt_opencl_cryptdes.params.tests[i].ciphertext) {
+		ciphertext = fmt_opencl_cryptdes.methods.split(fmt_opencl_cryptdes.params.tests[i].ciphertext, 0, &fmt_opencl_cryptdes);
+		binary = (WORD *)fmt_opencl_cryptdes.methods.binary(ciphertext);
+		salt_val = *(WORD *)fmt_opencl_cryptdes.methods.salt(ciphertext);
 		uncracked_hashes_t[2 * i] = binary[0];
 		uncracked_hashes_t[2 * i + 1] = binary[1];
 		num_uncracked_hashes(salt_val) = 1;
@@ -630,7 +630,7 @@ int opencl_DES_bs_cmp_one(void *binary, int index)
 
 int opencl_DES_bs_cmp_exact(char *source, int index)
 {
-	int *binary = fmt_opencl_DES.methods.binary(source);
+	int *binary = fmt_opencl_cryptdes.methods.binary(source);
 
 	if (binary[1] == hash_tables[current_salt][hash_ids[2 + 2 * index] + hash_table_size(current_salt)])
 		return 1;
@@ -1149,8 +1149,8 @@ size_t create_keys_kernel_set_args(int mask_mode)
 	int i;
 
 	if (mask_mode) {
-		fmt_opencl_DES.methods.set_key = set_key_mm;
-		fmt_opencl_DES.methods.get_key = get_key_mm;
+		fmt_opencl_cryptdes.methods.set_key = set_key_mm;
+		fmt_opencl_cryptdes.methods.get_key = get_key_mm;
 	}
 
 	des_finalize_int_keys();

--- a/src/opencl_DES_fmt_plug.c
+++ b/src/opencl_DES_fmt_plug.c
@@ -8,9 +8,9 @@
 #ifdef HAVE_OPENCL
 
 #if FMT_EXTERNS_H
-extern struct fmt_main fmt_opencl_DES;
+extern struct fmt_main fmt_opencl_cryptdes;
 #elif FMT_REGISTERS_H
-john_register_one(&fmt_opencl_DES);
+john_register_one(&fmt_opencl_cryptdes);
 #else
 
 #include <string.h>
@@ -276,7 +276,7 @@ static int cmp_all(WORD *binary, int count)
 	return 1;
 }
 
-struct fmt_main fmt_opencl_DES = {
+struct fmt_main fmt_opencl_cryptdes = {
 	{
 		FORMAT_LABEL,
 		FORMAT_NAME,

--- a/src/opencl_bf_fmt_plug.c
+++ b/src/opencl_bf_fmt_plug.c
@@ -8,9 +8,9 @@
 #ifdef HAVE_OPENCL
 
 #if FMT_EXTERNS_H
-extern struct fmt_main fmt_opencl_bf;
+extern struct fmt_main fmt_opencl_cryptb;
 #elif FMT_REGISTERS_H
-john_register_one(&fmt_opencl_bf);
+john_register_one(&fmt_opencl_cryptb);
 #else
 
 #include <stdlib.h>
@@ -162,7 +162,7 @@ static int cmp_exact(char *source, int index)
 	    sizeof(BF_binary));
 }
 
-struct fmt_main fmt_opencl_bf = {
+struct fmt_main fmt_opencl_cryptb = {
 	{
 		FORMAT_LABEL,
 		FORMAT_NAME,

--- a/src/opencl_gost12256hash_fmt_plug.c
+++ b/src/opencl_gost12256hash_fmt_plug.c
@@ -9,9 +9,9 @@
 #ifdef HAVE_OPENCL
 
 #if FMT_EXTERNS_H
-extern struct fmt_main fmt_opencl_cryptgost12256;
+extern struct fmt_main fmt_opencl_cryptstreebog256;
 #elif FMT_REGISTERS_H
-john_register_one(&fmt_opencl_cryptgost12256);
+john_register_one(&fmt_opencl_cryptstreebog256);
 #else
 
 #include <string.h>
@@ -427,7 +427,7 @@ static unsigned int iteration_count(void *salt)
 #define COMMON_GET_HASH_VAR crypt_out
 #include "common-get-hash.h"
 
-struct fmt_main fmt_opencl_cryptgost12256 = {
+struct fmt_main fmt_opencl_cryptstreebog256 = {
 	{
 		FORMAT_LABEL,
 		FORMAT_NAME,

--- a/src/opencl_gost12512hash_fmt_plug.c
+++ b/src/opencl_gost12512hash_fmt_plug.c
@@ -9,9 +9,9 @@
 #ifdef HAVE_OPENCL
 
 #if FMT_EXTERNS_H
-extern struct fmt_main fmt_opencl_cryptgost12512;
+extern struct fmt_main fmt_opencl_cryptstreebog512;
 #elif FMT_REGISTERS_H
-john_register_one(&fmt_opencl_cryptgost12512);
+john_register_one(&fmt_opencl_cryptstreebog512);
 #else
 
 #include <string.h>
@@ -426,7 +426,7 @@ static unsigned int iteration_count(void *salt)
 #define COMMON_GET_HASH_VAR crypt_out
 #include "common-get-hash.h"
 
-struct fmt_main fmt_opencl_cryptgost12512 = {
+struct fmt_main fmt_opencl_cryptstreebog512 = {
 	{
 		FORMAT_LABEL,
 		FORMAT_NAME,

--- a/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha256_fmt_plug.c
@@ -10,9 +10,9 @@
 #ifdef HAVE_OPENCL
 
 #if FMT_EXTERNS_H
-extern struct fmt_main fmt_opencl_pbkdf2_hmac_sha256;
+extern struct fmt_main fmt_opencl_pbkdf2_sha256;
 #elif FMT_REGISTERS_H
-john_register_one(&fmt_opencl_pbkdf2_hmac_sha256);
+john_register_one(&fmt_opencl_pbkdf2_sha256);
 #else
 
 #include <stdint.h>
@@ -362,7 +362,7 @@ static unsigned int iteration_count(void *salt)
 	return (unsigned int)my_salt->rounds;
 }
 
-struct fmt_main fmt_opencl_pbkdf2_hmac_sha256 = {
+struct fmt_main fmt_opencl_pbkdf2_sha256 = {
 {
 	FORMAT_LABEL,
 	FORMAT_NAME,

--- a/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
+++ b/src/opencl_pbkdf2_hmac_sha512_fmt_plug.c
@@ -11,9 +11,9 @@
 #ifdef HAVE_OPENCL
 
 #if FMT_EXTERNS_H
-extern struct fmt_main fmt_opencl_pbkdf2_hmac_sha512;
+extern struct fmt_main fmt_opencl_pbkdf2_sha512;
 #elif FMT_REGISTERS_H
-john_register_one(&fmt_opencl_pbkdf2_hmac_sha512);
+john_register_one(&fmt_opencl_pbkdf2_sha512);
 #else
 
 #include <stdint.h>
@@ -360,7 +360,7 @@ static unsigned int iteration_count(void *salt)
 	return (unsigned int) my_salt->rounds;
 }
 
-struct fmt_main fmt_opencl_pbkdf2_hmac_sha512 = {
+struct fmt_main fmt_opencl_pbkdf2_sha512 = {
 	{
 		FORMAT_LABEL,
 		FORMAT_NAME,

--- a/src/opencl_tc_fmt_plug.c
+++ b/src/opencl_tc_fmt_plug.c
@@ -10,7 +10,7 @@
 
 #if HAVE_OPENCL
 
-#define FMT_STRUCT fmt_opencl_tc
+#define FMT_STRUCT fmt_opencl_truecrypt
 #if FMT_EXTERNS_H
 extern struct fmt_main FMT_STRUCT;
 #elif FMT_REGISTERS_H


### PR DESCRIPTION
Sort streebogcrypt after gostcrypt, and eg. PBKDF2-HMAC-SHA256-opencl after PBKDF2-HMAC-SHA1-opencl