### PR TITLE
Monero "slow hash": start to use AES-NI and widening MUL

### DIFF
--- a/src/int-util.h
+++ b/src/int-util.h
@@ -49,6 +49,10 @@ static inline uint64_t lo_dword(uint64_t val) {
 }
 
 static inline uint64_t mul128(uint64_t multiplier, uint64_t multiplicand, uint64_t* product_hi) {
+#if defined(__GNUC__) && defined(__x86_64__)
+  __asm__("mul %2" : "+a" (multiplier), "=d" (*product_hi) : "r" (multiplicand) : "cc");
+  return multiplier;
+#else
   // multiplier   = ab = a * 2^32 + b
   // multiplicand = cd = c * 2^32 + d
   // ab * cd = a * c * 2^64 + (a * d + b * c) * 2^32 + b * d
@@ -72,6 +76,7 @@ static inline uint64_t mul128(uint64_t multiplier, uint64_t multiplicand, uint64
   assert(ac <= *product_hi);
 
   return product_lo;
+#endif
 }
 
 static inline uint64_t div_with_reminder(uint64_t dividend, uint32_t divisor, uint32_t* remainder) {

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -192,7 +192,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash)
 		xor_blocks(b, c);
 		swap_blocks(b, c);
 		copy_block(&long_state[j * AES_BLOCK_SIZE], c);
-		assert(j == e2i(a, MEMORY / AES_BLOCK_SIZE));
+		//assert(j == e2i(a, MEMORY / AES_BLOCK_SIZE));
 		swap_blocks(a, b);
 		/* Iteration 2 */
 		j = e2i(a, MEMORY / AES_BLOCK_SIZE);
@@ -202,7 +202,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash)
 		swap_blocks(b, c);
 		xor_blocks(b, c);
 		copy_block(&long_state[j * AES_BLOCK_SIZE], c);
-		assert(j == e2i(a, MEMORY / AES_BLOCK_SIZE));
+		//assert(j == e2i(a, MEMORY / AES_BLOCK_SIZE));
 		swap_blocks(a, b);
 	}
 


### PR DESCRIPTION
This optimizes only one of several loops.

Separately, we should also switch to using AES-NI, perhaps via our shared code, in the other loops where it's more complete AES rather than just one round.

The speedup from these changes is moderate - the partial usage of AES-NI may be adding tens of percent of performance, but the widening MUL is hardly measurable (but the generated assembly code does look simpler, with 1 instead of 4 MULs).