### PR TITLE
Fix BINARY_ALIGN in a few OpenCL formats

### DIFF
--- a/src/opencl_rawmd4_fmt_plug.c
+++ b/src/opencl_rawmd4_fmt_plug.c
@@ -291,12 +291,12 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 static void *get_binary(char *ciphertext)
 {
-	static unsigned char out[DIGEST_SIZE];
+	static uint32_t out[DIGEST_SIZE];
 	char *p;
 	int i;
 	p = ciphertext + TAG_LENGTH;
 	for (i = 0; i < sizeof(out); i++) {
-		out[i] = (atoi16[ARCH_INDEX(*p)] << 4) | atoi16[ARCH_INDEX(p[1])];
+		((unsigned char*)out)[i] = (atoi16[ARCH_INDEX(*p)] << 4) | atoi16[ARCH_INDEX(p[1])];
 		p += 2;
 	}
 	return out;

--- a/src/opencl_rawmd5_fmt_plug.c
+++ b/src/opencl_rawmd5_fmt_plug.c
@@ -316,12 +316,12 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 static void *get_binary(char *ciphertext)
 {
-	static unsigned char out[DIGEST_SIZE];
+	static uint32_t out[DIGEST_SIZE];
 	char *p;
 	int i;
 	p = ciphertext + TAG_LENGTH;
 	for (i = 0; i < sizeof(out); i++) {
-		out[i] = (atoi16[ARCH_INDEX(*p)] << 4) | atoi16[ARCH_INDEX(p[1])];
+		((unsigned char*)out)[i] = (atoi16[ARCH_INDEX(*p)] << 4) | atoi16[ARCH_INDEX(p[1])];
 		p += 2;
 	}
 	return out;

--- a/src/opencl_solarwinds_fmt_plug.c
+++ b/src/opencl_solarwinds_fmt_plug.c
@@ -42,7 +42,7 @@ john_register_one(&fmt_opencl_solarwinds);
 #define MAX_KEYS_PER_CRYPT      1
 
 #define BINARY_SIZE             64
-#define BINARY_ALIGN            MEM_ALIGN_WORD
+#define BINARY_ALIGN            4
 #define SALT_SIZE               sizeof(*cur_salt)
 #define SALT_ALIGN              MEM_ALIGN_WORD
 


### PR DESCRIPTION
It's amazing we still have this problem 12 years after introducing the alignment warnings.