### PR TITLE
slow_hash_plug.c as used for Monero: Use AES-NI almost fully

### DIFF
--- a/src/oaes_lib_plug.c
+++ b/src/oaes_lib_plug.c
@@ -40,6 +40,7 @@
 #endif
 
 #include "oaes_lib.h"
+#include "memory.h"
 
 #define OAES_RKEY_LEN 4
 #define OAES_COL_LEN 4
@@ -506,7 +507,7 @@ static OAES_RET oaes_key_expand( OAES_CTX * ctx )
 
 	_ctx->key->exp_data_len = _ctx->key->num_keys * OAES_RKEY_LEN * OAES_COL_LEN;
 	_ctx->key->exp_data = (uint8_t *)
-			calloc( _ctx->key->exp_data_len, sizeof( uint8_t ));
+			mem_calloc_align( _ctx->key->exp_data_len, sizeof( uint8_t ), 16);
 
 	if( NULL == _ctx->key->exp_data )
 		return OAES_RET_MEM;

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -190,7 +190,7 @@ void cn_slow_hash(const void *data, size_t length, char *hash)
 	const int have_aesni = mbedtls_aesni_has_support(MBEDTLS_AESNI_AES);
 #endif
 	//uint8_t long_state[MEMORY]; // This is 2 MB, too large for stack
-	uint8_t *long_state = mem_alloc(MEMORY);
+	uint8_t *long_state = mem_alloc_align(MEMORY, AES_BLOCK_SIZE); // This is 2 MiB, too large for stack
 	union cn_slow_hash_state state;
 	uint8_t text[INIT_SIZE_BYTE];
 	uint8_t a[AES_BLOCK_SIZE] JTR_ALIGN(16);


### PR DESCRIPTION
Except for key setup, which isn't performance critical in this code and where it isn't clear whether/how AES-NI fits.

This is just the first commit from #5667 to have it separately tested by our CircleCI jobs.