### PR TITLE
Some OpenCL packed-buffer formats: Add safety for count < GWS

### DIFF
--- a/src/opencl_cryptosafe_fmt_plug.c
+++ b/src/opencl_cryptosafe_fmt_plug.c
@@ -346,6 +346,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		if (idx_offset > 4 * (gws + 1))
 			idx_offset = 0;
 
+		/* Safety for when count < GWS */
+		for (int i = count; i <= gws; i++)
+			saved_idx[i] = key_idx;
+
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, 0, NULL, multi_profilingEvent[0]), "Failed transferring keys");
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_idx, CL_FALSE, idx_offset, 4 * (gws + 1) - idx_offset, saved_idx + (idx_offset / 4), 0, NULL, multi_profilingEvent[1]), "Failed transferring index");
 

--- a/src/opencl_krb5_tgs_fmt_plug.c
+++ b/src/opencl_krb5_tgs_fmt_plug.c
@@ -400,6 +400,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 	*pcount *= mask_int_cand.num_int_cand;
 
+	/* Safety for when count < GWS */
+	for (int i = count; i <= gws; i++)
+		saved_idx[i] = key_idx;
+
 	if (new_keys) {
 		/* Self-test kludge */
 		if (idx_offset > idxsize)

--- a/src/opencl_nt_fmt_plug.c
+++ b/src/opencl_nt_fmt_plug.c
@@ -636,6 +636,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	if (key_idx)
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_FALSE, key_offset, 4 * key_idx - key_offset, saved_plain + key_offset / 4, 0, NULL, multi_profilingEvent[0]), "failed in clEnqueueWriteBuffer buffer_keys.");
 
+	/* Safety for when count < GWS */
+	for (int i = count; i <= gws; i++)
+		saved_idx[i] = key_idx;
+
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_FALSE, idx_offset, 4 * gws - idx_offset, saved_idx + idx_offset / 4, 0, NULL, multi_profilingEvent[1]), "failed in clEnqueueWriteBuffer buffer_idx.");
 
 	if (!mask_gpu_is_static)

--- a/src/opencl_oldoffice_fmt_plug.c
+++ b/src/opencl_oldoffice_fmt_plug.c
@@ -530,6 +530,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		if (idx_offset > 4 * (gws + 1))
 			idx_offset = 0;
 
+		/* Safety for when count < GWS */
+		for (int i = count; i <= gws; i++)
+			saved_idx[i] = key_idx;
+
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, 0, NULL, multi_profilingEvent[0]), "Failed transferring keys");
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_idx, CL_FALSE, idx_offset, 4 * (gws + 1) - idx_offset, saved_idx + (idx_offset / 4), 0, NULL, multi_profilingEvent[1]), "Failed transferring index");
 

--- a/src/opencl_pdf_fmt_plug.c
+++ b/src/opencl_pdf_fmt_plug.c
@@ -341,6 +341,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		if (idx_offset > 4 * (gws + 1))
 			idx_offset = 0;
 
+		/* Safety for when count < GWS */
+		for (int i = count; i <= gws; i++)
+			saved_idx[i] = key_idx;
+
 		CLWRITE_CRYPT(cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, multi_profilingEvent[0]);
 		CLWRITE_CRYPT(cl_saved_idx, CL_FALSE, idx_offset, 4 * (gws + 1) - idx_offset, saved_idx + (idx_offset / 4), multi_profilingEvent[1]);
 

--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -325,6 +325,10 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		if (idx_offset > 4 * (gws + 1))
 			idx_offset = 0;	/* Self-test kludge */
 
+		/* Safety for when count < GWS */
+		for (int i = count; i <= gws; i++)
+			saved_idx[i] = key_idx;
+
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, 0, NULL, multi_profilingEvent[0]), "Failed transferring keys");
 		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], cl_saved_idx, CL_FALSE, idx_offset, 4 * (gws + 1) - idx_offset, saved_idx + (idx_offset / 4), 0, NULL, multi_profilingEvent[0]), "Failed transferring index");
 		BENCH_CLERROR(clFinish(queue[gpu_id]), "failed in clFinish");


### PR DESCRIPTION
The problem, if any, would occur during self-tests, single mode or at the last batch of a session, with stale data past currently used part of buffer. Actual problem seen with upcoming revised o5logon-opencl.

Can be benign if triggered but it may lead to a kernel crash.