### PR TITLE
Monero: Use AES-NI almost fully, reduce overhead

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -400,7 +400,7 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Dropped our old AES-NI code in favor of the AES code from mbedTLS, which
   supports AES-NI (Intel) as well as AES-CE (Arm).  The new code kicks in for
-  any format using AES.  Boosts of up to 13x seen on Intel and 7x on MacBook
+  most formats using AES.  Boosts of up to 13x seen on Intel and 7x on MacBook
   M1 (those are for the KeePass format with AES-KDF, which is extreme because
   all the heavy lifting is AES).  [magnum, Solar; 2024]
 
@@ -412,6 +412,8 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Add oracle2john.py and fix the o5logon format to support passwords longer
   than 16.  [k4amos; 2024]
+
+- Optimize the Monero format, use AES-NI for a ~10x speedup.  [Solar; 2025]
 
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):

--- a/src/bench.c
+++ b/src/bench.c
@@ -753,11 +753,11 @@ AGAIN:
 		}
 
 		/* FIXME: Kludge for thin dynamics, and OpenCL formats */
-		/* c3_fmt also added, since it is a somewhat dynamic   */
-		/* format and needs init called to change the name     */
+		/* Monero and crypt also added since they change their name */
 		if ((format->params.flags & FMT_DYNAMIC) ||
 		    strstr(format->params.label, "-opencl") ||
 		    strstr(format->params.label, "-ztex") ||
+		    !strcmp(format->params.label, "Monero") ||
 		    !strcmp(format->params.label, "crypt")) {
 #ifdef HAVE_OPENCL
 /*

--- a/src/monero_fmt_plug.c
+++ b/src/monero_fmt_plug.c
@@ -42,6 +42,7 @@ john_register_one(&fmt_monero);
 #define FORMAT_TAG              "$monero$"
 #define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
 #define ALGORITHM_NAME          "Pseudo-AES / ChaCha / Various 32/" ARCH_BITS_STR
+#define ALGORITHM_NAME_AESNI    "Pseudo-AES / ChaCha / Various " ARCH_BITS_STR "/" ARCH_BITS_STR " AES-NI"
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        7
 #define PLAINTEXT_LENGTH        125
@@ -85,6 +86,9 @@ static struct custom_salt {
 
 static void init(struct fmt_main *self)
 {
+	if (cn_slow_hash_aesni())
+		self->params.algorithm_name = ALGORITHM_NAME_AESNI;
+
 	omp_autotune(self, OMP_SCALE);
 
 #ifdef _OPENMP

--- a/src/oaes_lib.h
+++ b/src/oaes_lib.h
@@ -181,6 +181,8 @@ OAES_API OAES_RET oaes_encryption_round( const uint8_t * key, uint8_t * c );
 
 OAES_API OAES_RET oaes_pseudo_encrypt_ecb( OAES_CTX * ctx, uint8_t * c );
 
+OAES_API uint8_t * oaes_get_exp_data( const OAES_CTX * ctx );
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/oaes_lib_plug.c
+++ b/src/oaes_lib_plug.c
@@ -1334,3 +1334,9 @@ OAES_API OAES_RET oaes_pseudo_encrypt_ecb( OAES_CTX * ctx, uint8_t * c )
 
 	return OAES_RET_SUCCESS;
 }
+
+OAES_API uint8_t * oaes_get_exp_data( const OAES_CTX * ctx )
+{
+	oaes_ctx * _ctx = (oaes_ctx *) ctx;
+	return _ctx->key->exp_data;
+}

--- a/src/oaes_lib_plug.c
+++ b/src/oaes_lib_plug.c
@@ -40,6 +40,7 @@
 #endif
 
 #include "oaes_lib.h"
+#include "memory.h"
 
 #define OAES_RKEY_LEN 4
 #define OAES_COL_LEN 4
@@ -506,7 +507,7 @@ static OAES_RET oaes_key_expand( OAES_CTX * ctx )
 
 	_ctx->key->exp_data_len = _ctx->key->num_keys * OAES_RKEY_LEN * OAES_COL_LEN;
 	_ctx->key->exp_data = (uint8_t *)
-			calloc( _ctx->key->exp_data_len, sizeof( uint8_t ));
+			mem_calloc_align( _ctx->key->exp_data_len, sizeof( uint8_t ), 16);
 
 	if( NULL == _ctx->key->exp_data )
 		return OAES_RET_MEM;

--- a/src/slow_hash.h
+++ b/src/slow_hash.h
@@ -1,1 +1,2 @@
-int cn_slow_hash(const void *data, size_t length, char *hash, void *memory);
+extern int cn_slow_hash(const void *data, size_t length, char *hash, void *memory);
+extern int cn_slow_hash_aesni(void);

--- a/src/slow_hash.h
+++ b/src/slow_hash.h
@@ -1,1 +1,1 @@
-void cn_slow_hash(const void *data, size_t length, char *hash);
+int cn_slow_hash(const void *data, size_t length, char *hash, void *memory);

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -26,6 +26,7 @@
 #include "jh.h"
 #include "keccak.h"
 #include "sph_skein.h"
+#include "slow_hash.h"
 
 union hash_state {
 	uint8_t b[200];
@@ -276,4 +277,13 @@ int cn_slow_hash(const void *data, size_t length, char *hash, void *memory)
 	extra_hashes[state.hs.b[0] & 3](&state, 200, hash);
 	oaes_free(&aes_ctx);
 	return 0;
+}
+
+int cn_slow_hash_aesni(void)
+{
+#if MBEDTLS_AESNI_HAVE_CODE == 2
+	return mbedtls_aesni_has_support(MBEDTLS_AESNI_AES);
+#else
+	return 0;
+#endif
 }

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -130,11 +130,11 @@ static inline void xor_blocks(block *a, const block *b) {
 
 #pragma pack(push, 1)
 union cn_slow_hash_state {
-  union hash_state hs;
-  struct {
-    uint8_t k[64];
-    uint8_t init[INIT_SIZE_BYTE];
-  };
+	union hash_state hs;
+	struct {
+		uint64_t k[8];
+		uint8_t init[INIT_SIZE_BYTE];
+	};
 };
 #pragma pack(pop)
 
@@ -203,10 +203,10 @@ void cn_slow_hash(const void *data, size_t length, char *hash)
 		memcpy(&long_state[i * INIT_SIZE_BLK], text, INIT_SIZE_BYTE);
 	}
 
-	for (i = 0; i < 16; i++) {
-		a.b[i] = state.k[     i] ^ state.k[32 + i];
-		b.b[i] = state.k[16 + i] ^ state.k[48 + i];
-	}
+	a.u64[0] = state.k[0] ^ state.k[4];
+	a.u64[1] = state.k[1] ^ state.k[5];
+	b.u64[0] = state.k[2] ^ state.k[6];
+	b.u64[1] = state.k[3] ^ state.k[7];
 
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 	/* Dependency chain: address -> read value ------+

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -37,19 +37,15 @@ void hash_permutation(union hash_state *state);
 void hash_process(union hash_state *state, const uint8_t *buf, size_t count);
 
 enum {
-	HASH_SIZE = 32,
-	HASH_DATA_AREA = 136
+	HASH_SIZE = 32
 };
 
-void cn_fast_hash(const void *data, size_t length, char *hash);
 void cn_slow_hash(const void *data, size_t length, char *hash);
 
 void hash_extra_blake(const void *data, size_t length, char *hash);
 void hash_extra_groestl(const void *data, size_t length, char *hash);
 void hash_extra_jh(const void *data, size_t length, char *hash);
 void hash_extra_skein(const void *data, size_t length, char *hash);
-
-void tree_hash(const char (*hashes)[HASH_SIZE], size_t count, char *root_hash);
 
 static void (*const extra_hashes[4])(const void *, size_t, char *) = {
 	hash_extra_blake, hash_extra_groestl, hash_extra_jh, hash_extra_skein
@@ -151,13 +147,6 @@ void hash_permutation(union hash_state *state)
 void hash_process(union hash_state *state, const uint8_t *buf, size_t count)
 {
 	keccak1600(buf, count, (uint8_t*)state);
-}
-
-void cn_fast_hash(const void *data, size_t length, char *hash)
-{
-	union hash_state state;
-	hash_process(&state, data, length);
-	memcpy(hash, &state, HASH_SIZE);
 }
 
 #if MBEDTLS_AESNI_HAVE_CODE == 2

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -172,7 +172,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash)
 #if MBEDTLS_AESNI_HAVE_CODE == 2
 	const int have_aesni = mbedtls_aesni_has_support(MBEDTLS_AESNI_AES);
 #endif
-	block *long_state = mem_alloc(MEMORY); // This is 2 MiB, too large for stack
+	block *long_state = mem_alloc_align(MEMORY, AES_BLOCK_SIZE); // This is 2 MiB, too large for stack
 	OAES_CTX *aes_ctx = oaes_alloc();
 	union cn_slow_hash_state state;
 	block text[INIT_SIZE_BLK];

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -82,9 +82,9 @@ void hash_extra_skein(const void *data, size_t length, char *hash)
 #define INIT_SIZE_BLK   8
 #define INIT_SIZE_BYTE (INIT_SIZE_BLK * AES_BLOCK_SIZE)
 
-static size_t e2i(const uint8_t* a, size_t count) { return (*((uint64_t*)a) / AES_BLOCK_SIZE) & (count - 1); }
+static inline size_t e2i(const uint8_t* a, size_t count) { return (*((uint64_t*)a) / AES_BLOCK_SIZE) & (count - 1); }
 
-static void mul(const uint8_t* a, const uint8_t* b, uint8_t* res) {
+static inline void mul(const uint8_t* a, const uint8_t* b, uint8_t* res) {
   uint64_t a0, b0;
   uint64_t hi, lo;
 
@@ -95,7 +95,7 @@ static void mul(const uint8_t* a, const uint8_t* b, uint8_t* res) {
   ((uint64_t*)res)[1] = SWAP64LE(lo);
 }
 
-static void sum_half_blocks(uint8_t* a, const uint8_t* b) {
+static inline void sum_half_blocks(uint8_t* a, const uint8_t* b) {
   uint64_t a0, a1, b0, b1;
 
   a0 = SWAP64LE(((uint64_t*)a)[0]);
@@ -108,11 +108,11 @@ static void sum_half_blocks(uint8_t* a, const uint8_t* b) {
   ((uint64_t*)a)[1] = SWAP64LE(a1);
 }
 
-static void copy_block(uint8_t* dst, const uint8_t* src) {
+static inline void copy_block(uint8_t* dst, const uint8_t* src) {
   memcpy(dst, src, AES_BLOCK_SIZE);
 }
 
-static void swap_blocks(uint8_t* a, uint8_t* b) {
+static inline void swap_blocks(uint8_t* a, uint8_t* b) {
   size_t i;
   uint8_t t;
   for (i = 0; i < AES_BLOCK_SIZE; i++) {
@@ -122,7 +122,7 @@ static void swap_blocks(uint8_t* a, uint8_t* b) {
   }
 }
 
-static void xor_blocks(uint8_t* a, const uint8_t* b) {
+static inline void xor_blocks(uint8_t* a, const uint8_t* b) {
   size_t i;
   for (i = 0; i < AES_BLOCK_SIZE; i++) {
     a[i] ^= b[i];


### PR DESCRIPTION
This provides a ~10x speedup in my testing.

There's still more room for optimization - such as keeping the memory allocation around across calls, like we do for (ye)scrypt and Argon2, not yet implemented here. Also concurrent computation of more than one instance may be faster.

I also tried what looks like an even simpler code version for the main loop, but somehow it performs slower than what's in this PR, included below for possible future experiments:

```c
                /* Iteration 1 */
                j = e2i(&a, MEMORY / AES_BLOCK_SIZE);
                c = long_state[j];
#if MBEDTLS_AESNI_HAVE_CODE == 2
                if (have_aesni)
                        c.v = _mm_aesenc_si128(c.v, a.v);
                else
#endif
                        oaes_encryption_round(a.b, c.b);
                xor_blocks(&b, &c);
                long_state[j] = b;
                /* Iteration 2 */
                j = e2i(&c, MEMORY / AES_BLOCK_SIZE);
                b = long_state[j];
                mul(&b, &c, &d);
                sum_half_blocks(&a, &d);
                long_state[j] = a;
#if 0 && MBEDTLS_AESNI_HAVE_CODE == 2
                a.v = _mm_xor_si128(a.v, b.v);
#else
                a.u64[0] ^= b.u64[0];
                a.u64[1] ^= b.u64[1];
#endif
                b = c;
```