### PR TITLE
SSH format: Fix bogus "warning: array subscript is above array bounds", optimize

### DIFF
--- a/src/ssh_common_plug.c
+++ b/src/ssh_common_plug.c
@@ -127,7 +127,7 @@ void *ssh_get_salt(char *ciphertext)
 	if (cs.cipher == 2 || cs.cipher == 6) {
 		p = strtokm(NULL, "$");
 		if (!p && cs.cipher == 6 && cs.sl == 8) {
-			cs.cipher = -1;
+			cs.cipher = 7;
 		} else {
 			cs.rounds = atoi(p);
 			p = strtokm(NULL, "$");
@@ -144,7 +144,7 @@ unsigned int ssh_iteration_count(void *salt)
 	struct custom_salt *cur_salt = salt;
 
 	switch (cur_salt->cipher) {
-	case -1:
+	case 7:
 		return 1; // generate 8 bytes of key + DES
 	case 0:
 		return 2; // generate 24 bytes of key + 3DES
@@ -166,7 +166,7 @@ unsigned int ssh_kdf(void *salt)
 
 	switch (cur_salt->cipher) {
 	case 0:
-	case -1:
+	case 7:
 		return 1; // MD5 KDF + 3DES or DES
 	case 2:
 	case 6:

--- a/src/ssh_fmt_plug.c
+++ b/src/ssh_fmt_plug.c
@@ -111,7 +111,7 @@ static void set_salt(void *salt)
 }
 
 /* NB: keybytes is rounded up to a multiple of 16, need extra space for key */
-static inline void generate_key(char *password, size_t password_len, unsigned char *key, int keybytes)
+static MAYBE_INLINE void generate_key(char *password, size_t password_len, unsigned char *key, int keybytes)
 {
 	unsigned char *p = key;
 
@@ -130,7 +130,7 @@ static inline void generate_key(char *password, size_t password_len, unsigned ch
 	} while (keybytes > 0);
 }
 
-static inline int check_structure_bcrypt(unsigned char *out)
+static MAYBE_INLINE int check_structure_bcrypt(unsigned char *out)
 {
 /*
  * OpenSSH PROTOCOL.key file says:
@@ -147,7 +147,7 @@ static inline int check_structure_bcrypt(unsigned char *out)
 	return out[8] || out[9] || memcmp(out, out + 4, 4);
 }
 
-static inline int check_structure_asn1(unsigned char *out, int length, int real_len)
+static int check_structure_asn1(unsigned char *out, int length, int real_len)
 {
 	struct asn1_hdr hdr;
 	const uint8_t *pos, *end;
@@ -237,9 +237,8 @@ static void handleErrors(void)
 }
 #endif
 
-static inline void AES_ctr_decrypt(unsigned char *ciphertext,
-                                   int ciphertext_len, unsigned char *key,
-                                   unsigned char *iv, unsigned char *plaintext)
+static MAYBE_INLINE void AES_ctr_decrypt(unsigned char *ciphertext, int ciphertext_len,
+    unsigned char *key, unsigned char *iv, unsigned char *plaintext)
 {
 #ifdef MBEDTLS_CIPHER_MODE_CTR
 	size_t nc_off = 0;
@@ -270,7 +269,7 @@ static inline void AES_ctr_decrypt(unsigned char *ciphertext,
 #endif
 }
 
-static int common_crypt_code(char *password, size_t password_len)
+static MAYBE_INLINE int common_crypt_code(char *password, size_t password_len)
 {
 	int real_len;
 	unsigned char out[SAFETY_FACTOR + 16];

--- a/src/ssh_fmt_plug.c
+++ b/src/ssh_fmt_plug.c
@@ -280,7 +280,7 @@ static int common_crypt_code(char *password, size_t password_len)
 #endif
 
 	switch (cur_salt->cipher) {
-	case -1: {
+	case 7: { /* RSA/DSA keys with DES */
 		union {
 			unsigned char uc[16];
 			struct {
@@ -300,7 +300,7 @@ static int common_crypt_code(char *password, size_t password_len)
 		DES_cbc_encrypt(cur_salt->ct, out, SAFETY_FACTOR, &ks, &u.iv, DES_DECRYPT);
 		return check_structure_asn1(out, sizeof(out), real_len);
 	}
-	case 0: {
+	case 0: { /* RSA/DSA keys with 3DES */
 		union {
 			unsigned char uc[32];
 			struct {


### PR DESCRIPTION
which was seen with RHEL6'ish gcc 4.4.7.

Amends 71bb5a74a718c8d9b20ceece373804152c39aca7
Fixes #5758