### PR TITLE
OpenCL inline fixes and GOST formats tweaks

### DIFF
--- a/run/opencl/opencl_gost94.h
+++ b/run/opencl/opencl_gost94.h
@@ -300,7 +300,7 @@ INLINE void rhash_gost94_compute_sum_and_hash(gost94_ctx * ctx, const uint* bloc
  * @param msg message chunk
  * @param size length of the message chunk
  */
-NOINLINE void gost94_update(gost94_ctx *ctx, const uchar* msg, uint size, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
+static NOINLINE void gost94_update(gost94_ctx *ctx, const uchar* msg, uint size, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
 {
 	uint index = ctx->length & 31;
 	ctx->length += size;
@@ -361,7 +361,7 @@ INLINE void rhash_u32_swap_copy(void* to, const void* from, uint length) {
  * @param ctx the algorithm context containing current hashing state
  * @param result calculated hash in binary form
  */
-NOINLINE void gost94_final(gost94_ctx *ctx, uchar *result, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
+static NOINLINE void gost94_final(gost94_ctx *ctx, uchar *result, MAYBE_LOCAL const rhash_gost94_sbox *sbox)
 {
 	uint  index = ctx->length & 31;
 	uint* msg32 = (uint*)ctx->message;

--- a/run/opencl/opencl_misc.h
+++ b/run/opencl/opencl_misc.h
@@ -58,12 +58,14 @@ typedef uint32_t host_size_t;
 
 #define NOINLINE  __attribute__((noinline))
 
+#ifndef INLINE
 #if __MESA__
 #define INLINE
 #elif __POCL__
 #define INLINE    inline
 #else
 #define INLINE    static inline
+#endif
 #endif
 
 #endif /* _OPENCL_COMPILER */

--- a/run/opencl/opencl_streebog.h
+++ b/run/opencl/opencl_streebog.h
@@ -48,6 +48,10 @@
 #define UNROLL16
 #endif
 
+#if STREEBOG512CRYPT && !defined STREEBOG512
+#define STREEBOG512	1
+#endif
+
 #if STREEBOG_VECTOR
 #define memcpy512(dst, src) do {	  \
 		(dst)->VWORD = (src)->VWORD; \
@@ -906,7 +910,7 @@ stage3(GOST34112012Context *CTX, __local localbuf *loc_buf)
 	g0(&(CTX->h), &(CTX->Sigma), loc_buf);
 }
 
-NOINLINE void
+static NOINLINE void
 GOST34112012Update(GOST34112012Context *CTX, const uchar *data, uint len, __local localbuf *loc_buf)
 {
 	if (CTX->bufsize) {
@@ -937,15 +941,16 @@ GOST34112012Update(GOST34112012Context *CTX, const uchar *data, uint len, __loca
 	}
 }
 
-NOINLINE void
+static NOINLINE void
 GOST34112012Final(GOST34112012Context *CTX,
-#if STREEBOG512CRYPT
-                  uint512_u
-#else
-                  uint256_u
-#endif
-                  *digest, __local localbuf *loc_buf)
+                  void *_digest,
+                  __local localbuf *loc_buf)
 {
+#if STREEBOG512
+	uint512_u *digest = _digest;
+#else
+	uint256_u *digest = _digest;
+#endif
 	stage3(CTX, loc_buf);
 
 	CTX->bufsize = 0;


### PR DESCRIPTION
Our new-ish INLINE macro now started misbehaving on macos (re-definition). Also, the shared Streebog code had some type issues fixed here.