### PR TITLE
OpenCL AES (plain): Add some #ifdef to avoid warnings

### DIFF
--- a/run/opencl/opencl_aes_plain.h
+++ b/run/opencl/opencl_aes_plain.h
@@ -123,9 +123,9 @@ INLINE void AES_set_encrypt_key(AES_KEY_TYPE void *_userKey,
 	u32 *rk;
 	int i = 0;
 	u32 temp;
-	__local aes_local_t *lt = key->lt;
 
 #ifdef AES_LOCAL_TABLES
+	__local aes_local_t *lt = key->lt;
 	aes_table_init(lt);
 #endif
 
@@ -224,7 +224,9 @@ INLINE void AES_set_decrypt_key(AES_KEY_TYPE void *_userKey,
 	u32 *rk;
 	int i, j;
 	u32 temp;
+#ifdef AES_LOCAL_TABLES
 	__local aes_local_t *lt = key->lt;
+#endif
 
 	/* first, start with an encryption schedule */
 	AES_set_encrypt_key(userKey, bits, key);
@@ -271,7 +273,9 @@ INLINE void AES_encrypt(const uchar *in, uchar *out, const AES_KEY *key)
 {
 	const u32 *rk;
 	u32 s0, s1, s2, s3, t0, t1, t2, t3;
+#ifdef AES_LOCAL_TABLES
 	__local aes_local_t *lt = key->lt;
+#endif
 
 	rk = key->rd_key;
 
@@ -457,7 +461,9 @@ INLINE void AES_decrypt(const uchar *in, uchar *out, const AES_KEY *key)
 {
 	const u32 *rk;
 	u32 s0, s1, s2, s3, t0, t1, t2, t3;
+#ifdef AES_LOCAL_TABLES
 	__local aes_local_t *lt = key->lt;
+#endif
 
 //	assert(in && out && key);
 	rk = key->rd_key;


### PR DESCRIPTION
Old AMD CPU driver would complain about unused variable when not using local memory for tables.