### PR TITLE
Oubliette: expanded supported database version to 3.x (Oubliette v1.5)

### DIFF
--- a/src/oubliette_blowfish_fmt_plug.c
+++ b/src/oubliette_blowfish_fmt_plug.c
@@ -107,7 +107,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if (sscanf(p, "%d.%d", &version, &minor) != 2)
 		goto err;
-	if (version != 1 || minor != 0)
+	if (version < 1 || version > 3)
 		goto err;
 
 	if ((p = strtokm(NULL, "$")) == NULL)	/* hash */

--- a/src/oubliette_idea_fmt_plug.c
+++ b/src/oubliette_idea_fmt_plug.c
@@ -105,7 +105,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 		goto err;
 	if (sscanf(p, "%d.%d", &version, &minor) != 2)
 		goto err;
-	if (version != 1 || minor != 0)
+	if (version < 1 || version > 3)
 		goto err;
 
 	if ((p = strtokm(NULL, "$")) == NULL)	/* hash */


### PR DESCRIPTION
Hi.
Minor patch to support latest (last) version of Oubliette.
