### PR TITLE
Workaround many OpenCL format self-test failures, and general OpenCL fixes

### DIFF
--- a/run/opencl/ansible_kernel.cl
+++ b/run/opencl/ansible_kernel.cl
@@ -35,5 +35,10 @@ __kernel void ansible_final(__global crack_t *out,
 
 	pbkdf2_sha256_final(out, &salt->pbkdf2, state);
 
+#if gpu_amd(DEVICE_INFO)
+/* Workaround miscompile with AMD-APP 2766.4 */
+	(void) *(volatile __global uint *)out[ix].hash;
+#endif
+
 	hmac_sha256(out[ix].hash, 32, salt->blob, salt->bloblen, out[ix].hash, 16);
 }

--- a/run/opencl/opencl_hmac_sha1.h
+++ b/run/opencl/opencl_hmac_sha1.h
@@ -94,10 +94,16 @@ INLINE void hmac_sha1(HMAC_KEY_TYPE void *_key, uint key_len,
 	SHA1_Final(local_digest, &ctx);
 	for (i = 0; i < 16; i++)
 		u.pW[i] ^= (0x36363636 ^ 0x5c5c5c5c);
+#if gpu_amd(DEVICE_INFO)
+/* Workaround miscompile with AMD-APP 2766.4 */
+	SHA_CTX ctx2;
+#define ctx ctx2
+#endif
 	SHA1_Init(&ctx);
 	SHA1_Update(&ctx, u.buf, 64);
 	SHA1_Update(&ctx, local_digest, 20);
 	SHA1_Final(local_digest, &ctx);
+#undef ctx
 
 	memcpy_macro(digest, local_digest, digest_len);
 }

--- a/run/opencl/opencl_hmac_sha256.h
+++ b/run/opencl/opencl_hmac_sha256.h
@@ -97,10 +97,16 @@ INLINE void hmac_sha256(HMAC_KEY_TYPE void *_key, uint key_len,
 	SHA256_Final(local_digest, &ctx);
 	for (i = 0; i < 16; i++)
 		u.pW[i] ^= (0x36363636 ^ 0x5c5c5c5c);
+#if gpu_amd(DEVICE_INFO)
+/* Workaround miscompile with AMD-APP 2766.4 */
+	SHA256_CTX ctx2;
+#define ctx ctx2
+#endif
 	SHA256_Init(&ctx);
 	SHA256_Update(&ctx, u.buf, 64);
 	SHA256_Update(&ctx, local_digest, 32);
 	SHA256_Final(local_digest, &ctx);
+#undef ctx
 
 	memcpy_macro(digest, local_digest, digest_len);
 }

--- a/run/opencl/opencl_hmac_sha512.h
+++ b/run/opencl/opencl_hmac_sha512.h
@@ -97,10 +97,16 @@ INLINE void hmac_sha512(HMAC_KEY_TYPE void *_key, uint key_len,
 	SHA512_Final(local_digest, &ctx);
 	for (i = 0; i < 16; i++)
 		u.pW[i] ^= (0x3636363636363636UL ^ 0x5c5c5c5c5c5c5c5cUL);
+#if gpu_amd(DEVICE_INFO)
+/* Workaround miscompile with AMD-APP 2766.4 */
+	SHA512_CTX ctx2;
+#define ctx ctx2
+#endif
 	SHA512_Init(&ctx);
 	SHA512_Update(&ctx, u.buf, 128);
 	SHA512_Update(&ctx, local_digest, 64);
 	SHA512_Final(local_digest, &ctx);
+#undef ctx
 
 	memcpy_macro(digest, local_digest, digest_len);
 }

--- a/run/opencl/pbkdf2_ripemd160_kernel.cl
+++ b/run/opencl/pbkdf2_ripemd160_kernel.cl
@@ -150,9 +150,12 @@ __kernel void tc_ripemd_aesxts(__global const pbkdf2_password *inbuffer,
 {
 	__local aes_local_t lt;
 	uint idx = get_global_id(0);
-	uint key[64 / 4];
+	union {
+		uint u32[64 / 4];
+		uchar uc[64];
+	} key;
 
-	pbkdf2(inbuffer[idx].v, inbuffer[idx].length, salt->salt, key);
+	pbkdf2(inbuffer[idx].v, inbuffer[idx].length, salt->salt, key.u32);
 
-	AES_256_XTS_first_sector(salt->bin, outbuffer[idx].v, (uchar*)key, &lt);
+	AES_256_XTS_first_sector(salt->bin, outbuffer[idx].v, key.uc, &lt);
 }


### PR DESCRIPTION
See #5709.

I also included a change to `pbkdf2_ripemd160_kernel.cl` that doesn't make this kernel/format work on this device (it still works on 5 others in "super"), but I think is the right correctness fix anyway.