### PR TITLE
HMAC: Optimize opad XOR

### DIFF
--- a/src/rsvp_fmt_plug.c
+++ b/src/rsvp_fmt_plug.c
@@ -306,7 +306,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				if (len < 64)
 					MD5_Update(&ipad_mctx[index], ipad_constant_block, 64-len);
 				for (i = 0; i < len; ++i) {
-					pad[i] = p[i] ^ 0x5C;
+					pad[i] ^= 0x36 ^ 0x5C;
 				}
 				MD5_Init(&opad_mctx[index]);
 				MD5_Update(&opad_mctx[index], pad, len);
@@ -342,7 +342,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				if (len < 64)
 					SHA1_Update(&ipad_ctx[index], ipad_constant_block, 64-len);
 				for (i = 0; i < len; ++i) {
-					pad[i] = p[i] ^ 0x5C;
+					pad[i] ^= 0x36 ^ 0x5C;
 				}
 				SHA1_Init(&opad_ctx[index]);
 				SHA1_Update(&opad_ctx[index], pad, len);
@@ -380,7 +380,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				if (len < 64)
 					SHA224_Update(&ipad_ctx_224[index], ipad_constant_block, 64-len);
 				for (i = 0; i < len; ++i) {
-					pad[i] = p[i] ^ 0x5C;
+					pad[i] ^= 0x36 ^ 0x5C;
 				}
 				SHA224_Init(&opad_ctx_224[index]);
 				SHA224_Update(&opad_ctx_224[index], pad, len);
@@ -416,7 +416,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				if (len < 64)
 					SHA256_Update(&ipad_ctx_256[index], ipad_constant_block, 64-len);
 				for (i = 0; i < len; ++i) {
-					pad[i] = p[i] ^ 0x5C;
+					pad[i] ^= 0x36 ^ 0x5C;
 				}
 				SHA256_Init(&opad_ctx_256[index]);
 				SHA256_Update(&opad_ctx_256[index], pad, len);
@@ -452,7 +452,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				if (len < 128)
 					SHA384_Update(&ipad_ctx_384[index], ipad_constant_block, 128-len);
 				for (i = 0; i < len; ++i) {
-					pad[i] = p[i] ^ 0x5C;
+					pad[i] ^= 0x36 ^ 0x5C;
 				}
 				SHA384_Init(&opad_ctx_384[index]);
 				SHA384_Update(&opad_ctx_384[index], pad, len);
@@ -488,7 +488,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 				if (len < 128)
 					SHA512_Update(&ipad_ctx_512[index], ipad_constant_block, 128-len);
 				for (i = 0; i < len; ++i) {
-					pad[i] = p[i] ^ 0x5C;
+					pad[i] ^= 0x36 ^ 0x5C;
 				}
 				SHA512_Init(&opad_ctx_512[index]);
 				SHA512_Update(&opad_ctx_512[index], pad, len);

--- a/src/siemens-s7_fmt_plug.c
+++ b/src/siemens-s7_fmt_plug.c
@@ -205,7 +205,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 			SHA1_Update(&ipad_ctx[index], pad, 20);
 			SHA1_Update(&ipad_ctx[index], "\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36\x36", 44);
 			for (i = 0; i < 20; ++i) {
-				pad[i] = buf[i] ^ 0x5C;
+				pad[i] ^= 0x36 ^ 0x5C;
 			}
 			SHA1_Init(&opad_ctx[index]);
 			SHA1_Update(&opad_ctx[index], pad, 20);

--- a/src/wpapsk.h
+++ b/src/wpapsk.h
@@ -454,11 +454,9 @@ static void hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 	}
 	sha256_vector(1 + num_elem, _addr, _len, mac);
 
-	memset(k_pad, 0, sizeof(k_pad));
-	memcpy(k_pad, key, key_len);
 	/* XOR key with opad values */
 	for (i = 0; i < 64; i++)
-		k_pad[i] ^= 0x5c;
+		k_pad[i] ^= 0x36 ^ 0x5c;
 
 	/* perform outer SHA256 */
 	_addr[0] = k_pad;


### PR DESCRIPTION
There are several possible ways to construct HMAC's ipad and opad:
1. Initialize them (or one buffer to be reused as both) to key with NUL padding, then XOR the constants over that.
2. Initialize them to the constants, then XOR the key over the initial portions (until key length).
3. Compute the initial portions right away, then pass the rest of the constant data into separate *_Update() calls.
4. Combinations of the above and other variations (e.g., partial memset(), doing it out of a loop, etc.)

This commit optimizes existing implementations of 1 and 3 by XOR'ing the one reused pad buffer with XOR of the two constants instead of re-reading the key and XOR'ing that with the second constant.  Some implementations already had this optimization, and so are not touched by this commit.

Explicit usage of larger-than-byte XORs may be even more important, but isn't implemented with this minimal-change commit (would be non-trivial with arbitrary sizes and alignment of keys).  Some implementations already have this optimization.

This commit does not touch existing implementations of 2 and 4.  Those may (or may not) actually be as good as or even more optimal than optimized 1, such as due to efficiency of memset() and typically low key lengths.

This commit reduces john .text size by ~400 bytes in a Linux/x86_64 build.