### PR TITLE
Suppressor, wordlist, rules: bug fix and enhancements/cleanup

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -265,7 +265,7 @@ void crk_init(struct db_main *db, void (*fix_state)(void),
 	 * Resetting crk_process_key above disables the suppressor, but it can
 	 * possibly be re-enabled by a cracking mode.
 	 */
-	if (status.suppressor_start) {
+	if (status.suppressor_start && !status.suppressor_end) {
 		status.suppressor_end = status.cands;
 		status.suppressor_end_time = status_get_time();
 	}

--- a/src/memory.c
+++ b/src/memory.c
@@ -653,6 +653,9 @@ alloc_region(region_t * region, size_t size)
 #ifdef MAP_NOCORE
 	    MAP_NOCORE |
 #endif
+#ifdef MAP_POPULATE
+	    MAP_POPULATE |
+#endif
 	    MAP_ANON | MAP_PRIVATE;
 #if defined(MAP_HUGETLB) && defined(HUGEPAGE_SIZE)
 	size_t new_size = size;

--- a/src/pp.c
+++ b/src/pp.c
@@ -1192,11 +1192,6 @@ void do_prince_crack(struct db_main *db, const char *wordlist, int rules)
   setmode (fileno (stdout), O_BINARY);
   #endif
 #else
-  union {
-    char buffer[LINE_BUFFER_SIZE];
-    ARCH_WORD dummy;
-  } aligned;
-  char *last = aligned.buffer;
   int loopback = (options.flags & FLG_PRINCE_LOOPBACK) ? 1 : 0;
   int mask_mult = MAX(1, mask_num_qw);
   int our_fmt_len = (db->format->params.plaintext_length + ((mask_mult - 1) * mask_add_len)) / mask_mult - mask_add_len;
@@ -1371,7 +1366,7 @@ void do_prince_crack(struct db_main *db, const char *wordlist, int rules)
     do {
       char *rule;
 
-      if ((rule = rules_reject(prerule, -1, last, db)))
+      if ((rule = rules_reject(prerule, -1, db)))
       {
         list_add(rule_list, rule);
         active_rules++;
@@ -2334,8 +2329,7 @@ void do_prince_crack(struct db_main *db, const char *wordlist, int rules)
               do {
                 char *word;
 
-                if ((word = rules_apply(pw_buf, rule->data, -1, last))) {
-                  last = word;
+                if ((word = rules_apply(pw_buf, rule->data, -1))) {
 #if HAVE_REXGEN
                   if (regex) {
                     if ((jtr_done = do_regex_hybrid_crack(db, regex, word,

--- a/src/rules.h
+++ b/src/rules.h
@@ -60,11 +60,8 @@ extern void rules_init(struct db_main *db, int max_length);
  *
  * split == 0	"single crack" mode rules allowed
  * split < 0	"single crack" mode rules are invalid
- *
- * last may specify which internal buffer must not be touched.
  */
-extern char *rules_reject(char *rule, int split, char *last,
-	struct db_main *db);
+extern char *rules_reject(char *rule, int split, struct db_main *db);
 
 /*
  * Applies rule to a word. Returns the updated word, or NULL if rejected or
@@ -73,13 +70,8 @@ extern char *rules_reject(char *rule, int split, char *last,
  * split > 0	"single crack" mode, split is the second word's position
  * split == 0	"single crack" mode, only one word
  * split < 0	other cracking modes, "single crack" mode rules are invalid
- *
- * If last is non-NULL, it should be the previous mangled word and it is
- * assumed to be properly aligned for ARCH_WORD accesses (pointers returned by
- * rules_apply() are properly aligned).  If the new mangled word matches the
- * previous one, it will be rejected (rules_apply() will return NULL).
  */
-extern char *rules_apply(char *word, char *rule, int split, char *last);
+extern char *rules_apply(char *word, char *rule, int split);
 
 /*
  * Similar to rules_check(), but displays a message and does not return on

--- a/src/single.c
+++ b/src/single.c
@@ -674,7 +674,7 @@ static int single_process_pw(struct db_salt *salt, struct db_password *pw,
 	do {
 		if (first == global_head)
 			first_global = 1;
-		if ((key = rules_apply(first->data, rule, 0, NULL)))
+		if ((key = rules_apply(first->data, rule, 0)))
 		if (ext_filter(key))
 		if (single_add_key(salt, key, 0))
 			return 1;
@@ -701,7 +701,7 @@ static int single_process_pw(struct db_salt *salt, struct db_password *pw,
 				strnzcpy(pair, first->data, RULE_WORD_SIZE);
 				strnzcat(pair, second->data, RULE_WORD_SIZE);
 
-				if ((key = rules_apply(pair, rule, split, NULL)))
+				if ((key = rules_apply(pair, rule, split)))
 				if (ext_filter(key))
 				if (single_add_key(salt, key, 0))
 					return 1;
@@ -716,7 +716,7 @@ static int single_process_pw(struct db_salt *salt, struct db_password *pw,
 				pair[1] = 0;
 				strnzcat(pair, second->data, RULE_WORD_SIZE);
 
-				if ((key = rules_apply(pair, rule, 1, NULL)))
+				if ((key = rules_apply(pair, rule, 1)))
 				if (ext_filter(key))
 				if (single_add_key(salt, key, 0))
 					return 1;
@@ -817,7 +817,7 @@ static void single_run(void)
 				}
 			}
 
-			if (!(rule = rules_reject(prerule, 0, NULL, single_db))) {
+			if (!(rule = rules_reject(prerule, 0, single_db))) {
 				rule_number++;
 				if (options.verbosity >= VERB_DEFAULT &&
 				    !rules_mute &&

--- a/src/suppressor.c
+++ b/src/suppressor.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of John the Ripper password cracker,
- * Copyright (c) 2022 by Solar Designer
+ * Copyright (c) 2022,2025 by Solar Designer
  */
 
 #include <stdint.h>
@@ -27,6 +27,9 @@ static int suppressor_process_key(char *key);
 
 void suppressor_init(unsigned int new_flags)
 {
+	if (flags & SUPPRESSOR_OFF)
+		return;
+
 	if (!flags) {
 		if (!(new_flags & SUPPRESSOR_UPDATE))
 			return;
@@ -66,8 +69,10 @@ void suppressor_init(unsigned int new_flags)
 	flags = new_flags;
 	status.suppressor_end = 0;
 	status.suppressor_end_time = 0;
-	old_process_key = crk_process_key;
-	crk_process_key = suppressor_process_key;
+	if (crk_process_key != suppressor_process_key) {
+		old_process_key = crk_process_key;
+		crk_process_key = suppressor_process_key;
+	}
 }
 
 static void suppressor_done(void)

--- a/src/suppressor.c
+++ b/src/suppressor.c
@@ -55,9 +55,10 @@ void suppressor_init(unsigned int new_flags)
 			Klock = K / 2;
 
 		if (john_main_process) {
-			const char *msg = "Enabling duplicate candidate password suppressor";
-			log_event("%s", msg);
-			fprintf(stderr, "%s\n", msg);
+			const char *msg = "Enabling duplicate candidate password suppressor using ";
+			const char *suffix = options.fork ? " per process" : "";
+			log_event("%s%d MiB%s", msg, size, suffix);
+			fprintf(stderr, "%s%d MiB%s\n", msg, size, suffix);
 		}
 
 		filter = mem_calloc_align(N, sizeof(*filter), MEM_ALIGN_CACHE);

--- a/src/suppressor.h
+++ b/src/suppressor.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of John the Ripper password cracker,
- * Copyright (c) 2022 by Solar Designer
+ * Copyright (c) 2022,2025 by Solar Designer
  */
 
 /*
@@ -10,10 +10,10 @@
 #ifndef _JOHN_SUPPRESSOR_H
 #define _JOHN_SUPPRESSOR_H
 
-#define SUPPRESSOR_OFF		0
 #define SUPPRESSOR_UPDATE	1
 #define SUPPRESSOR_CHECK	2
 #define SUPPRESSOR_FORCE	4
+#define SUPPRESSOR_OFF		8
 
 /*
  * Initializes the suppressor.  Must be called after crk_init(), first with


### PR DESCRIPTION
Previously, we only supported a repeated initialization call after cracking mode transition, but as magnum found we may also call more than once from within wordlist mode.

Fixes #5714