### PR TITLE
Several Kerberos formats: Lowercase non-ASCII input

### DIFF
--- a/src/krb5_asrep_common_plug.c
+++ b/src/krb5_asrep_common_plug.c
@@ -12,6 +12,7 @@
 #include "misc.h"
 #include "common.h"
 #include "krb5_asrep_common.h"
+#include "unicode.h"
 
 char *krb5_asrep_split(char *ciphertext, int index, struct fmt_main *self)
 {
@@ -32,8 +33,6 @@ char *krb5_asrep_split(char *ciphertext, int index, struct fmt_main *self)
 		ptr += FORMAT_TAG_LEN;
 		memcpy(ptr, "23$", ETYPE_TAG_LEN); // old hashes
 		ptr += ETYPE_TAG_LEN;
-		for (i = 0; i < strlen(ciphertext) + 1; i++)
-			ptr[i] = tolower(ARCH_INDEX(ciphertext[i]));
 	} else { // new format hashes (with FORMAT_TAG)
 		p = ciphertext + FORMAT_TAG_LEN;
 		if (!strncmp(p, "23$", ETYPE_TAG_LEN))
@@ -47,14 +46,13 @@ char *krb5_asrep_split(char *ciphertext, int index, struct fmt_main *self)
 			p = strchr(ciphertext + FORMAT_TAG_LEN + ETYPE_TAG_LEN + 1, '$') + 1;
 			for (i = 0; i < p - ciphertext; i++)
 				ptr[i] = ARCH_INDEX(ciphertext[i]);
-			for (; i < strlen(ciphertext) + 1; i++)
-				ptr[i] = tolower(ARCH_INDEX(ciphertext[i]));
-
-		} else {
-			for (i = 0; i < strlen(ciphertext) + 1; i++)
-				ptr[i] = tolower(ARCH_INDEX(ciphertext[i]));
+			ptr += i;
+			ciphertext += i;
 		}
 	}
+
+	strcpy(ptr, ciphertext);
+	enc_strlwr(ptr);
 
 	return keeptr;
 }

--- a/src/krb5_tgs_common_plug.c
+++ b/src/krb5_tgs_common_plug.c
@@ -50,7 +50,6 @@ size_t krb5tgs_max_data_len = 1024;
 char *krb5tgs_split(char *ciphertext, int index, struct fmt_main *self)
 {
 	static char *ptr, *keeptr;
-	int i;
 
 	if (strnlen(ciphertext, LINE_BUFFER_SIZE) < LINE_BUFFER_SIZE &&
 	    strstr(ciphertext, "$SOURCE_HASH$"))
@@ -63,8 +62,8 @@ char *krb5tgs_split(char *ciphertext, int index, struct fmt_main *self)
 		ptr += FORMAT_TAG_LEN;
 	}
 
-	for (i = 0; i < strlen(ciphertext) + 1; i++)
-		ptr[i] = tolower(ARCH_INDEX(ciphertext[i]));
+	strcpy(ptr, ciphertext);
+	enc_strlwr(ptr);
 
 	return keeptr;
 }

--- a/src/krb5pa-md5_fmt_plug.c
+++ b/src/krb5pa-md5_fmt_plug.c
@@ -215,7 +215,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 	}
 
 	data = out + strlen(out) - 2 * (CHECKSUM_SIZE + TIMESTAMP_SIZE) - 1;
-	strlwr(data);
+	enc_strlwr(data);
 
 	return out;
 }

--- a/src/krb5pa-sha1_fmt_plug.c
+++ b/src/krb5pa-sha1_fmt_plug.c
@@ -287,7 +287,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *pFmt)
 	snprintf(out, sizeof(out), "%s%s$%s$%s$%s$%s", FORMAT_TAG, e, u, r, s, tc);
 
 	data = out + strlen(out) - 2 * (CHECKSUM_SIZE + TIMESTAMP_SIZE) - 1;
-	strlwr(data);
+	enc_strlwr(data);
 
 	return out;
 }


### PR DESCRIPTION
They would only lowercase ASCII until now, resulting in false negatives unless the tool that made the hash did it properly for us to start with.

This also includes modifications to shared enc_lc() and enc_uc() functions, getting rid of hardcoded length limits.

Closes #5651