### PR TITLE
o5logon-opencl: Support Oracle 12

### DIFF
--- a/run/john.conf
+++ b/run/john.conf
@@ -423,6 +423,17 @@ SleepOnTemperature = 1
 AvoidBusyWait = Y
 
 [Options:OpenCL]
+# Mute buggy nvidia warnings about kernel overriding noinline
+# attribute. Even with this set, they will show at "debug verbosity"
+# as in --verbose:6.
+MuteBogusWarnings = Y
+
+# Add ptxas info (-cl-nv-verbose) to build options for nvidia
+NvidiaShowPtxas = Y
+
+# Show runtime build warnings regardless of verbosity.
+AlwaysShowBuildWarnings = N
+
 # Set default OpenCL device(s). Command line option will override this.
 # If not set, we will search for a GPU or fall-back to the most
 # powerful device.  Syntax is same as --device option.

--- a/run/opencl/o5logon_kernel.cl
+++ b/run/opencl/o5logon_kernel.cl
@@ -1,89 +1,213 @@
 /*
-   This code was largely inspired by
-   pyrit opencl kernel sha1 routines, royger's sha1 sample,
-   and md5_opencl_kernel.cl inside jtr.
-   Copyright 2011 by Samuele Giovanni Tonon
-   samu at linuxasylum dot net
-   and Copyright (c) 2012-2017, magnum
-   This program comes with ABSOLUTELY NO WARRANTY; express or
-   implied .
-   This is free software, and you are welcome to redistribute it
-   under certain conditions; as expressed here
-   http://www.gnu.org/licenses/gpl-2.0.html
-*/
-
-/*
- * Modifications (c) 2014 Harrison Neal.
- * Licensed GPLv2
+ * Copyright (c) 2012-2025, magnum
+ * Copyright (c) 2014 Harrison Neal
+ * Copyright (c) 2011 by Samuele Giovanni Tonon, samu at linuxasylum dot net
+ *
+ * This program comes with ABSOLUTELY NO WARRANTY; express or
+ * implied .
+ * This is free software, and you are welcome to redistribute it
+ * under certain conditions; as expressed here
+ * http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 #include "opencl_device_info.h"
 #include "opencl_misc.h"
 #include "opencl_sha1.h"
-#define AES_SRC_TYPE __constant
+#include "opencl_md5_ctx.h"
+#include "opencl_mask.h"
+
+// Workaround for UHD Graphics 630 version "1.2(Jan 10 2025 21:16:54)"
+#if (__OS_X__ && gpu_intel(DEVICE_INFO))
+#define AES_BITSLICE 1
+#endif
 #include "opencl_aes.h"
 
 typedef struct {
-	uint salt[3]; // ((SALT_LENGTH + 3)/4)
-	uchar ct[48]; // CIPHERTEXT_LENGTH
-} salt_t;
+	uint pw_len;                          /* AUTH_PASSWORD length (blocks) */
+	uint salt[(SALT_LENGTH + 1 + 3) / 4]; /* AUTH_VFR_DATA */
+	uchar ct[CIPHERTEXT_LENGTH];          /* Server's AUTH_SESSKEY */
+	uchar csk[CIPHERTEXT_LENGTH];         /* Client's AUTH_SESSKEY */
+	uchar pw[PLAINTEXT_LENGTH + 16];      /* Client's AUTH_PASSWORD, padded */
+} o5logon_salt;
+
+#define SECRET_LEN (CIPHERTEXT_LENGTH - 16)
 
 __kernel void
