### PR TITLE
logger.c: Retry file lock also after ENOLCK

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1394,6 +1394,8 @@ static void john_load(void)
 		if (mpi_p > 1)
 			john_set_mpi();
 #endif
+		/* Without this, all nodes get the same PRNG sequence. */
+		srand(NODE);
 	}
 #if HAVE_OPENCL
 	/*


### PR DESCRIPTION
This means "No locks available".  We now handle it just like EAGAIN, retrying and hoping for recover.

Also adds diagnostic output of the lock delay when this happens.