### PR TITLE
OpenCL device_info robustness: Use |= instead of +=

### DIFF
--- a/run/opencl/opencl_device_info.h
+++ b/run/opencl/opencl_device_info.h
@@ -12,7 +12,6 @@
 #ifndef OPENCL_DEVICE_INFO_H
 #define	OPENCL_DEVICE_INFO_H
 
-//Copied from opencl_common.h
 #define DEV_UNKNOWN                 0           //0
 #define DEV_CPU                     (1 << 0)    //1
 #define DEV_GPU                     (1 << 1)    //2

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1555,7 +1555,7 @@ static cl_ulong gws_test(size_t gws, unsigned int rounds, int sequential_id)
 	for (i = 0; (*multi_profilingEvent[i]); i++)
 		number_of_events++;
 
-	//** Get execution time **//
+	/* Get execution time */
 	for (i = 0; i < number_of_events; i++) {
 		char mult[32] = "";
 
@@ -2155,22 +2155,22 @@ static void load_device_info(int sequential_id)
 	else if (device == CL_DEVICE_TYPE_ACCELERATOR)
 		device_info[sequential_id] = DEV_ACCELERATOR;
 
-	device_info[sequential_id] += get_vendor_id(sequential_id);
-	device_info[sequential_id] += get_processor_family(sequential_id);
-	device_info[sequential_id] += get_byte_addressable(sequential_id);
+	device_info[sequential_id] |= get_vendor_id(sequential_id);
+	device_info[sequential_id] |= get_processor_family(sequential_id);
+	device_info[sequential_id] |= get_byte_addressable(sequential_id);
 
 	get_compute_capability(sequential_id, &major, &minor);
 
 	if (major) {
-		device_info[sequential_id] += (major == 2 ? DEV_NV_C2X : 0);
-		device_info[sequential_id] +=
+		device_info[sequential_id] |= (major == 2 ? DEV_NV_C2X : 0);
+		device_info[sequential_id] |=
 		    (major == 3 && minor == 0 ? DEV_NV_C30 : 0);
-		device_info[sequential_id] +=
+		device_info[sequential_id] |=
 		    (major == 3 && minor == 2 ? DEV_NV_C32 : 0);
-		device_info[sequential_id] +=
+		device_info[sequential_id] |=
 		    (major == 3 && minor == 5 ? DEV_NV_C35 : 0);
-		device_info[sequential_id] += (major == 5 ? DEV_NV_MAXWELL : 0);
-		device_info[sequential_id] += (major >= 5 ? DEV_NV_MAXWELL_PLUS : 0);
+		device_info[sequential_id] |= (major == 5 ? DEV_NV_MAXWELL : 0);
+		device_info[sequential_id] |= (major >= 5 ? DEV_NV_MAXWELL_PLUS : 0);
 	}
 }
 
@@ -2654,8 +2654,7 @@ cl_uint get_processor_family(int sequential_id)
 	if (*dname)
 		strlwr(&dname[1]);
 
-	if gpu_amd
-	(device_info[sequential_id]) {
+	if (gpu_amd(device_info[sequential_id])) {
 
 		if ((strstr(dname, "Cedar") ||  //AMD Radeon VLIW5
 		        strstr(dname, "Redwood") || strstr(dname, "Juniper")


### PR DESCRIPTION
Also fix a few weird syntaxes in opencl_common.c

See #5417