### PR TITLE
Tweak the "excessive partial hash collisions" warnings

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -1,6 +1,8 @@
 /*
  * This file is part of John the Ripper password cracker,
  * Copyright (c) 1996-2001,2006,2008,2010-2013,2015 by Solar Designer
+ * Copyright (c) 2011-2025, magnum
+ * Copyright (c) 2009-2018, JimF
  */
 
 #if AC_BUILT
@@ -902,6 +904,30 @@ static char *fmt_self_test_body(struct fmt_main *format,
 			    format->methods.get_hash[size] !=
 			    fmt_default_get_hash)
 				return "get_hash method not allowed for FMT_HUGE_INPUT";
+		}
+	}
+
+	if (format->params.flags & FMT_BLOB) {
+		/*
+		 * BLOB formats can't use the default binary_hash_[0-6] functions.
+		 */
+		if (format->methods.binary_hash[0] == fmt_default_binary_hash_0)
+			return "default binary_hash_[0-6] method not allowed for FMT_BLOB";
+	}
+
+	if (format->params.binary_size == 0) {
+		for (size = 0; size < PASSWORD_HASH_SIZES; size++) {
+			/*
+			 * Salt-only formats can't have binary hash functions.
+			 */
+			if (format->methods.binary_hash[size] &&
+			    format->methods.binary_hash[size] !=
+			    fmt_default_binary_hash)
+				return "binary_hash method not allowed for salt-only formats";
+			if (format->methods.get_hash[size] &&
+			    format->methods.get_hash[size] !=
+			    fmt_default_get_hash)
+				return "get_hash method not allowed for salt-only formats";
 		}
 	}
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -1,8 +1,8 @@
 /*
  * This file is part of John the Ripper password cracker,
  * Copyright (c) 1996-2000,2003,2005,2010-2012,2015 by Solar Designer
- *
- * ...with heavy changes in the jumbo patch, by magnum and various authors
+ * Copyright (c) 2012-2025, magnum
+ * Copyright (c) 2009-2018, JimF
  */
 #if AC_BUILT
 #include "autoconfig.h"
