### PR TITLE
Monero & slow hash minor changes + add inline asm

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -413,7 +413,9 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 - Add oracle2john.py and fix the o5logon format to support passwords longer
   than 16.  [k4amos; 2024]
 
-- Optimize the Monero format, use AES-NI for a ~10x speedup.  [Solar; 2025]
+- Optimize the Monero format, speedup for one wallet is ~18x (mostly due to
+  AES-NI) and almost N times more than that for N wallets attacked concurrently
+  [Solar; 2025]
 
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):

--- a/src/armory_fmt_plug.c
+++ b/src/armory_fmt_plug.c
@@ -149,7 +149,7 @@ static void done(void)
  * than the tests.  However, don't do this when proceeding from self-test to
  * benchmark, so that memory (de)allocation time doesn't affect the speeds.
  */
-void reset(struct db_main *db)
+static void reset(struct db_main *db)
 {
 	if (benchmark_running)
 		return;

--- a/src/bench.c
+++ b/src/bench.c
@@ -754,11 +754,11 @@ AGAIN:
 		}
 
 		/* FIXME: Kludge for thin dynamics, and OpenCL formats */
-		/* c3_fmt also added, since it is a somewhat dynamic   */
-		/* format and needs init called to change the name     */
+		/* Monero and crypt also added since they change their name */
 		if ((format->params.flags & FMT_DYNAMIC) ||
 		    strstr(format->params.label, "-opencl") ||
 		    strstr(format->params.label, "-ztex") ||
+		    !strcmp(format->params.label, "Monero") ||
 		    !strcmp(format->params.label, "crypt")) {
 #ifdef HAVE_OPENCL
 /*

--- a/src/memory.c
+++ b/src/memory.c
@@ -635,7 +635,7 @@ void alter_endianity_w64(void *_x, unsigned int count) {
 #include <sys/mman.h>
 #endif
 
-#define HUGEPAGE_THRESHOLD		(12 * 1024 * 1024)
+#define HUGEPAGE_THRESHOLD		(2 * 1024 * 1024)
 
 #ifdef __x86_64__
 #define HUGEPAGE_SIZE			(2 * 1024 * 1024)

--- a/src/monero_fmt_plug.c
+++ b/src/monero_fmt_plug.c
@@ -63,7 +63,7 @@ static struct fmt_tests tests[] = {
 
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *saved_len;
-static char (*saved_slow_hash)[64];
+static char (*saved_slow_hash)[32];
 static int keys_changed, any_cracked, *cracked;
 static size_t cracked_size;
 

--- a/src/monero_fmt_plug.c
+++ b/src/monero_fmt_plug.c
@@ -34,7 +34,12 @@ john_register_one(&fmt_monero);
 #define FORMAT_NAME             "Monero Wallet"
 #define FORMAT_TAG              "$monero$"
 #define TAG_LENGTH              (sizeof(FORMAT_TAG) - 1)
-#define ALGORITHM_NAME          "Pseudo-AES / ChaCha / Various 32/" ARCH_BITS_STR
+#define ALGORITHM_NAME          "Pseudo-AES/Keccak/BLAKE/Groestl/JH/Skein/ChaCha 8/" ARCH_BITS_STR
+#if __AVX__
+#define ALGORITHM_NAME_AESNI    "Pseudo-AES/Keccak/BLAKE/Groestl/JH/Skein/ChaCha 128/128 AVX AES-NI"
+#else
+#define ALGORITHM_NAME_AESNI    "Pseudo-AES/Keccak/BLAKE/Groestl/JH/Skein/ChaCha 128/128 SSE4.1 AES-NI"
+#endif
 #define BENCHMARK_COMMENT       ""
 #define BENCHMARK_LENGTH        7
 #define PLAINTEXT_LENGTH        125
@@ -78,6 +83,9 @@ static struct custom_salt {
 
 static void init(struct fmt_main *self)
 {
+	if (cn_slow_hash_aesni())
+		self->params.algorithm_name = ALGORITHM_NAME_AESNI;
+
 	omp_autotune(self, OMP_SCALE);
 
 #ifdef _OPENMP

--- a/src/slow_hash.h
+++ b/src/slow_hash.h
@@ -1,1 +1,2 @@
 extern int cn_slow_hash(const void *data, size_t length, char *hash, void *memory);
+extern int cn_slow_hash_aesni(void);

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -397,3 +397,12 @@ fail:
 	oaes_free(&aes_ctx);
 	return -1;
 }
+
+int cn_slow_hash_aesni(void)
+{
+#if MBEDTLS_AESNI_HAVE_CODE == 2
+	return mbedtls_aesni_has_support(MBEDTLS_AESNI_AES);
+#else
+	return 0;
+#endif
+}

--- a/src/slow_hash_plug.c
+++ b/src/slow_hash_plug.c
@@ -212,18 +212,17 @@ int cn_slow_hash(const void *data, size_t length, char *hash, void *memory)
 	for (i = 0; i < ITER / 2; i++) {
 		/* Iteration 1 */
 		j = e2i(&a, MEMORY / AES_BLOCK_SIZE);
-		c = long_state[j];
-		c.v = _mm_aesenc_si128(c.v, a.v);
+		c.v = _mm_aesenc_si128(long_state[j].v, a.v);
 		xor_blocks(&b, &c);
-		long_state[j] = b;
-		block e = a; a = c;
+		long_state[j].v = b.v;
+		block e = a; a.v = c.v;
 		/* Iteration 2 */
 		j = e2i(&a, MEMORY / AES_BLOCK_SIZE);
-		c = long_state[j];
+		c.v = long_state[j].v;
 		mul(&a, &c, &d);
 		sum_half_blocks(&e, &d);
-		long_state[j] = e;
-		b = a;
+		long_state[j].v = e.v;
+		b.v = a.v;
 #if 0
 		a.v = _mm_xor_si128(c.v, e.v);
 #else

--- a/src/yescrypt/yescrypt-platform.c
+++ b/src/yescrypt/yescrypt-platform.c
@@ -25,7 +25,7 @@
 #include <linux/mman.h> /* for MAP_HUGE_2MB */
 #endif
 
-#define HUGEPAGE_THRESHOLD		(32 * 1024 * 1024)
+#define HUGEPAGE_THRESHOLD		(12 * 1024 * 1024)
 
 #ifdef __x86_64__
 #define HUGEPAGE_SIZE			(2 * 1024 * 1024)


### PR DESCRIPTION
The inline asm didn't work out yet - it's smaller, but slower (in my testing, YMMV). Perhaps the whole idea of keeping the `a` and `b` blocks in SIMD registers isn't a great fit for the 2nd iteration with its scalar MUL, which may be why compiler-generated code is sometimes faster (after the C source had been tweaked). Perhaps keeping them in memory can be faster. Where by "keeping" I mean their "primary" location across remaining iterations of the unrolled loop. What happens inside the loop's body can then be optimized arbitrarily.