### PR TITLE
Fix a suppressor segfault due to being called twice from wordlist

### DIFF
--- a/src/suppressor.c
+++ b/src/suppressor.c
@@ -27,6 +27,9 @@ static int suppressor_process_key(char *key);
 
 void suppressor_init(unsigned int new_flags)
 {
+	if (old_process_key)
+		return;
+
 	if (!flags) {
 		if (!(new_flags & SUPPRESSOR_UPDATE))
 			return;


### PR DESCRIPTION
We had a dupe suppression segfault (mentioned with the mgetl problem in #5704, but unrelated). It turns out it would only trigger when running `--loopback`. The problem is that wordlist.c would call `suppressor_init()` twice in that case, resulting in `old_process_key` being set to `suppressor_process_key()` and losing the original pointer to `crk_process_key()` forever. Later, `crk_process_key` would be reset to the incorrect `old_process_key` and as a result we'd eventually call `suppressor_process_key()` _after `filter` is freed_.

In wordlist.c, the label `REDO_AFTER_LMLOOP:` is a hint of why it happens. I separately added protection in suppressor.c as well (does not affect performance) - in my opinion we should do both.

BTW Presumably the problem would only surface when we actually had some LM hashes in the input file, _and_ some of them was present in the pot file so assembled to the special loop. That's why it went under the radar for quite some time. I didn't verify this explanation though, the `available time / curiosity` ratio is too low.
