### PR TITLE
PRINCE mode: Drop the obscure --prince-mmap option

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -422,7 +422,11 @@ Major changes from 1.9.0-jumbo-1 (May 2019) in this bleeding-edge version:
 
 - Use AVX512VL XOP-like bit rotates for scrypt's Salsa20.  [Solar; 2025]
 
-- When we use AVX512BW, also enable usage of AVX512VL and AVX512DQ.  [Claudio André; 2025]
+- When we use AVX512BW, also enable usage of AVX512VL and AVX512DQ.  [Claudio
+  André; 2025]
+
+- Deprecate and ignore the --prince-mmap option. It was too problematic to fix.
+  [magnum; 2025]
 
 
 Major changes from 1.8.0-jumbo-1 (December 2014) to 1.9.0-jumbo-1 (May 2019):

--- a/doc/PRINCE
+++ b/doc/PRINCE
@@ -33,8 +33,6 @@ Usage: ./john --prince[=<wordlist file>] hashfile (...)
     with --prince. You can even use this with rules and/or external filter at
     the same time. When mask is used it will also accelerate use on GPU with
     fast formats.
-  - Use mmap for loading: --prince-mmap. This is intended for when running many
-    processes on one same machine.
   - You can use your .pot file as a wordlist: --prince-loopback.
 
 • Other optional parameters in JtR:

--- a/src/options.c
+++ b/src/options.c
@@ -91,6 +91,7 @@ static struct opt_entry opt_list[] = {
 	{"prince-wl-max", FLG_ONCE, 0, FLG_PRINCE_CHK, OPT_REQ_PARAM, "%d", &prince_wl_max},
 	{"prince-case-permute", FLG_PRINCE_CASE_PERMUTE, 0, FLG_PRINCE_CHK, FLG_PRINCE_MMAP},
 	{"prince-keyspace", FLG_PRINCE_KEYSPACE | FLG_STDOUT, 0, FLG_PRINCE_CHK, FLG_RULES_IN_USE},
+	/* -prince-mmap is deprecated and ignored. Remove after releasing 1.9.0-Jumbo-2 */
 	{"prince-mmap", FLG_PRINCE_MMAP, 0, FLG_PRINCE_CHK, FLG_PRINCE_CASE_PERMUTE},
 #endif
 	/* -enc is an alias for -input-enc for logic reasons, never deprecated */
@@ -239,7 +240,6 @@ static struct opt_entry opt_list[] = {
 "--prince-wl-dist-len       Calculate length distribution from wordlist\n" \
 "--prince-wl-max=N          Load only N words from input wordlist\n" \
 "--prince-case-permute      Permute case of first letter\n" \
-"--prince-mmap              Memory-map infile (not available with case permute)\n" \
 "--prince-keyspace          Just show total keyspace that would be produced\n" \
 "                           (disregarding skip and limit)\n"
 #else

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -263,7 +263,7 @@ void rec_save(void)
 #endif
 	opt = rec_argv;
 	while (*++opt) {
-		/********* Re-write deprecated options *********/
+		/********* Re-write or drop deprecated options *********/
 		if (!strncmp(*opt, "--internal-encoding", 19))
 			memcpy(*opt, "--internal-codepage", 19);
 		else
@@ -278,6 +278,13 @@ void rec_save(void)
 		}
 		else
 		if (!strncmp(*opt, "--fix-state-delay", 17)) {
+			char **o = opt;
+			do
+				*o = o[1];
+			while (*++o);
+			rec_argc--;
+		}
+		if (!strcmp(*opt, "--prince-mmap")) {
 			char **o = opt;
 			do
 				*o = o[1];


### PR DESCRIPTION
I seriously doubt anyone was using it. Even I had forgotten it existed. PRINCE wordlists are supposedly fairly small anyway.

The code was VERY problematic (it did "work" as long as file was not a multiple of page size, but it was MAP_WRITE with no communication between processes - it can't ever have worked well). It could probably be fixed but definitely wasn't worth the effort.

Like with the few other deprecated options, we support resuming sessions using this option (ignoring it and dropping it from next session file update) until *after* next release.

See also #5704.