### PR TITLE
Use positional argument for input files in 2john scripts

### DIFF
--- a/run/aix2john.py
+++ b/run/aix2john.py
@@ -17,7 +17,6 @@
 
 
 import argparse
-import binascii
 import sys
 import re
 
@@ -62,26 +61,17 @@ def process_file(filename, is_standard):
 
 if __name__ == "__main__":
 
-    if len(sys.argv) < 2:
-        sys.stderr.write("Usage: %s [-s] -f <AIX passwd file (/etc/security/passwd)>\n" % sys.argv[0])
-        sys.exit(1)
-
     parser = argparse.ArgumentParser()
     parser.add_argument('-s', action="store_true",
         default=False,
         dest="is_standard",
         help='Use this option if "lpa_options = std_hash=true" is activated'
-        )
+    )
 
-    parser.add_argument('-f', dest="filename",
-        default=False,
-        help='Specify the AIX shadow file filename to read (usually /etc/security/passwd)'
-        )
+    parser.add_argument("filename",
+        help='The AIX shadow file to read (usually /etc/security/passwd)'
+    )
 
     args = parser.parse_args()
 
-    if args.filename:
-        process_file(args.filename, args.is_standard)
-    else:
-        print("Please specify a filename (-f)")
-        sys.exit(1)
+    process_file(args.filename, args.is_standard)

--- a/run/radius2john.py
+++ b/run/radius2john.py
@@ -12,14 +12,14 @@
 # ---
 
 # Utility to bruteforce RADIUS shared-secret
-# Usage: ./radius2john.py -f <pcap files>
+# Usage: ./radius2john.py <pcap files>
 #
 # This script depends on Scapy (https://scapy.net)
 # To install: pip install --user scapy
 
 # ---
 
-# Application of two  methods described in http://www.untruth.org/~josh/security/radius/radius-auth.html :
+# Application of two  methods described in https://www.untruth.org/~josh/security/radius/radius-auth.html :
 # "3.3 User-Password Attribute Based Shared Secret Attack"
 # "3.1 Response Authenticator Based Shared Secret Attack"
 
@@ -40,9 +40,11 @@ try:
     import scapy.all as scapy
 except ImportError:
     print(
-        "Scapy seems to be missing, run 'pip install --user scapy' to install it"
+        "Scapy seems to be missing, run 'pip install --user scapy' to install it",
+        file=sys.stderr
     )
     sys.exit(1)
+
 
 def read_file(args, filename):
     packets = scapy.rdpcap(filename)
@@ -122,11 +124,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,epilog=
     """
     ### Utility to bruteforce RADIUS shared-secret written by k4amos
-    Basic Usage: ./radius2john.py -f <pcap files>"
 
     ---
 
-    Application of two  methods described in http://www.untruth.org/~josh/security/radius/radius-auth.html :
+    Application of two  methods described in https://www.untruth.org/~josh/security/radius/radius-auth.html :
     - "3.3 User-Password Attribute Based Shared Secret Attack"
     - "3.1 Response Authenticator Based Shared Secret Attack"
 
@@ -140,9 +141,9 @@ if __name__ == "__main__":
     and dumps md5 and salt as needed.
     """)
 
-    parser.add_argument('-f', '--file', type=str, required=True, nargs='+')
-    parser.add_argument('--single', help='To get only one hash per client IPs', action='store_true', default=False)
-    parser.add_argument('-l', '--login', type=str,help='User login used for the 3.3 attack')
+    parser.add_argument('file', type=str, nargs='+', help='Input PCAP files')
+    parser.add_argument('--single', help='To get only one hash per client IP', action='store_true', default=False)
+    parser.add_argument('-l', '--login', type=str, help='User login used for the 3.3 attack')
     parser.add_argument('-p', '--password', type=str, help='User password used for the 3.3 attack')
 
     parsed_args = parser.parse_args()
@@ -150,10 +151,7 @@ if __name__ == "__main__":
 
     if args["login"] is not None and args["password"] is None:
         # Attack 3.3 can work without login verification (if there is only one client, there is no point), but cannot work without a password
-        print("You must specify the password used by the client for the '3.3 User-Password Attribute Based Shared Secret Attack'")
-        print("Basic Usage: ./radius2john.py -f <pcap files>")
-        print("You can specify '-h' to display help")
-        sys.exit(1)
+        parser.error("You must specify the password used by the client for the '3.3 User-Password Attribute Based Shared Secret Attack'")
 
     all_requests = {}
     dumped_ips = {}


### PR DESCRIPTION
As requested in https://github.com/openwall/john/pull/5643#discussion_r1903171219 this PR turns the input file arguments for `radius2john.py` and `aix2john.py` into positional arguments.

Plus a bit of cleanup while I was at it.