### PR TITLE
rules.c: Fix regression from drop of consecutive dupe suppression

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -1858,6 +1858,13 @@ char *rules_process_stack_all(char *key, rule_stack *ctx)
 		if (!stack_rules_mute)
 			log_event("+ Stacked Rule #%u: '%.100s' accepted",
 			          rules_stacked_number + 1, ctx->rule->data);
+	} else {
+		if ((ctx->rule = ctx->rule->next)) {
+			rules_stacked_number++;
+			if (!stack_rules_mute)
+				log_event("+ Stacked Rule #%u: '%.100s' accepted",
+				          rules_stacked_number + 1, ctx->rule->data);
+		}
 	}
 
 	rules_stacked_after = 0;


### PR DESCRIPTION
Apparently --rules-stack was b0rken all the time, relying on the dupe suppression to proceed to next rule.  This must have been ineffective.

Closes #5722