### PR TITLE
Stacked rules: Fix rule number in logs, in Single mode

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -1804,9 +1804,10 @@ out_ERROR_UNALLOWED:
 }
 
 /*
- * Advance stacked rules. We iterate main rules first and only then we
- * advance the stacked rules (and rewind the main rules). Repeat until
- * main rules are done with the last stacked rule.
+ * Advance stacked rules. We run all words through each main rule,
+ * rewinding the wordlist inbetween them. Each result from that is run
+ * through each stacked rule, rewinding the latter before advancing to
+ * next word (or next main rule).
  */
 int rules_advance_stack(rule_stack *ctx, int quiet)
 {

--- a/src/rules.c
+++ b/src/rules.c
@@ -1816,7 +1816,7 @@ int rules_advance_stack(rule_stack *ctx, int quiet)
 		rules_stacked_number++;
 		if (!quiet)
 			log_event("+ Stacked Rule #%u: '%.100s' accepted",
-			          rules_stacked_number, ctx->rule->data);
+			          rules_stacked_number + 1, ctx->rule->data);
 	}
 
 	return !ctx->done;


### PR DESCRIPTION
Closes #5729

Tested in all combos I could imagine: Single+stack, wordlist with rules+stack or only stack, prince with rules+stack or only stack. Then all of them again with stopped/resumed session. Is there anything more we should test?

I refrained from doing anything more (which would actually be #5722) to avoid untimely regression but I did put some debug stuff in there, trying to verify we don't have more crazy bugs such as the one fixed by 3e75e1bd. I saw nothing suspicious.