@@ -996,6 +996,9 @@ static void ldr_load_pw_line(struct db_main *db, char *line)
 
 		if (!(db->options->flags & DB_WORDS) && dupe_checking) {
 			int collisions = 0;
+			int hash_collisions_max = format->params.binary_size ?
+				LDR_HASH_COLLISIONS_MAX : LDR_HASH_COLLISIONS_SALT_ONLY;
+
 			if ((current_pw = db->password_hash[pw_hash]))
 			do {
 				if (!fmt_bincmp(binary, current_pw->binary, format) &&
@@ -1004,7 +1007,7 @@ static void ldr_load_pw_line(struct db_main *db, char *line)
 					db->options->flags |= DB_NODUP;
 					break;
 				}
-				if (++collisions <= LDR_HASH_COLLISIONS_MAX)
+				if (++collisions <= hash_collisions_max)
 					continue;
 
 				if (john_main_process) {

--- a/src/office_common.h
+++ b/src/office_common.h
@@ -1,14 +1,10 @@
 /*
  * Office 2007-2013 cracker patch for JtR, common code. This software is
  * Copyright (c) 2014 by JimF
- * Copyright (c) 2012-2019 magnum
+ * Copyright (c) 2012-2025 magnum
  * and is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
- *
- * This file takes replicated but common code, shared between the CPU
- * office format, and the GPU office formats, and places it into one
- * common location.
  */
 
 #include "formats.h"
@@ -35,10 +31,17 @@ typedef struct ms_office_binary_blob_t {
 	uint8_t encryptedVerifierHash[32];
 } ms_office_binary_blob;
 
-void *ms_office_common_get_salt(char *ciphertext);
-void *ms_office_common_binary(char *ciphertext);
-int ms_office_common_valid(char *ciphertext, struct fmt_main *self);
+extern void *ms_office_common_get_salt(char *ciphertext);
+extern void *ms_office_common_binary(char *ciphertext);
+extern int ms_office_common_valid(char *ciphertext, struct fmt_main *self);
 
 /* other 'common' functions for MSOffice */
-unsigned int ms_office_common_iteration_count(void *salt);
-unsigned int ms_office_common_version(void *salt);
+extern unsigned int ms_office_common_iteration_count(void *salt);
+extern unsigned int ms_office_common_version(void *salt);
+extern int ms_office_binary_hash_0(void *binary);
+extern int ms_office_binary_hash_1(void *binary);
+extern int ms_office_binary_hash_2(void *binary);
+extern int ms_office_binary_hash_3(void *binary);
+extern int ms_office_binary_hash_4(void *binary);
+extern int ms_office_binary_hash_5(void *binary);
+extern int ms_office_binary_hash_6(void *binary);

--- a/src/office_common_plug.c
+++ b/src/office_common_plug.c
@@ -1,8 +1,10 @@
 /*
- * Office 2007-2013 cracker patch for JtR, common code. 2014 by JimF
- * This file takes replicated but common code, shared between the CPU
- * office format, and the GPU office formats, and places it into one
- * common location (with some tiny tweaks, for things like valid).
+ * Office 2007-2013 cracker patch for JtR, common code. This software is
+ * Copyright (c) 2014 by JimF
+ * Copyright (c) 2012-2025 magnum
+ * and is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  */
 
 #include "arch.h"
@@ -145,3 +147,23 @@ unsigned int ms_office_common_version(void *salt)
 {
 	return ((ms_office_custom_salt*)salt)->version;
 }
+
+static int ms_office_binary_hash(void *binary, uint32_t mask)
+{
+	fmt_data *blob = binary;
+	ms_office_binary_blob *verifiers = blob->blob;
+	uint8_t *encryptedVerifier = verifiers->encryptedVerifier;
+	uint32_t hash;
+
+	memcpy(&hash, encryptedVerifier, sizeof(hash));
+
+	return hash & mask;
+}
+
+int ms_office_binary_hash_0(void *binary) { return ms_office_binary_hash(binary, PH_MASK_0); }
+int ms_office_binary_hash_1(void *binary) { return ms_office_binary_hash(binary, PH_MASK_1); }
+int ms_office_binary_hash_2(void *binary) { return ms_office_binary_hash(binary, PH_MASK_2); }
+int ms_office_binary_hash_3(void *binary) { return ms_office_binary_hash(binary, PH_MASK_3); }
+int ms_office_binary_hash_4(void *binary) { return ms_office_binary_hash(binary, PH_MASK_4); }
+int ms_office_binary_hash_5(void *binary) { return ms_office_binary_hash(binary, PH_MASK_5); }
+int ms_office_binary_hash_6(void *binary) { return ms_office_binary_hash(binary, PH_MASK_6); }

--- a/src/office_fmt_plug.c
+++ b/src/office_fmt_plug.c
@@ -1,7 +1,7 @@
 /*
  * Office 2007 cracker patch for JtR. This software is
  * Copyright (c) 2012 Dhiru Kholia <dhiru.kholia at gmail.com>.
- * Copyright (c) 2012-2021 magnum
+ * Copyright (c) 2012-2025 magnum
  * and is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -802,13 +802,13 @@ struct fmt_main fmt_office = {
 		},
 		fmt_default_source,
 		{
-			fmt_default_binary_hash_0,
-			fmt_default_binary_hash_1,
-			fmt_default_binary_hash_2,
-			fmt_default_binary_hash_3,
-			fmt_default_binary_hash_4,
-			fmt_default_binary_hash_5,
-			fmt_default_binary_hash_6
+			ms_office_binary_hash_0,
+			ms_office_binary_hash_1,
+			ms_office_binary_hash_2,
+			ms_office_binary_hash_3,
+			ms_office_binary_hash_4,
+			ms_office_binary_hash_5,
+			ms_office_binary_hash_6
 		},
 		fmt_default_salt_hash,
 		NULL,

--- a/src/opencl_office_fmt_plug.c
+++ b/src/opencl_office_fmt_plug.c
@@ -2,7 +2,7 @@
  * MS Office >= 2007 cracker for JtR. OpenCL support by magnum.
  *
  * This software is Copyright (c) 2012, Dhiru Kholia <dhiru.kholia at gmail.com>
- * and Copyright (c) 2012-2021, magnum
+ * and Copyright (c) 2012-2025, magnum
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -499,7 +499,13 @@ struct fmt_main fmt_opencl_office = {
 		},
 		fmt_default_source,
 		{
-			fmt_default_binary_hash
+			ms_office_binary_hash_0,
+			ms_office_binary_hash_1,
+			ms_office_binary_hash_2,
+			ms_office_binary_hash_3,
+			ms_office_binary_hash_4,
+			ms_office_binary_hash_5,
+			ms_office_binary_hash_6
 		},
 		fmt_default_salt_hash,
 		NULL,

--- a/src/params.h
+++ b/src/params.h
@@ -359,6 +359,12 @@ extern unsigned int password_hash_thresholds[PASSWORD_HASH_SIZES];
 #define LDR_HASH_COLLISIONS_MAX		1000
 
 /*
+ * Same as above but for salt-only formats, higher because they can't currently
+ * be "fixed" for the issue but still used for explaining the long load time.
+ */
+#define LDR_HASH_COLLISIONS_SALT_ONLY	10000
+
+/*
  * How many bitmap entries should the cracker prefetch at once.  Set this to 0
  * to disable prefetching.
  */


### PR DESCRIPTION
For salt-only formats, bump the warning threshold to <s>10x `LDR_HASH_COLLISIONS_MAX`.</s> `LDR_HASH_COLLISIONS_SALT_ONLY` which is currently 10x `LDR_HASH_COLLISIONS_MAX` in params.h.

Add a self-test for detecting misuse of default binary hash functions with FMT_BLOB formats.

Fix such bug in Office formats.

Closes #5736