-o5logon_kernel(__global const uint *keys, __constant salt_t *salt,
-               __global const uint *index, __global uint *result)
+o5logon_kernel(__global const uchar* key_buf, __global const uint* const key_idx,
+               __constant o5logon_salt* salt,
+               __global volatile uint* crack_count_ret,
+               __global uint* const out_index,
+               __global const uint* const int_key_loc,
+               __global const uint* const int_keys)
 {
 	__local aes_local_t lt;
 	AES_KEY akey; akey.lt = &lt;
-	uint W[16] = { 0 }, salt_s[3], output[5];
-	uint gid = get_global_id(0);
-	uint base = index[gid];
-	uint len = base & 63;
-	uint i;
-	uint shift = len % 4;
-	uint sr = 8 * shift;
-	uint sl = 32 - sr;
-	uint sra = (0xffffffff - (1 << sr)) + 1;
-	uint sla = 0xffffffff - sra;
-	union {
-		uchar c[24];
-		uint w[24 / 4];
-	} aes_key;
-	union {
-		uchar c[16];
-		ulong l[16 / 8];
-	} pt;
-	uchar iv[16];
 
-	keys += base >> 6;
+	const uint gid = get_global_id(0);
 
-	for (i = 0; i < (len + 3) / 4; i++)
-		W[i] = SWAP32(*keys++);
+#if NUM_INT_KEYS > 1 && !IS_STATIC_GPU_MASK
+	const uint ikl = int_key_loc[gid];
+	const uint loc0 = ikl & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+	const uint loc1 = (ikl & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+	const uint loc2 = (ikl & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+	const uint loc3 = (ikl & 0xff000000) >> 24;
+#endif
+#endif
+#endif
 
-	// Do the typical byte swapping...
-	for (i = 0; i < 3; i++)
-		salt_s[i] = SWAP32(salt->salt[i]);
+#if !IS_STATIC_GPU_MASK
+#define GPU_LOC_0 loc0
+#define GPU_LOC_1 loc1
+#define GPU_LOC_2 loc2
+#define GPU_LOC_3 loc3
+#else
+#define GPU_LOC_0 LOC_0
+#define GPU_LOC_1 LOC_1
+#define GPU_LOC_2 LOC_2
+#define GPU_LOC_3 LOC_3
+#endif
 
-	// Shift the salt bytes into place after the given key.
-	W[len / 4] |= (salt_s[0] & sra) >> sr;
-	W[len / 4 + 1] = ((salt_s[0] & sla) << sl) | ((salt_s[1] & sra) >> sr);
-	W[len / 4 + 2] = ((salt_s[1] & sla) << sl) | ((salt_s[2] & sra) >> sr);
-	W[len / 4 + 3] = (salt_s[2] & sla) << sl;
+	const uint base = key_idx[gid];
+	const uint len = key_idx[gid + 1] - base;
+	key_buf += base;
 
-	// The 0x80 ending character was added to the salt before we receive it
+	const uint shift = len % 4;
+	const uint sr = 8 * shift;
+	const uint sl = 32 - sr;
+	const uint sra = (0xffffffff - (1 << sr)) + 1;
+	const uint sla = 0xffffffff - sra;
 
-	W[15] = (len + 10) << 3;
+	// Endian swap salt
+	uint salt_be[sizeof(salt->salt) / 4];
+	for (uint i = 0; i < sizeof(salt->salt) / 4; i++)
+		salt_be[i] = SWAP32(salt->salt[i]);
 
-	sha1_single(uint, W, output);
+	for (uint idx = 0; idx < NUM_INT_KEYS; idx++) {
+		const uint gidx = gid * NUM_INT_KEYS + idx;
+		uchar password[PLAINTEXT_LENGTH] = { 0 };
+		uint i;
 
-	for (i = 0; i < 5; i++)
-		aes_key.w[i] = SWAP32(output[i]);
-	aes_key.w[5] = 0;
+		for (i = 0; i < len; i++)
+			password[i] = key_buf[i];
 
-	for (i = 0; i < 16; i++)
-		iv[i] = salt->ct[16 + i];
+#if NUM_INT_KEYS > 1
+		password[GPU_LOC_0] = (int_keys[idx] & 0xff);
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+		password[GPU_LOC_1] = (int_keys[idx] & 0xff >> 8);
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+		password[GPU_LOC_2] = (int_keys[idx] & 0xff >> 16);
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+		password[GPU_LOC_3] = (int_keys[idx] & 0xff >> 24);
+#endif
+#endif
+#endif
+		uint W[16] = { 0 };
+		for (i = 0; i < PLAINTEXT_LENGTH / 4; i++)
+			GET_UINT32BE(W[i], password, 4 * i);
 
-	AES_set_decrypt_key(aes_key.c, 192, &akey);
-	AES_cbc_decrypt(&salt->ct[32], pt.c, 16, &akey, iv);
+		// Shift the salt bytes into place after the given key.
+		W[len / 4] |= (salt_be[0] & sra) >> sr;
+		W[len / 4 + 1] = ((salt_be[0] & sla) << sl) | ((salt_be[1] & sra) >> sr);
+		W[len / 4 + 2] = ((salt_be[1] & sla) << sl) | ((salt_be[2] & sra) >> sr);
+		W[len / 4 + 3] = (salt_be[2] & sla) << sl;
 
-	result[gid] = (pt.l[1] == 0x0808080808080808UL);
+		// The Merkel-Damgård 0x80 ending byte was already added to the salt
+		// on host side, here's the length.
+		W[15] = (len + 10) << 3;
+
+		uint output[160 / 32];
+		sha1_single(uint, W, output);
+
+		union {
+			uchar c[192 / 8];
+			uint w[0];
+		} key;
+		for (i = 0; i < 5; i++)
+			key.w[i] = SWAP32(output[i]);
+		key.w[5] = 0;
+
+		uchar iv[16];
+
+		AES_set_decrypt_key(key.c, 192, &akey);
+
+		if (salt->pw_len) {
+			const uint blen = (len + 15) / 16;
+
+			// Early reject
+			if (salt->pw_len != blen)
+				return;
+
+			memcpy_cp(iv, salt->ct, 16);
+			uchar ct[SECRET_LEN];
+			memcpy_cp(ct, salt->ct + 16, SECRET_LEN);
+
+			uchar s_secret[SECRET_LEN];
+			//AES_set_decrypt_key(key.c, 192, &akey);
+			AES_cbc_decrypt(ct, s_secret, SECRET_LEN, &akey, iv);
+
+			memcpy_cp(iv, salt->csk, 16);
+			uchar csk[SECRET_LEN];
+			memcpy_cp(csk, salt->csk + 16, SECRET_LEN);
+			uchar c_secret[SECRET_LEN];
+			//AES_set_decrypt_key(key.c, 192, &akey);
+			AES_cbc_decrypt(csk, c_secret, SECRET_LEN, &akey, iv);
+
+			uchar combined_sk[SECRET_LEN];
+			for (i = 0; i < SECRET_LEN; i++)
+				combined_sk[i] = s_secret[i] ^ c_secret[i];
+
+			uchar final_key[32];
+			MD5_CTX ctx;
+			MD5_Init(&ctx);
+			MD5_Update(&ctx, combined_sk, 16);
+			MD5_Final(final_key, &ctx);
+			MD5_Init(&ctx);
+			MD5_Update(&ctx, combined_sk + 16, 8);
+			MD5_Final(final_key + 16, &ctx);
+
+			memcpy_cp(iv, salt->pw, 16);
+
+			uchar pw[PLAINTEXT_LENGTH];
+			memcpy_cp(pw, salt->pw + 16, PLAINTEXT_LENGTH);
+
+			uchar dec_pw[PLAINTEXT_LENGTH + 16];
+			AES_set_decrypt_key(final_key, 192, &akey);
+			AES_cbc_decrypt(pw, dec_pw, salt->pw_len * 16, &akey, iv);
+
+			if (!memcmp_pp(dec_pw, password, len) &&
+			    check_pkcs_pad(dec_pw, salt->pw_len * 16, AES_BLOCK_SIZE))
+				out_index[atomic_inc(crack_count_ret)] = gidx;
+		} else {
+			union {
+				uchar c[16];
+				ulong l[0];
+			} pt;
+
+			memcpy_cp(iv, &salt->ct[16], 16);
+			uchar ct[16];
+			memcpy_cp(ct, &salt->ct[32], 16);
+			//AES_set_decrypt_key(key.c, 192, &akey);
+			AES_cbc_decrypt(ct, pt.c, 16, &akey, iv);
+
+			if (pt.l[1] == 0x0808080808080808UL)
+				out_index[atomic_inc(crack_count_ret)] = gidx;
+		}
+	}
 }

--- a/src/o5logon_common.h
+++ b/src/o5logon_common.h
@@ -1,0 +1,48 @@
+/*
+ * This software is Copyright (c) 2025 magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#ifndef O5LOGON_COMMON
+#define O5LOGON_COMMON
+
+#include <string.h>
+
+#include "arch.h"
+#include "formats.h"
+#include "misc.h"
+#include "common.h"
+#include "params.h"
+#include "options.h"
+
+#define FORMAT_NAME         "Oracle O5LOGON protocol"
+#define FORMAT_TAG          "$o5logon$"
+#define FORMAT_TAG_LEN      (sizeof(FORMAT_TAG)-1)
+
+#define BENCHMARK_COMMENT   ""
+#define BENCHMARK_LENGTH    7
+#define PLAINTEXT_LENGTH    32	/* Can't be bumped for OpenCL */
+#define CIPHERTEXT_LENGTH   48
+#define SALT_LENGTH         10
+#define BINARY_SIZE         0
+#define BINARY_ALIGN        1
+#define SALT_SIZE           sizeof(o5logon_salt)
+#define SALT_ALIGN          sizeof(int32_t)
+
+typedef struct {
+	unsigned int pw_len;               /* AUTH_PASSWORD length (blocks) */
+	unsigned char salt[(SALT_LENGTH + 1 + 3) / 4 * 4]; /* AUTH_VFR_DATA */
+	unsigned char ct[CIPHERTEXT_LENGTH];       /* Server's AUTH_SESSKEY */
+	unsigned char csk[CIPHERTEXT_LENGTH];      /* Client's AUTH_SESSKEY */
+	unsigned char pw[PLAINTEXT_LENGTH + 16];  /* Client's AUTH_PASSWORD */
+} o5logon_salt;
+
+extern struct fmt_tests o5logon_tests[];
+
+extern int o5logon_valid(char *ciphertext, struct fmt_main *self);
+extern void *o5logon_get_salt(char *ciphertext);
+
+#endif

--- a/src/o5logon_common_plug.c
+++ b/src/o5logon_common_plug.c
@@ -1,0 +1,107 @@
+/*
+ * This software is Copyright (c) 2025 magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+#include "o5logon_common.h"
+
+struct fmt_tests o5logon_tests[] = {
+	{"$o5logon$566499330E8896301A1D2711EFB59E756D41AF7A550488D82FE7C8A418E5BE08B4052C0DC404A805C1D7D43FE3350873*4F739806EBC1D7742BC6", "password"},
+	{"$o5logon$3BB71A77E1DBB5FFCCC8FC8C4537F16584CB5113E4CCE3BAFF7B66D527E32D29DF5A69FA747C4E2C18C1837F750E5BA6*4F739806EBC1D7742BC6", "password"},
+	{"$o5logon$ED91B97A04000F326F17430A65DACB30CD1EF788E6EC310742B811E32112C0C9CC39554C9C01A090CB95E95C94140C28*7FD52BC80AA5836695D4", "test1"},
+	{"$o5logon$B7711CC7E805520CEAE8C1AC459F745639E6C9338F192F92204A9518B226ED39851C154CB384E4A58C444A6DF26146E4*3D14D54520BC9E6511F4", "openwall"},
+	{"$o5logon$76F9BBAEEA9CF70F2A660A909F85F374F16F0A4B1BE1126A062AE9F0D3268821EF361BF08EBEF392F782F2D6D0192FD6*3D14D54520BC9E6511F4", "openwall"},
+	{"$o5logon$C35A36EA7FF7293EF828B2BD5A2830CA28A57BF621EAE14B605D41A88FC2CF7EFE7C73495FB22F06D6D98317D63DDA71*406813CBAEED2FD4AD23", "MDDATA"},
+	{"$o5logon$B9AC30E3CD7E1D7C95FA17E1C62D061289C36FD5A6C45C098FF7572AB9AD2B684FB7E131E03CE1543A5A99A30D68DD13*447BED5BE70F7067D646", "sys"},
+	// the following hash (from HITCON 2014 CTF) revealed multiple bugs in this format (false positives)!
+	// m3odbe
+	// m3o3rt
+	{"$o5logon$A10D52C1A432B61834F4B0D9592F55BD0DA2B440AEEE1858515A646683240D24A61F0C9366C63E93D629292B7891F44A*878C0B92D61A594F2680", "m3ow00"},
+	{"$o5logon$52696131746C356643796B6D716F46474444787745543263764B725A6D756A69E46DE32AFBB33E385C6D9C7031F4F2B9*3131316D557239736A65", "123456"},
+	{"$o5logon$4336396C304B684638634450576B30397867704F54766D71494F676F5A5A386F09F4A10B5908B3ED5B1D6878A6C78751*573167557661774E7271", ""},
+
+	// The below are Oracle 12 hashes
+	{"$o5logon$4D04DBD23D103F05D9B57EB6EC14D83A0A468AB906EAC907D3A8C796573E5F34BC15F0ECBC9EAC0350A38A663A368233*442192E518F6F43D7CF7*D3963B6AAED39C231BD5C92A10C0F146CA4784D1503A9B97598B31D33406390B7CA4F8B3EE5406A54C1842E4E63D1220*192AB7C9BA21C883824CF3D5BA073AC1129FD841E0AF6DF522C7EBDC52783CB8B97B792BFB6D9D743C7F4376FF0E7F93", "password1234567890"},
+	{"$o5logon$475FEF5BD6E8BCD9972935CE0A857B0B928438B0E4662588384F164801E59373490674B58039AEA2FDBB814C2496EA35*3D14D54520BC9E6511F4*BD0B6E2FD58320CA4B0516A21EF2AF70B61E5ACFC3EE4D5D6E5C492A7932D09C*80A1EADECBD79D1F70221AD8081FD201B92699151735499F42AD36A028A6A836D46AA81F0E27AC7E68CC66619F1F4D56", "openwall"},
+	{"$o5logon$8D032D2C3AAB74E34ADABE9D4E62A3B19029DB37054665A004435DAF0B6C571A16DFE69C232923A1685414307DC01D88*681D0B32B396420D5914*EA974D3A9D7ECDC7316E03772847A9960E7DE5D86D416781072A36A6B7DBB430*0B8297E48756AA562F369651C18B73A5FEAA89151787298A4116E66090B6B72535154AE28B5D29DFA8740706D74FC49A", "password"},
+	{NULL}
+};
+
+int o5logon_valid(char *ciphertext, struct fmt_main *self)
+{
+	char *ctcopy;
+	char *keeptr;
+	char *p;
+	int extra;
+
+	if (strncmp(ciphertext,  FORMAT_TAG, FORMAT_TAG_LEN))
+		return 0;
+	ctcopy = xstrdup(ciphertext);
+	keeptr = ctcopy;
+	ctcopy += FORMAT_TAG_LEN;
+	p = strtokm(ctcopy, "*"); /* server's sesskey */
+	if (!p)
+		goto err;
+	if (hexlenu(p, &extra) != CIPHERTEXT_LENGTH * 2 || extra)
+		goto err;
+	if ((p = strtokm(NULL, "*")) == NULL)	/* salt */
+		goto err;
+	if (hexlenu(p, &extra) != SALT_LENGTH * 2 || extra)
+		goto err;
+	/* optional fields follow */
+	if ((p = strtokm(NULL, "*"))) {	/* client's encrypted password */
+		int len = hexlenu(p, &extra);
+
+		if (extra || len < 64 || len % 32 || len > 2 * (PLAINTEXT_LENGTH + 16))
+			goto err;
+		if ((p = strtokm(NULL, "*")) == NULL)	/* client's sesskey */
+			goto err;
+		if (hexlenu(p, &extra) != CIPHERTEXT_LENGTH * 2 || extra)
+			goto err;
+	}
+	MEM_FREE(keeptr);
+	return 1;
+
+err:
+	MEM_FREE(keeptr);
+	return 0;
+}
+
+void *o5logon_get_salt(char *ciphertext)
+{
+	static o5logon_salt cs;
+	char *ctcopy = xstrdup(ciphertext);
+	char *keeptr = ctcopy;
+	char *p;
+	int i;
+
+	memset(&cs, 0, sizeof(cs));
+	ctcopy += FORMAT_TAG_LEN;	/* skip over "$o5logon$" */
+	p = strtokm(ctcopy, "*");
+	for (i = 0; i < CIPHERTEXT_LENGTH; i++)
+		cs.ct[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	p = strtokm(NULL, "*");
+	for (i = 0; i < SALT_LENGTH; i++)
+		cs.salt[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	cs.salt[SALT_LENGTH] = 0x80;
+	memset(&cs.salt[SALT_LENGTH + 1], 0, sizeof(cs.salt) - (SALT_LENGTH + 1));
+
+	/* Oracle 12 hashes may have more fields (optional for older ver) */
+	if ((p = strtokm(NULL, "*"))) {
+		cs.pw_len = hexlenu(p, 0) / 2 / 16 - 1;
+		for (i = 0; p[i * 2]; i++)
+			cs.pw[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+		p = strtokm(NULL, "*");
+		for (i = 0; i < CIPHERTEXT_LENGTH; i++)
+			cs.csk[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
+				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
+	}
+
+	MEM_FREE(keeptr);
+	return (void *)&cs;
+}

--- a/src/o5logon_fmt_plug.c
+++ b/src/o5logon_fmt_plug.c
@@ -4,14 +4,15 @@
  *
  * O5LOGON is used since version 11g. CVE-2012-3137 applies to Oracle 11.1
  * and 11.2 databases. Oracle has "fixed" the problem in version 11.2.0.3.
+ * Oracle 12 support is now added as well.
  *
- * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
+ * This software is
+ * Copyright (c) 2012-2025 magnum
+ * Copyright (c) 2014 Harrison Neal
+ * Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>,
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted.
- *
- * Modifications (c) 2014 Harrison Neal, released under the same terms
- * as the original.
  */
 
 #if FMT_EXTERNS_H
@@ -20,7 +21,6 @@ extern struct fmt_main fmt_o5logon;
 john_register_one(&fmt_o5logon);
 #else
 
-#include <string.h>
 #include <stdint.h>
 
 #ifdef _OPENMP
@@ -29,28 +29,12 @@ john_register_one(&fmt_o5logon);
 
 #include "arch.h"
 #include "sha.h"
-#include "misc.h"
-#include "common.h"
-#include "formats.h"
-#include "params.h"
-#include "options.h"
 #include "aes.h"
 #include "md5.h"
+#include "o5logon_common.h"
 
 #define FORMAT_LABEL            "o5logon"
-#define FORMAT_NAME             "Oracle O5LOGON protocol"
-#define FORMAT_TAG              "$o5logon$"
-#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME          "SHA1 AES 32/" ARCH_BITS_STR
-#define BENCHMARK_COMMENT       ""
-#define BENCHMARK_LENGTH        7
-#define PLAINTEXT_LENGTH        32 /* Multiple of 16 */
-#define CIPHERTEXT_LENGTH       48
-#define SALT_LENGTH             10
-#define BINARY_SIZE             0
-#define BINARY_ALIGN            1
-#define SALT_ALIGN              sizeof(int32_t)
-#define SALT_SIZE               sizeof(struct custom_salt)
+#define ALGORITHM_NAME          "MD5 SHA1 AES 32/" ARCH_BITS_STR
 #define MIN_KEYS_PER_CRYPT      1
 #define MAX_KEYS_PER_CRYPT      256
 
@@ -58,35 +42,10 @@ john_register_one(&fmt_o5logon);
 #define OMP_SCALE               8 // Tuned w/ MKPC on super
 #endif
 
-static struct fmt_tests o5logon_tests[] = {
-	{"$o5logon$566499330E8896301A1D2711EFB59E756D41AF7A550488D82FE7C8A418E5BE08B4052C0DC404A805C1D7D43FE3350873*4F739806EBC1D7742BC6", "password"},
-	{"$o5logon$3BB71A77E1DBB5FFCCC8FC8C4537F16584CB5113E4CCE3BAFF7B66D527E32D29DF5A69FA747C4E2C18C1837F750E5BA6*4F739806EBC1D7742BC6", "password"},
-	{"$o5logon$ED91B97A04000F326F17430A65DACB30CD1EF788E6EC310742B811E32112C0C9CC39554C9C01A090CB95E95C94140C28*7FD52BC80AA5836695D4", "test1"},
-	{"$o5logon$B7711CC7E805520CEAE8C1AC459F745639E6C9338F192F92204A9518B226ED39851C154CB384E4A58C444A6DF26146E4*3D14D54520BC9E6511F4", "openwall"},
-	{"$o5logon$76F9BBAEEA9CF70F2A660A909F85F374F16F0A4B1BE1126A062AE9F0D3268821EF361BF08EBEF392F782F2D6D0192FD6*3D14D54520BC9E6511F4", "openwall"},
-	{"$o5logon$C35A36EA7FF7293EF828B2BD5A2830CA28A57BF621EAE14B605D41A88FC2CF7EFE7C73495FB22F06D6D98317D63DDA71*406813CBAEED2FD4AD23", "MDDATA"},
-	{"$o5logon$B9AC30E3CD7E1D7C95FA17E1C62D061289C36FD5A6C45C098FF7572AB9AD2B684FB7E131E03CE1543A5A99A30D68DD13*447BED5BE70F7067D646", "sys"},
-	// the following hash (from HITCON 2014 CTF) revealed multiple bugs in this format (false positives)!
-	// m3odbe
-	// m3o3rt
-	{"$o5logon$A10D52C1A432B61834F4B0D9592F55BD0DA2B440AEEE1858515A646683240D24A61F0C9366C63E93D629292B7891F44A*878C0B92D61A594F2680", "m3ow00"},
-	{"$o5logon$52696131746C356643796B6D716F46474444787745543263764B725A6D756A69E46DE32AFBB33E385C6D9C7031F4F2B9*3131316D557239736A65", "123456"},
-	{"$o5logon$4336396C304B684638634450576B30397867704F54766D71494F676F5A5A386F09F4A10B5908B3ED5B1D6878A6C78751*573167557661774E7271", ""},
-	{"$o5logon$4D04DBD23D103F05D9B57EB6EC14D83A0A468AB906EAC907D3A8C796573E5F34BC15F0ECBC9EAC0350A38A663A368233*442192E518F6F43D7CF7*D3963B6AAED39C231BD5C92A10C0F146CA4784D1503A9B97598B31D33406390B7CA4F8B3EE5406A54C1842E4E63D1220*192AB7C9BA21C883824CF3D5BA073AC1129FD841E0AF6DF522C7EBDC52783CB8B97B792BFB6D9D743C7F4376FF0E7F93", "password1234567890"},
-	{NULL}
-};
-
 static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static int *saved_len;
 static int *cracked, any_cracked;
-
-static struct custom_salt {
-	unsigned char salt[SALT_LENGTH];         /* AUTH_VFR_DATA */
-	unsigned char ct[CIPHERTEXT_LENGTH];     /* Server's AUTH_SESSKEY */
-	unsigned char csk[CIPHERTEXT_LENGTH];    /* Client's AUTH_SESSKEY */
-	unsigned char pw[16 + PLAINTEXT_LENGTH]; /* Client's AUTH_PASSWORD */
-	int pw_len;                              /* AUTH_PASSWORD length (blocks) */
-} *cur_salt;
+static o5logon_salt *cur_salt;
 
 static void init(struct fmt_main *self)
 {
@@ -107,84 +66,9 @@ static void done(void)
 	MEM_FREE(saved_key);
 }
 
-static int valid(char *ciphertext, struct fmt_main *self)
-{
-	char *ctcopy;
-	char *keeptr;
-	char *p;
-	int extra;
-
-	if (strncmp(ciphertext,  FORMAT_TAG, FORMAT_TAG_LEN))
-		return 0;
-	ctcopy = xstrdup(ciphertext);
-	keeptr = ctcopy;
-	ctcopy += FORMAT_TAG_LEN;
-	p = strtokm(ctcopy, "*"); /* server's sesskey */
-	if (!p)
-		goto err;
-	if (hexlenu(p, &extra) != CIPHERTEXT_LENGTH * 2 || extra)
-		goto err;
-	if ((p = strtokm(NULL, "*")) == NULL)	/* salt */
-		goto err;
-	if (hexlenu(p, &extra) != SALT_LENGTH * 2 || extra)
-		goto err;
-	/* optional fields follow */
-	if ((p = strtokm(NULL, "*"))) {	/* client's encrypted password */
-		int len = hexlenu(p, &extra);
-
-		if (extra || len < 64 || len % 32 || len > 2 * PLAINTEXT_LENGTH + 32)
-			goto err;
-		if ((p = strtokm(NULL, "*")) == NULL)	/* client's sesskey */
-			goto err;
-		if (hexlenu(p, &extra) != CIPHERTEXT_LENGTH * 2 || extra)
-			goto err;
-	}
-	MEM_FREE(keeptr);
-	return 1;
-
-err:
-	MEM_FREE(keeptr);
-	return 0;
-}
-
-static void *get_salt(char *ciphertext)
-{
-	static struct custom_salt cs;
-	char *ctcopy = xstrdup(ciphertext);
-	char *keeptr = ctcopy;
-	char *p;
-	int i;
-
-	memset(&cs, 0, sizeof(cs));
-	ctcopy += FORMAT_TAG_LEN;	/* skip over "$o5logon$" */
-	p = strtokm(ctcopy, "*");
-	for (i = 0; i < CIPHERTEXT_LENGTH; i++)
-		cs.ct[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	p = strtokm(NULL, "*");
-	for (i = 0; i < SALT_LENGTH; i++)
-		cs.salt[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-			+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-
-	/* Oracle 12 hashes may have more fields (optional for older ver) */
-	if ((p = strtokm(NULL, "*"))) {
-		cs.pw_len = hexlenu(p, 0) / 2 / 16 - 1;
-		for (i = 0; p[i * 2]; i++)
-			cs.pw[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-		p = strtokm(NULL, "*");
-		for (i = 0; i < CIPHERTEXT_LENGTH; i++)
-			cs.csk[i] = atoi16[ARCH_INDEX(p[i * 2])] * 16
-				+ atoi16[ARCH_INDEX(p[i * 2 + 1])];
-	}
-
-	MEM_FREE(keeptr);
-	return (void *)&cs;
-}
-
 static void set_salt(void *salt)
 {
-	cur_salt = (struct custom_salt *)salt;
+	cur_salt = (o5logon_salt*)salt;
 }
 
 static int crypt_all(int *pcount, struct db_salt *salt)
@@ -246,8 +130,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				AES_set_decrypt_key(final_key, 192, &akey);
 				AES_cbc_encrypt(cur_salt->pw, password, (cur_salt->pw_len + 1) * 16, &akey, iv, AES_DECRYPT);
 
-				if (!memcmp(dec_pw, saved_key[index], saved_len[index]))
-				{
+				if (!memcmp(dec_pw, saved_key[index], saved_len[index])) {
 					char *p = dec_pw + 16 * blen - 1;
 					int n, pad;
 					int res = 1;
@@ -276,8 +159,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			AES_set_decrypt_key(key, 192, &akey);
 			AES_cbc_encrypt(cur_salt->ct + 32, pt, 16, &akey, iv, AES_DECRYPT);
 
-			if (!memcmp(pt + 8, "\x08\x08\x08\x08\x08\x08\x08\x08", 8))
-			{
+			if (!memcmp(pt + 8, "\x08\x08\x08\x08\x08\x08\x08\x08", 8)) {
 				cracked[index] = 1;
 #ifdef _OPENMP
 #pragma omp atomic
@@ -340,10 +222,10 @@ struct fmt_main fmt_o5logon = {
 		done,
 		fmt_default_reset,
 		fmt_default_prepare,
-		valid,
+		o5logon_valid,
 		fmt_default_split,
 		fmt_default_binary,
-		get_salt,
+		o5logon_get_salt,
 		{ NULL },
 		fmt_default_source,
 		{

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1142,7 +1142,8 @@ static char *get_build_opts(int sequential_id, const char *opts)
 #ifdef __APPLE__
 	        "-D__OS_X__ ",
 #else
-	        (options.verbosity >= VERB_LEGACY &&
+	        (cfg_get_bool(SECTION_OPTIONS, SUBSECTION_OPENCL, "NvidiaShowPtxas", 1) &&
+	         options.verbosity >= VERB_LEGACY &&
 	         gpu_nvidia(device_info[sequential_id])) ?
 	         "-cl-nv-verbose " : "",
 #endif
@@ -1272,6 +1273,13 @@ void opencl_build(int sequential_id, const char *opts, int save, const char *fil
 	uint64_t end = john_get_nano();
 	log_event("- build time: %ss", ns2string(end - start));
 
+	char *cleaned_log = build_log;
+	if (cfg_get_bool(SECTION_OPTIONS, SUBSECTION_OPENCL, "MuteBogusWarnings", 1) &&
+	    options.verbosity < VERB_DEBUG) {
+		while (!strncmp(cleaned_log, "(): Warning: Function ", 22) && strstr(cleaned_log + 23, " is a kernel, so overriding noinline attribute. The function may be inlined when called."))
+			while (*cleaned_log && *cleaned_log++ != '\n');
+	}
+
 	// Report build errors and warnings
 	// Nvidia may return a single '\n' that we ignore
 	if (build_code != CL_SUCCESS) {
@@ -1279,19 +1287,20 @@ void opencl_build(int sequential_id, const char *opts, int save, const char *fil
 		if (options.verbosity <= VERB_LEGACY)
 			fprintf(stderr, "Options used: %s %s\n",
 			        build_opts, kernel_source_file);
-		if (strlen(build_log) > 1) {
+		if (strlen(cleaned_log) > 1) {
 			fprintf(stderr, "Build time: %ss\n", ns2string(end - start));
-			fprintf(stderr, "Build log: %s\n", build_log);
+			fprintf(stderr, "Build log: %s\n", cleaned_log);
 		} else if (options.verbosity >= VERB_MAX)
 			fprintf(stderr, "Build time: %ss\n", ns2string(end - start));
 		fprintf(stderr, "Error building kernel %s. DEVICE_INFO=%d\n",
 		        kernel_source_file, device_info[sequential_id]);
 		HANDLE_CLERROR(build_code, "clBuildProgram");
 	}
-	else if (options.verbosity >= LOG_VERB) {
-		if (strlen(build_log) > 1) {
+	else if (cfg_get_bool(SECTION_OPTIONS, SUBSECTION_OPENCL, "AlwaysShowBuildWarnings", 1) ||
+	         options.verbosity >= LOG_VERB) {
+		if (strlen(cleaned_log) > 1) {
 			fprintf(stderr, "Build time: %ss\n", ns2string(end - start));
-			fprintf(stderr, "Build log: %s\n", build_log);
+			fprintf(stderr, "Build log: %s\n", cleaned_log);
 		} else if (options.verbosity >= VERB_MAX)
 			fprintf(stderr, "Build time: %ss\n", ns2string(end - start));
 	}


### PR DESCRIPTION
Also implements internal mask, for a 3-4x boost (due to "packed" key buffer it was pretty good already).
    
Closes #5648

<s>The "Mute stupid warnings" commit (#5456) will be dropped before merging (I could make a separate PR after adding a conf option for it). It strips the idiot warnings while retaining any relevant warnings (mutes the warning entirely if there were no relevant ones).</s>

<s>As of now, there's a bug in here. I have stared at the code for days, can't find it. Things behave weird - segfaults and such, on any device (including super's AMD that brings down the entire host). Debugging sometimes show super weird stuff that I can't draw any conclusions from.

Switching to the alternative (bitsliced) AES code sometimes move the problem around, or nearly hides it.

Running at LWS=1 sometimes helps a little or a lot. Everything points to a buffer overflow, except I can't find any, ASan can't either, and under ASan there's no nvidia device to be seen. A backtrace nearly always points to opaque OpenCL runtime stuff only.</s>

The o5logon stuff should ideally have been two commits, one for separating shared code and one for internal mask. But it's all too tangled to be fixed in retrospect.