### PR TITLE
OpenCL Bitslice DES key setup: Use LUT3 on nvidias

### DIFF
--- a/run/opencl/DES_bs_finalize_keys_kernel.cl
+++ b/run/opencl/DES_bs_finalize_keys_kernel.cl
@@ -34,6 +34,12 @@
 #define mask40 0x40404040
 #define mask80 0x80808080
 
+/*
+ * LUT3 did not do any good in our testing (2025-03) and the binary size
+ * for DEScrypt kernel grew a little, so this is defined out for now.
+ */
+#undef HAVE_LUT3
+
 #if HAVE_LUT3
 #define kvand_or(dst, src, mask)			\
 	dst = vlut3(dst, src, mask, 0xf8)


### PR DESCRIPTION
There's no change in performance.

The non-mask (self test) kernel uses 2 more registers (36 vs 34) with LUT3, and binary size grew with 928 bytes from 6828 to 7756.
The mask kernel stays at 64 registers, but binary size grew with 922 bytes from 9891 to 10813.

Should I leave LUT3 enabled here? I could just add an `#undef HAVE_LUT3` somewhere, with a comment.

#5707