### PR TITLE
Several formats' prepare(): Fix bugs when checking fields

### DIFF
--- a/src/MSCHAPv2_bs_fmt_plug.c
+++ b/src/MSCHAPv2_bs_fmt_plug.c
@@ -281,13 +281,11 @@ static char *prepare(char *split_fields[10], struct fmt_main *pFmt)
 			}
 		}
 	}
-	else if (split_fields[0] && split_fields[3] && split_fields[4] && split_fields[5] &&
-	        strlen(split_fields[3]) == CHALLENGE_LENGTH/2 &&
+	else if (strlen(split_fields[3]) == CHALLENGE_LENGTH/2 &&
 	        strlen(split_fields[4]) == CIPHERTEXT_LENGTH &&
 	        strlen(split_fields[5]) == CHALLENGE_LENGTH/2)
 		ret = prepare_long(split_fields);
-	else if (split_fields[0] && split_fields[3] && split_fields[4] &&
-	        strlen(split_fields[3]) == CHALLENGE_LENGTH/4 &&
+	else if (strlen(split_fields[3]) == CHALLENGE_LENGTH/4 &&
 	        strlen(split_fields[4]) == CIPHERTEXT_LENGTH)
 		ret = prepare_short(split_fields);
 	else

--- a/src/NETLMv2_fmt_plug.c
+++ b/src/NETLMv2_fmt_plug.c
@@ -183,7 +183,9 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 
 	if (!strncmp(split_fields[1], FORMAT_TAG, FORMAT_TAG_LEN))
 		return split_fields[1];
-	if (!login || !uid || !srv_challenge || !nethashv2 || !cli_challenge)
+	if (!login[0] || !strcmp(login, "?"))
+		return split_fields[1];
+	if (!srv_challenge[0] || !nethashv2[0] || !cli_challenge[0])
 		return split_fields[1];
 
 	/* DOMAIN\USER: -or- USER::DOMAIN: */

--- a/src/NETNTLMv2_fmt_plug.c
+++ b/src/NETNTLMv2_fmt_plug.c
@@ -197,7 +197,9 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 
 	if (!strncmp(split_fields[1], FORMAT_TAG, FORMAT_TAG_LEN))
 		return split_fields[1];
-	if (!login || !uid || !srv_challenge || !nethashv2 || !cli_challenge)
+	if (!login[0] || !strcmp(login, "?"))
+		return split_fields[1];
+	if (!srv_challenge[0] || !nethashv2[0] || !cli_challenge[0])
 		return split_fields[1];
 
 	/* DOMAIN\USER: -or- USER::DOMAIN: */

--- a/src/asaMD5_fmt_plug.c
+++ b/src/asaMD5_fmt_plug.c
@@ -103,7 +103,7 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 		return split_fields[1];
 
 	if (!valid(split_fields[1], self)) {
-		if (split_fields[1] && strlen(split_fields[1]) == 16) {
+		if (strlen(split_fields[1]) == 16) {
 			char username[4+1] = "";
 
 			strncat(username, split_fields[0], 4);

--- a/src/dynamic_fmt.c
+++ b/src/dynamic_fmt.c
@@ -1138,7 +1138,7 @@ static char *prepare(char *split_fields[10], struct fmt_main *pFmt)
 
 	// at this point max length is still < 512.  491 + strlen($dynamic_xxxxx$) is 506
 	if (pPriv->nUserName && !strstr(cpBuilding, "$$U")) {
-		if (split_fields[0] && split_fields[0][0] && strcmp(split_fields[0], "?")) {
+		if (split_fields[0][0] && strcmp(split_fields[0], "?")) {
 			char *userName=split_fields[0], *cp;
 			static char ct[1024];
 			// assume field[0] is in format: username OR DOMAIN\\username  If we find a \\, then  use the username 'following' it.
@@ -1154,7 +1154,7 @@ static char *prepare(char *split_fields[10], struct fmt_main *pFmt)
 		for (i = 0; i < 10; ++i) {
 			if (pPriv->FldMask&(MGF_FLDx_BIT<<i)) {
 				sprintf(Tmp, "$$F%d", i);
-				if (split_fields[i] && split_fields[i][0] && strcmp(split_fields[i], "/") && !strstr(cpBuilding, Tmp)) {
+				if (split_fields[i][0] && strcmp(split_fields[i], "/") && !strstr(cpBuilding, Tmp)) {
 					static char ct[1024];
 					char ct2[1024];
 					snprintf(ct2, sizeof(ct2), "%s$$F%d%s", cpBuilding, i, split_fields[i]);

--- a/src/leet_cc_fmt_plug.c
+++ b/src/leet_cc_fmt_plug.c
@@ -157,7 +157,7 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 {
 	char* cp;
 
-	if (!split_fields[0])
+	if (!split_fields[0][0] || !strcmp(split_fields[0], "?"))
 		return split_fields[1];
 	if (strnlen(split_fields[1], BINARY_SIZE * 2 + 1) != BINARY_SIZE * 2)
 		return split_fields[1];

--- a/src/mscash_common_plug.c
+++ b/src/mscash_common_plug.c
@@ -143,7 +143,7 @@ char *mscash1_common_prepare(char *split_fields[10], struct fmt_main *self)
 	if (!strncmp(split_fields[1], FORMAT_TAG, FORMAT_TAG_LEN))
 		return split_fields[1];
 
-	if (!split_fields[0])
+	if (!split_fields[0][0] || !strcmp(split_fields[0], "?"))
 		return split_fields[1];
 
 	// ONLY check, if this string split_fields[1], is ONLY a 32 byte hex string.
@@ -391,7 +391,7 @@ char *mscash2_common_prepare(char *split_fields[10], struct fmt_main *self)
 		MEM_FREE(cp);
 		return split_fields[1];
 	}
-	if (!split_fields[0])
+	if (!split_fields[0][0] || !strcmp(split_fields[0], "?"))
 		return split_fields[1];
 
 	// ONLY check, if this string split_fields[1], is ONLY a 32 byte hex string.

--- a/src/oldoffice_common_plug.c
+++ b/src/oldoffice_common_plug.c
@@ -106,14 +106,12 @@ error:
 /* uid field may contain a meet-in-the-middle hash */
 char *oldoffice_prepare(char *split_fields[10], struct fmt_main *self)
 {
-	if (split_fields[0] && oldoffice_valid(split_fields[0], self) &&
-	    split_fields[1] &&
-	    hexlen(split_fields[1], 0) == 10) {
+	if (oldoffice_valid(split_fields[0], self) && hexlen(split_fields[1], 0) == 10) {
 		mitm_catcher.ct_hash = hex_hash(split_fields[0]);
 		memcpy(mitm_catcher.mitm, split_fields[1], 10);
 		return split_fields[0];
 	}
-	else if (oldoffice_valid(split_fields[1], self) && split_fields[2] &&
+	else if (oldoffice_valid(split_fields[1], self) &&
 	         hexlen(split_fields[2], 0) == 10) {
 		mitm_catcher.ct_hash = hex_hash(split_fields[1]);
 		memcpy(mitm_catcher.mitm, split_fields[2], 10);

--- a/src/opencl_ntlmv2_fmt_plug.c
+++ b/src/opencl_ntlmv2_fmt_plug.c
@@ -461,7 +461,9 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 
 	if (!strncmp(split_fields[1], FORMAT_TAG, FORMAT_TAG_LEN))
 		return split_fields[1];
-	if (!login || !uid || !srv_challenge || !nethashv2 || !cli_challenge)
+	if (!login[0] || !strcmp(login, "?"))
+		return split_fields[1];
+	if (!srv_challenge[0] || !nethashv2[0] || !cli_challenge[0])
 		return split_fields[1];
 
 	/* DOMAIN\USER: -or- USER::DOMAIN: */

--- a/src/oracle_fmt_plug.c
+++ b/src/oracle_fmt_plug.c
@@ -168,7 +168,7 @@ static char *prepare(char *split_fields[10], struct fmt_main *self)
 {
 	char *cp;
 
-	if (!split_fields[0])
+	if (!split_fields[0][0] || !strcmp(split_fields[0], "?"))
 		return split_fields[1];
 	if (!strncmp(split_fields[1], FORMAT_TAG, FORMAT_TAG_LEN))
 		return split_fields[1];

--- a/src/sl3_common_plug.c
+++ b/src/sl3_common_plug.c
@@ -28,7 +28,7 @@ char *sl3_prepare(char *split_fields[10], struct fmt_main *self)
 	if (strlen(split_fields[1]) != 2 * BINARY_SIZE)
 		return split_fields[1];
 
-	if (!split_fields[0])
+	if (!split_fields[0][0] || !strcmp(split_fields[0], "?"))
 		return split_fields[1];
 
 	len = strlen(split_fields[0]);

--- a/src/wow_srp_fmt_plug.c
+++ b/src/wow_srp_fmt_plug.c
@@ -256,6 +256,10 @@ static char *prepare(char *split_fields[10], struct fmt_main *pFmt) {
 		}
 		return split_fields[1];
 	}
+
+	if (!split_fields[0][0] || !strcmp(split_fields[0], "?"))
+		return split_fields[1];
+
 	if (strnlen(split_fields[1], 129) <= 128) {
 		strnzcpy(ct, split_fields[1], 128);
 		cp = &ct[strlen(ct)];


### PR DESCRIPTION
fields[n] is never NULL, and the string fields[0] points to is only a nullstring if there is an explicit field saying so (i.e. line starts with a ":")

For a missing login field (no ":", bare hash) fields[0] is set to "?" in loader.
    
This bug made some formats make up uncrackable hashes from thin air instead of rejecting when salt is unknown - leading to false negatives. Those formats are in a separate commit.

This was tested manually and with Test Suite.
