### PR TITLE
bitshares2john.py and BitShares format: Use less revealing non-hashes

### DIFF
--- a/run/bitshares2john.py
+++ b/run/bitshares2john.py
@@ -75,7 +75,7 @@ def process_file(filename):
         if "encryption_key" not in data:
             continue
         encryption_key = data["encryption_key"]
-        sys.stdout.write("%s:$BitShares$0*%s\n" % (name, encryption_key))
+        sys.stdout.write("%s:$BitShares$0*%s\n" % (name, encryption_key[-64:]))
 
 
 if __name__ == "__main__":

--- a/src/bitshares_fmt_plug.c
+++ b/src/bitshares_fmt_plug.c
@@ -112,12 +112,19 @@ static int valid(char *ciphertext, struct fmt_main *self)
 	if ((p = strtokm(NULL, "*")) == NULL)   // ciphertext
 		goto err;
 	value = hexlenl(p, &extra);
-	if (type == 0) {
-		if (value > MAX_CIPHERTEXT_LENGTH * 2 || value < 32 * 2 || extra)
+	if (value > MAX_CIPHERTEXT_LENGTH * 2 || extra)
+		goto err;
+	switch (type) {
+	case 0:
+		if (value < 32 * 2 || (value & 31))
 			goto err;
-	} else {
-		if (value > MAX_CIPHERTEXT_LENGTH * 2 || value < 256 * 2 || extra)  // rough check!
+		break;
+	case 1:
+		if (value < 256 * 2 || ((value - 66) & 31)) // rough check!
 			goto err;
+		break;
+	default:
+		goto err;
 	}
 
 	MEM_FREE(keeptr);

--- a/src/bitshares_fmt_plug.c
+++ b/src/bitshares_fmt_plug.c
@@ -278,6 +278,12 @@ static int cmp_exact(char *source, int index)
 	return 1;
 }
 
+static unsigned int tunable_cost_type(void *_salt)
+{
+	struct custom_salt *salt = (struct custom_salt *)_salt;
+	return salt->type;
+}
+
 struct fmt_main fmt_bitshares = {
 	{
 		FORMAT_LABEL,
@@ -294,7 +300,7 @@ struct fmt_main fmt_bitshares = {
 		MIN_KEYS_PER_CRYPT,
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_HUGE_INPUT,
-		{ NULL },
+		{"type [0:wallet 1:backup]"},
 		{ FORMAT_TAG },
 		tests
 	}, {
@@ -306,7 +312,7 @@ struct fmt_main fmt_bitshares = {
 		fmt_default_split,
 		fmt_default_binary,
 		get_salt,
-		{ NULL },
+		{tunable_cost_type},
 		fmt_default_source,
 		{
 			fmt_default_binary_hash

--- a/src/bitshares_fmt_plug.c
+++ b/src/bitshares_fmt_plug.c
@@ -52,6 +52,7 @@ static struct fmt_tests tests[] = {
 	// BitShares.Setup.2.0.180115.exe
 	{"$BitShares$0*ec415018f26e7182a273655aef7cec47966306c48956604462f5b9e1613b3b70ebaaed4d7600b24a424ddb7d4cd56e55", "openwall"},
 	{"$BitShares$0*3bebbec17f0643ee9d3d5e48f04451bf7e38765f3bf2fa6ea12f680d60da121bb04ced9f76681744f3730322082c7ec7", "äbc12345"},
+	{"$BitShares$0*966306c48956604462f5b9e1613b3b70ebaaed4d7600b24a424ddb7d4cd56e55", "openwall"},
 	// Google Chrome -> https://wallet.bitshares.org in January, 2018
 	{"$BitShares$0*97452e44d43818099fbd2cc7539588c2c2dbc4e06e1b18831ded86b7e68e51d2da2c2b81054863032248a9da93ea1943", "openwall123"},
 	// Backup (.bin) files from February, 2018

--- a/src/bitshares_fmt_plug.c
+++ b/src/bitshares_fmt_plug.c
@@ -149,6 +149,10 @@ static void *get_salt(char *ciphertext)
 	cs.type = atoi(p);
 	p = strtokm(NULL, "*");
 	cs.ctlen = strlen(p) / 2;
+	if (cs.type == 0) {
+		p += 2 * (cs.ctlen - 32);
+		cs.ctlen = 32;
+	}
 	for (i = 0; i < cs.ctlen; i++)
 		cs.ct[i] = (atoi16[ARCH_INDEX(p[2 * i])] << 4) | atoi16[ARCH_INDEX(p[2 * i + 1])];
 


### PR DESCRIPTION
This excludes the first AES block (out of 3) from the type 0 (wallet) non-hashes. What remains is usable to decrypt the final block that's expected to contain padding only.

The type 1 (backup) non-hashes are probably still fully revealing - there's a lot of data, although I don't know what fields are in it, beyond the safe truncated SHA-256 that the format checks, for which it needs all the rest. For both test vectors of this type that we have, the decrypted data contains recognizable patterns within the first AES block, so we could have used that instead of the padding and checksum (or along with padding, but not checksum, if we include the first AES block and the last two AES blocks, but not the middle). However, just two test vectors perhaps from the same system may not be enough to conclude that those same constant values or patterns will remain in files that others have.

The Python script edit here is trivial, but is untested - I do not have a file to test it on.

@kholia Maybe you can submit some sample input files for this script to the john-samples repo, please?