### PR TITLE
rules.c: Simplify the latest bugfix to stacked rules

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1,8 +1,9 @@
 /*
  * This file is part of John the Ripper password cracker,
  * Copyright (c) 1996-2024 by Solar Designer
- *
- * ...with changes in jumbo by JimF, magnum, Claudio, and several others
+ * Copyright (c) 2009-2025, magnum
+ * Copyright (c) 2021, Claudio
+ * Copyright (c) 2009-2018, JimF
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -1947,6 +1948,7 @@ static void john_done(void)
 			/* We already printed to stderr from signals.c */
 			log_event("%s", abort_msg);
 		} else if (children_ok) {
+			log_event("Candidates tried: %"PRIu64"p", status.cands);
 			log_event("Session completed");
 			if (john_main_process) {
 				fprintf(stderr, "Session completed. %s\n", mode_exit_message);

--- a/src/rules.c
+++ b/src/rules.c
@@ -1,8 +1,8 @@
 /*
  * This file is part of John the Ripper password cracker,
  * Copyright (c) 1996-99,2003,2005,2009,2010,2015,2016 by Solar Designer
- *
- * With heavy changes in Jumbo, by JimF and magnum
+ * Copyright (c) 2009-2025, magnum
+ * Copyright (c) 2009-2018, JimF
  */
 
 #include <stdio.h>
@@ -1855,28 +1855,22 @@ char *rules_process_stack_all(char *key, rule_stack *ctx)
 	if (!ctx->rule) {
 		ctx->rule = ctx->stack_rule->head;
 		rules_stacked_number = 0;
-		if (!stack_rules_mute)
-			log_event("+ Stacked Rule #%u: '%.100s' accepted",
-			          rules_stacked_number + 1, ctx->rule->data);
 	} else {
 		if ((ctx->rule = ctx->rule->next)) {
 			rules_stacked_number++;
-			if (!stack_rules_mute)
-				log_event("+ Stacked Rule #%u: '%.100s' accepted",
-				          rules_stacked_number + 1, ctx->rule->data);
 		}
 	}
 
 	rules_stacked_after = 0;
 
 	while (ctx->rule) {
+		if (!stack_rules_mute)
+			log_event("+ Stacked Rule #%u: '%.100s' accepted",
+			          rules_stacked_number + 1, ctx->rule->data);
 		if ((word = rules_apply(key, ctx->rule->data, -1)))
 			return word;
 		if ((ctx->rule = ctx->rule->next)) {
 			rules_stacked_number++;
-			if (!stack_rules_mute)
-			    log_event("+ Stacked Rule #%u: '%.100s' accepted",
-			          rules_stacked_number + 1, ctx->rule->data);
 		}
 	}
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -1876,12 +1876,12 @@ char *rules_process_stack_all(char *key, rule_stack *ctx)
 
 	rules_stacked_after = !!(options.flags & (FLG_RULES_CHK | FLG_SINGLE_CHK | FLG_BATCH_CHK));
 
-	if (!stack_rules_mute && options.verbosity <= VERB_DEFAULT) {
+	if (!stack_rules_mute && options.verbosity < VERB_DEBUG) {
 		stack_rules_mute = 1;
 		if (john_main_process) {
 			log_event(
 "- Some rule logging suppressed. Re-enable with --verbosity=%d or greater",
-			          VERB_LEGACY);
+			          VERB_DEBUG);
 		}
 	}
 
@@ -2118,12 +2118,12 @@ int rules_count(struct rpp_context *start, int split)
 	}
 
 	if (((options.flags & FLG_PIPE_CHK) && count1 >= RULES_MUTE_THR) &&
-	    options.verbosity < VERB_LEGACY) {
+	    options.verbosity < VERB_DEBUG) {
 		rules_mute = 1;
 		if (john_main_process) {
 			log_event(
 "- Some rule logging suppressed. Re-enable with --verbosity=%d or greater",
-			          VERB_LEGACY);
+			          VERB_DEBUG);
 		}
 	}
 	return count1;

--- a/src/single.c
+++ b/src/single.c
@@ -896,12 +896,12 @@ static void single_run(void)
 		if (rules_stacked_after) {
 			saved_min[0] = rule_number = 0;
 			rpp_init(rule_ctx, options.activesinglerules);
-			if (!rules_mute && options.verbosity <= VERB_DEFAULT) {
+			if (!rules_mute && options.verbosity < VERB_DEBUG) {
 				rules_mute = 1;
 				if (john_main_process) {
 					log_event(
 "- Some rule logging suppressed. Re-enable with --verbosity=%d or greater",
-					          VERB_LEGACY);
+					          VERB_DEBUG);
 				}
 			}
 		}


### PR DESCRIPTION
Just drop a couple of identical `log_event()` and move the last one so it covers all three

Also as a separate commit, add a log call just before session end that says how many candidates were processed.

See #5722