### PR TITLE
OpenCL: Fallback to libnvidia-ml.so.1 for NVML

### DIFF
--- a/src/gpu_common.c
+++ b/src/gpu_common.c
@@ -126,7 +126,9 @@ void nvidia_probe(void)
 	if (nvml_lib)
 		return;
 
-	if (!(nvml_lib = dlopen("libnvidia-ml.so", RTLD_LAZY|RTLD_GLOBAL)))
+	if (!(nvml_lib = dlopen("libnvidia-ml.so.1", RTLD_LAZY|RTLD_GLOBAL)) &&
+	    !(nvml_lib = dlopen("libnvidia-ml.so", RTLD_LAZY|RTLD_GLOBAL)) &&
+	    !(nvml_lib = dlopen("nvml.dll", RTLD_LAZY|RTLD_GLOBAL)))
 		return;
 
 	nvmlInit = (NVMLINIT) dlsym(nvml_lib, "nvmlInit");
@@ -160,14 +162,10 @@ void amd_probe(void)
 	if (adl_lib)
 		return;
 
-#if HAVE_WINDOWS_H
-	if (!(adl_lib = dlopen("atiadlxx.dll", RTLD_LAZY|RTLD_GLOBAL)) &&
+	if (!(adl_lib = dlopen("libatiadlxx.so", RTLD_LAZY|RTLD_GLOBAL)) &&
+	    !(adl_lib = dlopen("atiadlxx.dll", RTLD_LAZY|RTLD_GLOBAL)) &&
 	    !(adl_lib = dlopen("atiadlxy.dll", RTLD_LAZY|RTLD_GLOBAL)))
 		return;
-#else
-	if (!(adl_lib = dlopen("libatiadlxx.so", RTLD_LAZY|RTLD_GLOBAL)))
-		return;
-#endif
 
 	env = getenv("COMPUTE");
 	if (env && *env)

--- a/src/opencl_dynamic_loader.c
+++ b/src/opencl_dynamic_loader.c
@@ -591,12 +591,12 @@ static void load_opencl_dll(void)
 
 	/* Names to try to load */
 	const char * const opencl_names[] = {
+		"libOpenCL.so.1",	/* Linux/others */
 		"libOpenCL.so",		/* Linux/others, hack via "development" sub-package's symlink */
 		"OpenCL",		/* _WIN */
 		"/System/Library/Frameworks/OpenCL.framework/OpenCL", /* __APPLE__ */
 		"opencl.dll",		/* __CYGWIN__ */
-		"cygOpenCL-1.dll",	/* __CYGWIN__ */
-		"libOpenCL.so.1"	/* Linux/others, no "development" sub-package installed */
+		"cygOpenCL-1.dll"	/* __CYGWIN__ */
 	};
 
 	for (i = 0; i < sizeof(opencl_names)/sizeof(opencl_names[0]); i++) {

--- a/src/opencl_generate_dynamic_loader.py
+++ b/src/opencl_generate_dynamic_loader.py
@@ -134,12 +134,12 @@ static void load_opencl_dll(void)
 
 	/* Names to try to load */
 	const char * const opencl_names[] = {
+		"libOpenCL.so.1",	/* Linux/others */
 		"libOpenCL.so",		/* Linux/others, hack via "development" sub-package's symlink */
 		"OpenCL",		/* _WIN */
 		"/System/Library/Frameworks/OpenCL.framework/OpenCL", /* __APPLE__ */
 		"opencl.dll",		/* __CYGWIN__ */
-		"cygOpenCL-1.dll",	/* __CYGWIN__ */
-		"libOpenCL.so.1"	/* Linux/others, no "development" sub-package installed */
+		"cygOpenCL-1.dll"	/* __CYGWIN__ */
 	};
 
 	for (i = 0; i < sizeof(opencl_names)/sizeof(opencl_names[0]); i++) {


### PR DESCRIPTION
We've been fine for a well over decade with just dlopening `libnvidia-ml.so` but recently it stopped working on my Ubuntu 24.04.  Turns out we need to fallback to `libnvidia-ml.so.1`.  Not sure if there's a better fix but this is how hashcat does it as well.