### PR TITLE
Change shared CPU HMAC code to use size_t for datalen instead of uint64_t

### DIFF
--- a/src/hmac_sha.h
+++ b/src/hmac_sha.h
@@ -16,19 +16,19 @@
 
 #ifndef _JTR_HMAC_SHA_H
 
-extern void JTR_hmac_sha1(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len);
+extern void JTR_hmac_sha1(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len);
 #define hmac_sha1(key,keylen,data,datalen,dgst,dgstlen) JTR_hmac_sha1(key,keylen,data,datalen,dgst,dgstlen)
 
-extern void JTR_hmac_sha256(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len);
+extern void JTR_hmac_sha256(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len);
 #define hmac_sha256(key,keylen,data,datalen,dgst,dgstlen) JTR_hmac_sha256(key,keylen,data,datalen,dgst,dgstlen)
 
-extern void JTR_hmac_sha512(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len);
+extern void JTR_hmac_sha512(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len);
 #define hmac_sha512(key,keylen,data,datalen,dgst,dgstlen) JTR_hmac_sha512(key,keylen,data,datalen,dgst,dgstlen)
 
-extern void JTR_hmac_sha224(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len);
+extern void JTR_hmac_sha224(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len);
 #define hmac_sha224(key,keylen,data,datalen,dgst,dgstlen) JTR_hmac_sha224(key,keylen,data,datalen,dgst,dgstlen)
 
-extern void JTR_hmac_sha384(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len);
+extern void JTR_hmac_sha384(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len);
 #define hmac_sha384(key,keylen,data,datalen,dgst,dgstlen) JTR_hmac_sha384(key,keylen,data,datalen,dgst,dgstlen)
 
 #endif /* _JTR_HMAC_SHA_H */

--- a/src/hmac_sha_plug.c
+++ b/src/hmac_sha_plug.c
@@ -34,7 +34,7 @@
 #define HMAC_SHA_OPAD_XOR (0x36363636^0x5c5c5c5c)
 #endif
 
-void JTR_hmac_sha1(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len) {
+void JTR_hmac_sha1(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len) {
 	JTR_ALIGN(8) unsigned char buf[64];
 	unsigned char local_digest[20];
 	ARCH_WORD *pW = (ARCH_WORD *)buf;
@@ -72,7 +72,7 @@ void JTR_hmac_sha1(const unsigned char *key, int key_len, const unsigned char *d
 	}
 }
 
-void JTR_hmac_sha256(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len) {
+void JTR_hmac_sha256(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len) {
 	JTR_ALIGN(8) unsigned char buf[64];
 	unsigned char local_digest[32];
 	ARCH_WORD *pW = (ARCH_WORD *)buf;
@@ -111,7 +111,7 @@ void JTR_hmac_sha256(const unsigned char *key, int key_len, const unsigned char 
 	}
 }
 
-void JTR_hmac_sha224(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len) {
+void JTR_hmac_sha224(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len) {
 	JTR_ALIGN(8) unsigned char buf[64];
 	unsigned char local_digest[28];
 	ARCH_WORD *pW = (ARCH_WORD *)buf;
@@ -151,7 +151,7 @@ void JTR_hmac_sha224(const unsigned char *key, int key_len, const unsigned char 
 	}
 }
 
-void JTR_hmac_sha512(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len) {
+void JTR_hmac_sha512(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len) {
 	JTR_ALIGN(8) unsigned char buf[128];
 	unsigned char local_digest[64];
 	ARCH_WORD *pW = (ARCH_WORD *)buf;
@@ -190,7 +190,7 @@ void JTR_hmac_sha512(const unsigned char *key, int key_len, const unsigned char 
 	}
 }
 
-void JTR_hmac_sha384(const unsigned char *key, int key_len, const unsigned char *data, uint64_t data_len, unsigned char *digest, int digest_len) {
+void JTR_hmac_sha384(const unsigned char *key, int key_len, const unsigned char *data, size_t data_len, unsigned char *digest, int digest_len) {
 	JTR_ALIGN(8) unsigned char buf[128];
 	unsigned char local_digest[48];
 	ARCH_WORD *pW = (ARCH_WORD *)buf;

--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -374,13 +374,6 @@ static int cmp_exact(char *source, int index)
 }
 
 
-static unsigned int cost_hmac_len(void *salt)
-{
-	winzip_salt *s = *((winzip_salt**)salt);
-
-	return s->comp_len;
-}
-
 struct fmt_main fmt_opencl_zip = {
 	{
 		FORMAT_LABEL,
@@ -398,7 +391,7 @@ struct fmt_main fmt_opencl_zip = {
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_DYNA_SALT | FMT_HUGE_INPUT,
 		{
-			"HMAC size"
+			"HMAC size [KiB]"
 		},
 		{ WINZIP_FORMAT_TAG },
 		winzip_common_tests
@@ -412,7 +405,7 @@ struct fmt_main fmt_opencl_zip = {
 		winzip_common_binary,
 		winzip_common_get_salt,
 		{
-			cost_hmac_len
+			winzip_common_cost_hmac_len
 		},
 		fmt_default_source,
 		{

--- a/src/pkzip.c
+++ b/src/pkzip.c
@@ -248,3 +248,10 @@ void *winzip_common_binary(char *ciphertext) {
 	}
 	return bin;
 }
+
+unsigned int winzip_common_cost_hmac_len(void *salt)
+{
+	winzip_salt *s = *((winzip_salt**)salt);
+
+	return (s->comp_len + 1023) / 1024;
+}

--- a/src/pkzip.h
+++ b/src/pkzip.h
@@ -106,6 +106,7 @@ extern int winzip_common_valid(char *ciphertext, struct fmt_main *self);
 extern char *winzip_common_split(char *ciphertext, int index, struct fmt_main *self);
 extern void *winzip_common_binary(char *ciphertext);
 extern void *winzip_common_get_salt(char *ciphertext);
+extern unsigned int winzip_common_cost_hmac_len(void *salt);
 
 extern struct fmt_tests winzip_common_tests[];
 

--- a/src/zip_fmt_plug.c
+++ b/src/zip_fmt_plug.c
@@ -208,13 +208,6 @@ static int cmp_exact(char *source, int index)
 	return 1;
 }
 
-static unsigned int cost_hmac_len(void *salt)
-{
-	winzip_salt *s = *((winzip_salt**)salt);
-
-	return s->comp_len;
-}
-
 struct fmt_main fmt_zip = {
 	{
 		FORMAT_LABEL,
@@ -232,7 +225,7 @@ struct fmt_main fmt_zip = {
 		MAX_KEYS_PER_CRYPT,
 		FMT_CASE | FMT_8_BIT | FMT_OMP | FMT_DYNA_SALT | FMT_HUGE_INPUT,
 		{
-			"HMAC size"
+			"HMAC size [KiB]"
 		},
 		{ WINZIP_FORMAT_TAG },
 		winzip_common_tests
@@ -246,7 +239,7 @@ struct fmt_main fmt_zip = {
 		winzip_common_binary,
 		winzip_common_get_salt,
 		{
-			cost_hmac_len
+			winzip_common_cost_hmac_len
 		},
 		fmt_default_source,
 		{


### PR DESCRIPTION
This change means 32-bit hosts won't support ZIP files of 4 GiB or larger. They will be reject with a warning and hints.

Also changes ZIP cost to report size in KiB, instead of overflowing the unsigned int at 4 GiB or larger.