### PR TITLE
OpenCL kernels: Use our INLINE macro consistently

### DIFF
--- a/run/opencl/DES_bs_hash_checking_kernel.cl
+++ b/run/opencl/DES_bs_hash_checking_kernel.cl
@@ -19,7 +19,7 @@
 #define OFFSET_TABLE_SIZE hash_chk_params.offset_table_size
 #define HASH_TABLE_SIZE hash_chk_params.hash_table_size
 
-inline void cmp_final(unsigned DES_bs_vector *B,
+INLINE void cmp_final(unsigned DES_bs_vector *B,
 		      unsigned DES_bs_vector *binary,
 		      __global unsigned int *offset_table,
 		      __global unsigned int *hash_table,

--- a/run/opencl/androidbackup_kernel.cl
+++ b/run/opencl/androidbackup_kernel.cl
@@ -21,7 +21,7 @@ typedef struct {
 	uchar masterkey_blob[MAX_MASTERKEYBLOB_LEN];
 } ab_salt;
 
-inline int ab_decrypt(__global uchar *key, MAYBE_CONSTANT ab_salt *salt, __local aes_local_t *lt)
+INLINE int ab_decrypt(__global uchar *key, MAYBE_CONSTANT ab_salt *salt, __local aes_local_t *lt)
 {
 	uchar out[MAX_MASTERKEYBLOB_LEN];
 	const int length = salt->masterkey_blob_length;

--- a/run/opencl/blockchain_kernel.cl
+++ b/run/opencl/blockchain_kernel.cl
@@ -33,7 +33,7 @@ typedef struct {
 	int length;
 } blockchain_salt;
 
-inline int blockchain_decrypt(__global uchar *derived_key,
+INLINE int blockchain_decrypt(__global uchar *derived_key,
                               __constant uchar *data, __local aes_local_t *lt)
 {
 	AES_KEY akey; akey.lt = lt;

--- a/run/opencl/cryptsha256_kernel_DEFAULT.cl
+++ b/run/opencl/cryptsha256_kernel_DEFAULT.cl
@@ -18,7 +18,7 @@
     #define FAST
 #endif
 
-inline void init_ctx(sha256_ctx * ctx) {
+INLINE void init_ctx(sha256_ctx * ctx) {
     ctx->H[0] = H0;
     ctx->H[1] = H1;
     ctx->H[2] = H2;
@@ -31,7 +31,7 @@ inline void init_ctx(sha256_ctx * ctx) {
     ctx->buflen = 0;
 }
 
-inline void memcpy_R(      uint8_t * dest,
+INLINE void memcpy_R(      uint8_t * dest,
                      const uint8_t * src,
                      const uint32_t srclen) {
     uint32_t i = 0;
@@ -45,7 +45,7 @@ inline void memcpy_R(      uint8_t * dest,
     }
 }
 
-inline void memcpy_C(                 uint8_t * dest,
+INLINE void memcpy_C(                 uint8_t * dest,
                      __constant const uint8_t * src,
                      const uint32_t srclen) {
     uint32_t i = 0;
@@ -59,7 +59,7 @@ inline void memcpy_C(                 uint8_t * dest,
     }
 }
 
-inline void memcpy_G(               uint8_t * dest,
+INLINE void memcpy_G(               uint8_t * dest,
                      __global const uint8_t * src,
                      const uint32_t srclen) {
     uint32_t i = 0;
@@ -73,7 +73,7 @@ inline void memcpy_G(               uint8_t * dest,
     }
 }
 
-inline void sha256_block(sha256_ctx * ctx) {
+INLINE void sha256_block(sha256_ctx * ctx) {
     uint32_t a = ctx->H[0];
     uint32_t b = ctx->H[1];
     uint32_t c = ctx->H[2];
@@ -136,7 +136,7 @@ inline void sha256_block(sha256_ctx * ctx) {
     ctx->H[7] += h;
 }
 
-inline void insert_to_buffer_R(sha256_ctx    * ctx,
+INLINE void insert_to_buffer_R(sha256_ctx    * ctx,
                         const uint8_t * string,
                         const uint32_t len) {
 
@@ -149,7 +149,7 @@ inline void insert_to_buffer_R(sha256_ctx    * ctx,
     ctx->buflen += len;
 }
 
-inline void insert_to_buffer_C(           sha256_ctx    * ctx,
+INLINE void insert_to_buffer_C(           sha256_ctx    * ctx,
                         __constant const uint8_t * string,
                                  const uint32_t len) {
 #ifdef FAST
@@ -161,7 +161,7 @@ inline void insert_to_buffer_C(           sha256_ctx    * ctx,
     ctx->buflen += len;
 }
 
-inline void insert_to_buffer_G(         sha256_ctx    * ctx,
+INLINE void insert_to_buffer_G(         sha256_ctx    * ctx,
                         __global const uint8_t * string,
                                  const uint32_t len) {
 #ifdef FAST
@@ -173,7 +173,7 @@ inline void insert_to_buffer_G(         sha256_ctx    * ctx,
     ctx->buflen += len;
 }
 
-inline void ctx_update_R(sha256_ctx * ctx,
+INLINE void ctx_update_R(sha256_ctx * ctx,
                   uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -189,7 +189,7 @@ inline void ctx_update_R(sha256_ctx * ctx,
     }
 }
 
-inline void ctx_update_C(           sha256_ctx * ctx,
+INLINE void ctx_update_C(           sha256_ctx * ctx,
                   __constant uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -205,7 +205,7 @@ inline void ctx_update_C(           sha256_ctx * ctx,
     }
 }
 
-inline void ctx_update_G(         sha256_ctx * ctx,
+INLINE void ctx_update_G(         sha256_ctx * ctx,
                   __global uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -221,7 +221,7 @@ inline void ctx_update_G(         sha256_ctx * ctx,
     }
 }
 
-inline void ctx_append_1(sha256_ctx * ctx) {
+INLINE void ctx_append_1(sha256_ctx * ctx) {
 
     uint32_t length = ctx->buflen;
     PUT(BUFFER, length, 0x80);
@@ -237,19 +237,19 @@ inline void ctx_append_1(sha256_ctx * ctx) {
     }
 }
 
-inline void ctx_add_length(sha256_ctx * ctx) {
+INLINE void ctx_add_length(sha256_ctx * ctx) {
 
     ctx->buffer[15].mem_32[0] = SWAP32(ctx->total * 8);
 }
 
-inline void finish_ctx(sha256_ctx * ctx) {
+INLINE void finish_ctx(sha256_ctx * ctx) {
 
     ctx_append_1(ctx);
     ctx_add_length(ctx);
     ctx->buflen = 0;
 }
 
-inline void clear_ctx_buffer(sha256_ctx * ctx) {
+INLINE void clear_ctx_buffer(sha256_ctx * ctx) {
 
     uint64_t * l = (uint64_t *) ctx->buffer;
 
@@ -262,7 +262,7 @@ inline void clear_ctx_buffer(sha256_ctx * ctx) {
     ctx->buflen = 0;
 }
 
-inline void sha256_digest_move(sha256_ctx * ctx,
+INLINE void sha256_digest_move(sha256_ctx * ctx,
                                uint32_t   * result,
                                const int size) {
 
@@ -273,7 +273,7 @@ inline void sha256_digest_move(sha256_ctx * ctx,
         result[i] = SWAP32(ctx->H[i]);
 }
 
-inline void sha256_digest(sha256_ctx * ctx) {
+INLINE void sha256_digest(sha256_ctx * ctx) {
 
     if (ctx->buflen <= 55) { //data+0x80+datasize fits in one 512bit block
         finish_ctx(ctx);
@@ -295,7 +295,7 @@ inline void sha256_digest(sha256_ctx * ctx) {
     sha256_block(ctx);
 }
 
-inline void sha256_prepare(__constant sha256_salt     * salt_data,
+INLINE void sha256_prepare(__constant sha256_salt     * salt_data,
                            __global   sha256_password * keys_data,
                                       sha256_buffers  * fast_buffers,
                                       sha256_ctx      * ctx) {
@@ -353,7 +353,7 @@ inline void sha256_prepare(__constant sha256_salt     * salt_data,
 #undef saltlen
 #undef passlen
 
-inline void sha256_crypt(sha256_buffers  * fast_buffers,
+INLINE void sha256_crypt(sha256_buffers  * fast_buffers,
                   sha256_ctx      * ctx,
                   const uint32_t saltlen, const uint32_t passlen,
                   const uint32_t rounds) {

--- a/run/opencl/cryptsha256_kernel_GPU.cl
+++ b/run/opencl/cryptsha256_kernel_GPU.cl
@@ -47,7 +47,7 @@
 #endif
 
 /************************** helper **************************/
-inline void init_H(sha256_ctx * ctx) {
+INLINE void init_H(sha256_ctx * ctx) {
     ctx->H[0] = H0;
     ctx->H[1] = H1;
     ctx->H[2] = H2;
@@ -58,7 +58,7 @@ inline void init_H(sha256_ctx * ctx) {
     ctx->H[7] = H7;
 }
 
-inline void init_ctx(sha256_ctx * ctx) {
+INLINE void init_ctx(sha256_ctx * ctx) {
     ctx->H[0] = H0;
     ctx->H[1] = H1;
     ctx->H[2] = H2;
@@ -89,7 +89,7 @@ inline void init_ctx(sha256_ctx * ctx) {
     ctx->buflen = 0;
 }
 
-inline void clear_ctx_buffer(sha256_ctx * ctx) {
+INLINE void clear_ctx_buffer(sha256_ctx * ctx) {
 
     ctx->buffer[0].mem_32[0] = 0;
     ctx->buffer[1].mem_32[0] = 0;
@@ -112,7 +112,7 @@ inline void clear_ctx_buffer(sha256_ctx * ctx) {
 }
 
 /************************** prepare **************************/
-inline void clear_buffer(uint32_t     * destination,
+INLINE void clear_buffer(uint32_t     * destination,
                          const uint32_t len,
                          const uint32_t limit) {
 
@@ -126,7 +126,7 @@ inline void clear_buffer(uint32_t     * destination,
     }
 }
 
-inline void sha256_block(sha256_ctx * ctx) {
+INLINE void sha256_block(sha256_ctx * ctx) {
     uint32_t a = ctx->H[0];
     uint32_t b = ctx->H[1];
     uint32_t c = ctx->H[2];
@@ -190,7 +190,7 @@ inline void sha256_block(sha256_ctx * ctx) {
     ctx->H[7] += h;
 }
 
-inline void insert_to_buffer_R(sha256_ctx    * ctx,
+INLINE void insert_to_buffer_R(sha256_ctx    * ctx,
                                const uint8_t * string,
                                const uint32_t len) {
 
@@ -208,7 +208,7 @@ inline void insert_to_buffer_R(sha256_ctx    * ctx,
     clear_buffer(ctx->buffer->mem_32, ctx->buflen, 16);
 }
 
-inline void insert_to_buffer_G(         sha256_ctx    * ctx,
+INLINE void insert_to_buffer_G(         sha256_ctx    * ctx,
                                __global const uint8_t * string,
                                const uint32_t len) {
 
@@ -229,7 +229,7 @@ inline void insert_to_buffer_G(         sha256_ctx    * ctx,
     }
 }
 
-inline void insert_to_buffer_C(           sha256_ctx    * ctx,
+INLINE void insert_to_buffer_C(           sha256_ctx    * ctx,
                                MAYBE_CONSTANT uint8_t * string,
                                const uint32_t len) {
 
@@ -250,7 +250,7 @@ inline void insert_to_buffer_C(           sha256_ctx    * ctx,
     }
 }
 
-inline void ctx_update_R(sha256_ctx * ctx,
+INLINE void ctx_update_R(sha256_ctx * ctx,
                          uint8_t    * string,
                          const uint32_t len) {
 
@@ -272,7 +272,7 @@ inline void ctx_update_R(sha256_ctx * ctx,
     }
 }
 
-inline void ctx_update_G(         sha256_ctx * ctx,
+INLINE void ctx_update_G(         sha256_ctx * ctx,
                          __global const uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -293,7 +293,7 @@ inline void ctx_update_G(         sha256_ctx * ctx,
     }
 }
 
-inline void ctx_update_C(           sha256_ctx * ctx,
+INLINE void ctx_update_C(           sha256_ctx * ctx,
                          MAYBE_CONSTANT uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -314,7 +314,7 @@ inline void ctx_update_C(           sha256_ctx * ctx,
     }
 }
 
-inline void sha256_digest(sha256_ctx * ctx,
+INLINE void sha256_digest(sha256_ctx * ctx,
                           uint32_t   * result,
                           const uint32_t size) {
 
@@ -343,7 +343,7 @@ inline void sha256_digest(sha256_ctx * ctx,
         result[i] = SWAP32(ctx->H[i]);
 }
 
-inline void sha256_prepare(
+INLINE void sha256_prepare(
 	MAYBE_CONSTANT sha256_salt     * const __restrict salt_data,
         __global   const sha256_password * const __restrict keys_data,
 	                 sha256_buffers  * fast_buffers) {
@@ -534,7 +534,7 @@ void kernel_preprocess(
 }
 
 /************************** hashing **************************/
-inline void sha256_block_be(uint32_t * buffer, uint32_t * H) {
+INLINE void sha256_block_be(uint32_t * buffer, uint32_t * H) {
     uint32_t t;
     uint32_t a = H[0];
     uint32_t b = H[1];
@@ -608,7 +608,7 @@ inline void sha256_block_be(uint32_t * buffer, uint32_t * H) {
     H[7] += h;
 }
 
-inline void update_w_G(
+INLINE void update_w_G(
 	         uint32_t * const w,
 	         uint32_t * const H,
         __global uint32_t * const work_memory, const uint32_t loop_index,
@@ -653,7 +653,7 @@ inline void update_w_G(
     }
 }
 
-inline void update_w(
+INLINE void update_w(
 	uint32_t * const w,
 	uint32_t * const H,
         uint32_t * const string,
@@ -700,7 +700,7 @@ inline void update_w(
     }
 }
 
-inline void sha256_crypt(
+INLINE void sha256_crypt(
 	 __global buffer_32      * const __restrict alt_result,
 	 __global uint32_t       * const __restrict work_memory) {
 
@@ -845,7 +845,7 @@ inline void sha256_crypt(
         alt_result[i].mem_32[0] = H[i];
 }
 
-inline void sha256_crypt_f(
+INLINE void sha256_crypt_f(
 	const uint32_t rounds,
 	__global buffer_32      * const __restrict alt_result,
 	__global uint32_t       * const __restrict work_memory) {

--- a/run/opencl/cryptsha512_kernel_DEFAULT.cl
+++ b/run/opencl/cryptsha512_kernel_DEFAULT.cl
@@ -18,7 +18,7 @@
     #define FAST
 #endif
 
-inline void init_ctx(sha512_ctx * ctx) {
+INLINE void init_ctx(sha512_ctx * ctx) {
     ctx->H[0] = H0;
     ctx->H[1] = H1;
     ctx->H[2] = H2;
@@ -40,7 +40,7 @@ inline void init_ctx(sha512_ctx * ctx) {
 
 #else /* These violate strict aliasing rules */
 
-inline void memcpy_R(      uint8_t * dest,
+INLINE void memcpy_R(      uint8_t * dest,
                      const uint8_t * src,
                      const uint32_t srclen) {
     uint32_t i = 0;
@@ -54,7 +54,7 @@ inline void memcpy_R(      uint8_t * dest,
     }
 }
 
-inline void memcpy_C(                 uint8_t * dest,
+INLINE void memcpy_C(                 uint8_t * dest,
                      __constant const uint8_t * src,
                      const uint32_t srclen) {
     uint32_t i = 0;
@@ -68,7 +68,7 @@ inline void memcpy_C(                 uint8_t * dest,
     }
 }
 
-inline void memcpy_G(               uint8_t * dest,
+INLINE void memcpy_G(               uint8_t * dest,
                      __global const uint8_t * src,
                      const uint32_t srclen) {
     uint32_t i = 0;
@@ -84,7 +84,7 @@ inline void memcpy_G(               uint8_t * dest,
 
 #endif /* __OS_X__ */
 
-inline void sha512_block(sha512_ctx * ctx) {
+INLINE void sha512_block(sha512_ctx * ctx) {
     uint64_t a = ctx->H[0];
     uint64_t b = ctx->H[1];
     uint64_t c = ctx->H[2];
@@ -116,7 +116,7 @@ inline void sha512_block(sha512_ctx * ctx) {
     ctx->H[7] += h;
 }
 
-inline void insert_to_buffer_R(sha512_ctx    * ctx,
+INLINE void insert_to_buffer_R(sha512_ctx    * ctx,
                         const uint8_t * string,
                         const uint32_t len) {
 
@@ -129,7 +129,7 @@ inline void insert_to_buffer_R(sha512_ctx    * ctx,
     ctx->buflen += len;
 }
 
-inline void insert_to_buffer_C(           sha512_ctx    * ctx,
+INLINE void insert_to_buffer_C(           sha512_ctx    * ctx,
                         __constant const uint8_t * string,
                                  const uint32_t len) {
 #ifdef FAST
@@ -141,7 +141,7 @@ inline void insert_to_buffer_C(           sha512_ctx    * ctx,
     ctx->buflen += len;
 }
 
-inline void insert_to_buffer_G(         sha512_ctx    * ctx,
+INLINE void insert_to_buffer_G(         sha512_ctx    * ctx,
                         __global const uint8_t * string,
                                  const uint32_t len) {
 #ifdef FAST
@@ -153,7 +153,7 @@ inline void insert_to_buffer_G(         sha512_ctx    * ctx,
     ctx->buflen += len;
 }
 
-inline void ctx_update_R(sha512_ctx * ctx,
+INLINE void ctx_update_R(sha512_ctx * ctx,
                   uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -169,7 +169,7 @@ inline void ctx_update_R(sha512_ctx * ctx,
     }
 }
 
-inline void ctx_update_C(           sha512_ctx * ctx,
+INLINE void ctx_update_C(           sha512_ctx * ctx,
                   __constant uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -185,7 +185,7 @@ inline void ctx_update_C(           sha512_ctx * ctx,
     }
 }
 
-inline void ctx_update_G(         sha512_ctx * ctx,
+INLINE void ctx_update_G(         sha512_ctx * ctx,
                   __global uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -201,7 +201,7 @@ inline void ctx_update_G(         sha512_ctx * ctx,
     }
 }
 
-inline void ctx_append_1(sha512_ctx * ctx) {
+INLINE void ctx_append_1(sha512_ctx * ctx) {
 
     uint32_t length = ctx->buflen;
     PUT(BUFFER, length, 0x80);
@@ -217,19 +217,19 @@ inline void ctx_append_1(sha512_ctx * ctx) {
     }
 }
 
-inline void ctx_add_length(sha512_ctx * ctx) {
+INLINE void ctx_add_length(sha512_ctx * ctx) {
 
     ctx->buffer[15].mem_64[0] = SWAP64((uint64_t) (ctx->total * 8));
 }
 
-inline void finish_ctx(sha512_ctx * ctx) {
+INLINE void finish_ctx(sha512_ctx * ctx) {
 
     ctx_append_1(ctx);
     ctx_add_length(ctx);
     ctx->buflen = 0;
 }
 
-inline void clear_ctx_buffer(sha512_ctx * ctx) {
+INLINE void clear_ctx_buffer(sha512_ctx * ctx) {
 
 #ifdef UNROLL
     #pragma unroll
@@ -240,7 +240,7 @@ inline void clear_ctx_buffer(sha512_ctx * ctx) {
     ctx->buflen = 0;
 }
 
-inline void sha512_digest_move(sha512_ctx * ctx,
+INLINE void sha512_digest_move(sha512_ctx * ctx,
                                uint64_t   * result,
                                const int size) {
 
@@ -251,7 +251,7 @@ inline void sha512_digest_move(sha512_ctx * ctx,
         result[i] = SWAP64(ctx->H[i]);
 }
 
-inline void sha512_digest(sha512_ctx * ctx) {
+INLINE void sha512_digest(sha512_ctx * ctx) {
 
     if (ctx->buflen <= 111) { //data+0x80+datasize fits in one 1024bit block
         finish_ctx(ctx);
@@ -273,7 +273,7 @@ inline void sha512_digest(sha512_ctx * ctx) {
     sha512_block(ctx);
 }
 
-inline void sha512_prepare(__constant sha512_salt     * salt_data,
+INLINE void sha512_prepare(__constant sha512_salt     * salt_data,
                     __global   sha512_password * keys_data,
                                sha512_buffers  * fast_buffers,
                                sha512_ctx      * ctx) {
@@ -331,7 +331,7 @@ inline void sha512_prepare(__constant sha512_salt     * salt_data,
 #undef saltlen
 #undef passlen
 
-inline void sha512_crypt(sha512_buffers  * fast_buffers,
+INLINE void sha512_crypt(sha512_buffers  * fast_buffers,
                   sha512_ctx      * ctx,
                   const uint32_t saltlen, const uint32_t passlen,
                   const uint32_t rounds) {

--- a/run/opencl/cryptsha512_kernel_GPU.cl
+++ b/run/opencl/cryptsha512_kernel_GPU.cl
@@ -71,7 +71,7 @@
 #endif
 
 /************************** helper **************************/
-inline void init_H(sha512_ctx * ctx) {
+INLINE void init_H(sha512_ctx * ctx) {
     ctx->H[0] = H0;
     ctx->H[1] = H1;
     ctx->H[2] = H2;
@@ -82,7 +82,7 @@ inline void init_H(sha512_ctx * ctx) {
     ctx->H[7] = H7;
 }
 
-inline void init_ctx(sha512_ctx * ctx) {
+INLINE void init_ctx(sha512_ctx * ctx) {
     ctx->H[0] = H0;
     ctx->H[1] = H1;
     ctx->H[2] = H2;
@@ -113,7 +113,7 @@ inline void init_ctx(sha512_ctx * ctx) {
     ctx->buflen = 0;
 }
 
-inline void clear_ctx_buffer(sha512_ctx * ctx) {
+INLINE void clear_ctx_buffer(sha512_ctx * ctx) {
 
     ctx->buffer[0].mem_64[0] = 0;
     ctx->buffer[1].mem_64[0] = 0;
@@ -136,7 +136,7 @@ inline void clear_ctx_buffer(sha512_ctx * ctx) {
 }
 
 /************************** prepare **************************/
-inline void clear_buffer(uint64_t     * destination,
+INLINE void clear_buffer(uint64_t     * destination,
                          const uint32_t len,
                          const uint32_t limit) {
 
@@ -150,7 +150,7 @@ inline void clear_buffer(uint64_t     * destination,
     }
 }
 
-inline void sha512_block(sha512_ctx * ctx) {
+INLINE void sha512_block(sha512_ctx * ctx) {
     uint64_t a = ctx->H[0];
     uint64_t b = ctx->H[1];
     uint64_t c = ctx->H[2];
@@ -218,7 +218,7 @@ inline void sha512_block(sha512_ctx * ctx) {
     ctx->H[7] += h;
 }
 
-inline void insert_to_buffer_R(sha512_ctx    * ctx,
+INLINE void insert_to_buffer_R(sha512_ctx    * ctx,
                                const uint8_t * string,
                                const uint32_t len) {
 
@@ -236,7 +236,7 @@ inline void insert_to_buffer_R(sha512_ctx    * ctx,
     clear_buffer(ctx->buffer->mem_64, ctx->buflen, 16);
 }
 
-inline void insert_to_buffer_G(         sha512_ctx    * ctx,
+INLINE void insert_to_buffer_G(         sha512_ctx    * ctx,
                                __global const uint8_t * string,
                                const uint32_t len) {
 
@@ -257,7 +257,7 @@ inline void insert_to_buffer_G(         sha512_ctx    * ctx,
     }
 }
 
-inline void insert_to_buffer_C(           sha512_ctx    * ctx,
+INLINE void insert_to_buffer_C(           sha512_ctx    * ctx,
                                MAYBE_CONSTANT uint8_t * string,
                                const uint32_t len) {
 
@@ -278,7 +278,7 @@ inline void insert_to_buffer_C(           sha512_ctx    * ctx,
     }
 }
 
-inline void ctx_update_R(sha512_ctx * ctx,
+INLINE void ctx_update_R(sha512_ctx * ctx,
                          uint8_t    * string,
                          const uint32_t len) {
 
@@ -300,7 +300,7 @@ inline void ctx_update_R(sha512_ctx * ctx,
     }
 }
 
-inline void ctx_update_G(         sha512_ctx * ctx,
+INLINE void ctx_update_G(         sha512_ctx * ctx,
                          __global const uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -321,7 +321,7 @@ inline void ctx_update_G(         sha512_ctx * ctx,
     }
 }
 
-inline void ctx_update_C(           sha512_ctx * ctx,
+INLINE void ctx_update_C(           sha512_ctx * ctx,
                          MAYBE_CONSTANT uint8_t    * string, uint32_t len) {
 
     ctx->total += len;
@@ -342,7 +342,7 @@ inline void ctx_update_C(           sha512_ctx * ctx,
     }
 }
 
-inline void sha512_digest(sha512_ctx * ctx,
+INLINE void sha512_digest(sha512_ctx * ctx,
                           uint64_t   * result,
                           const uint32_t size) {
 
@@ -371,7 +371,7 @@ inline void sha512_digest(sha512_ctx * ctx,
         result[i] = SWAP64(ctx->H[i]);
 }
 
-inline void sha512_prepare(
+INLINE void sha512_prepare(
 	MAYBE_CONSTANT sha512_salt     * const __restrict salt_data,
         __global   const sha512_password * const __restrict keys_data,
 	                 sha512_buffers  * fast_buffers) {
@@ -542,7 +542,7 @@ void kernel_preprocess(
 }
 
 /************************** hashing **************************/
-inline void sha512_block_be(uint64_t * buffer, uint64_t * H) {
+INLINE void sha512_block_be(uint64_t * buffer, uint64_t * H) {
     uint64_t t;
     uint64_t a = H[0];
     uint64_t b = H[1];
@@ -616,7 +616,7 @@ inline void sha512_block_be(uint64_t * buffer, uint64_t * H) {
     H[7] += h;
 }
 
-inline void sha512_crypt_full(
+INLINE void sha512_crypt_full(
 	 __global buffer_64      * const __restrict alt_result,
 	 __global uint64_t       * const __restrict work_memory) {
 
@@ -725,7 +725,7 @@ inline void sha512_crypt_full(
         alt_result[i].mem_64[0] = H[i];
 }
 
-inline void sha512_crypt_fast(
+INLINE void sha512_crypt_fast(
 	 __global buffer_64      * const __restrict alt_result,
 	 __global uint64_t       * const __restrict work_memory) {
 
@@ -824,7 +824,7 @@ inline void sha512_crypt_fast(
         alt_result[i].mem_64[0] = H[i];
 }
 
-inline void sha512_crypt_f(
+INLINE void sha512_crypt_f(
 	const uint32_t rounds,
 	__global buffer_64      * const __restrict alt_result,
 	__global uint64_t       * const __restrict work_memory) {

--- a/run/opencl/dmg_kernel.cl
+++ b/run/opencl/dmg_kernel.cl
@@ -36,7 +36,7 @@ typedef struct {
 	uchar zchunk[4096]; /* chunk #0 */
 } dmg_salt;
 
-inline int apple_des3_ede_unwrap_key1(MAYBE_CONSTANT uchar *wrapped_key,
+INLINE int apple_des3_ede_unwrap_key1(MAYBE_CONSTANT uchar *wrapped_key,
                                       const int wrapped_key_len,
                                       const uchar *decryptKey)
 {
@@ -64,7 +64,7 @@ inline int apple_des3_ede_unwrap_key1(MAYBE_CONSTANT uchar *wrapped_key,
 }
 
 /* Check for 64-bit NULL at 32-bit alignment */
-inline int check_nulls(const void *buf, uint size)
+INLINE int check_nulls(const void *buf, uint size)
 {
 	const uint *p = buf;
 
@@ -76,7 +76,7 @@ inline int check_nulls(const void *buf, uint size)
 	return 0;
 }
 
-inline int check_v1hash(const uchar *derived_key,
+INLINE int check_v1hash(const uchar *derived_key,
                         MAYBE_CONSTANT dmg_salt *salt)
 {
 	if (!apple_des3_ede_unwrap_key1(salt->wrapped_aes_key,
@@ -90,7 +90,7 @@ inline int check_v1hash(const uchar *derived_key,
 	return 1;
 }
 
-inline int check_v2hash(const uchar *derived_key,
+INLINE int check_v2hash(const uchar *derived_key,
                         MAYBE_CONSTANT dmg_salt *salt, __local aes_local_t *lt)
 {
 	des3_context ks;

--- a/run/opencl/ed25519-donna/ed25519-donna-portable.h
+++ b/run/opencl/ed25519-donna/ed25519-donna-portable.h
@@ -4,7 +4,7 @@
 #define ALIGN(x) __attribute__((aligned(x)))
 
 /* endian */
-inline uint32_t U8TO32_LE(const unsigned char *p) {
+INLINE uint32_t U8TO32_LE(const unsigned char *p) {
 	return
 	(((uint32_t)(p[0])      ) |
 	 ((uint32_t)(p[1]) <<  8) |

--- a/run/opencl/encfs_kernel.cl
+++ b/run/opencl/encfs_kernel.cl
@@ -31,7 +31,7 @@ typedef struct {
 			buf[i] ^= buf[i - 1]; \
 	} while(0)
 
-inline void encfs_common_setIVec(MAYBE_CONSTANT encfs_salt *salt,
+INLINE void encfs_common_setIVec(MAYBE_CONSTANT encfs_salt *salt,
                                  uchar *ivec, uint64_t seed, uchar *key)
 {
 	uchar iv_and_seed[MAX_IVLENGTH+8];
@@ -48,7 +48,7 @@ inline void encfs_common_setIVec(MAYBE_CONSTANT encfs_salt *salt,
 	          ivec, salt->ivLength);
 }
 
-inline void flipBytes(uchar *buf, uint size)
+INLINE void flipBytes(uchar *buf, uint size)
 {
 	uchar revBuf[64];
 	uint bytesLeft = size;
@@ -65,7 +65,7 @@ inline void flipBytes(uchar *buf, uint size)
 	}
 }
 
-inline uint64_t _checksum_64(MAYBE_CONSTANT encfs_salt *salt, uchar *key,
+INLINE uint64_t _checksum_64(MAYBE_CONSTANT encfs_salt *salt, uchar *key,
                              const uchar *data, uint dataLen,
                              uint64_t *chainedIV)
 {
@@ -106,7 +106,7 @@ inline uint64_t _checksum_64(MAYBE_CONSTANT encfs_salt *salt, uchar *key,
 	return value;
 }
 
-inline uint64_t MAC_64(MAYBE_CONSTANT encfs_salt *salt,
+INLINE uint64_t MAC_64(MAYBE_CONSTANT encfs_salt *salt,
                        const uchar *data,
                        uint len, uchar *key, uint64_t *chainedIV )
 {
@@ -118,7 +118,7 @@ inline uint64_t MAC_64(MAYBE_CONSTANT encfs_salt *salt,
 	return tmp;
 }
 
-inline uint encfs_common_MAC_32(MAYBE_CONSTANT encfs_salt *salt, uchar *src,
+INLINE uint encfs_common_MAC_32(MAYBE_CONSTANT encfs_salt *salt, uchar *src,
                                 uint len, uchar *key)
 {
 	uint64_t *chainedIV = NULL;
@@ -128,7 +128,7 @@ inline uint encfs_common_MAC_32(MAYBE_CONSTANT encfs_salt *salt, uchar *src,
 	return mac32;
 }
 
-inline void encfs_common_streamDecode(MAYBE_CONSTANT encfs_salt *salt,
+INLINE void encfs_common_streamDecode(MAYBE_CONSTANT encfs_salt *salt,
                                       uchar *buf, uint size, uint64_t iv64,
                                       uchar *key, __local aes_local_t *lt)
 {

--- a/run/opencl/enpass_kernel.cl
+++ b/run/opencl/enpass_kernel.cl
@@ -29,7 +29,7 @@ typedef struct {
 	unsigned char data[16];
 } enpass_salt;
 
-inline uint verify_page(uchar *data)
+INLINE uint verify_page(uchar *data)
 {
 	uint32_t pageSize;
 	uint32_t usableSize;
@@ -104,7 +104,7 @@ void enpass5_final(MAYBE_CONSTANT enpass_salt *salt,
 	}
 }
 
-inline void _e6_preproc(__global const uint *key,
+INLINE void _e6_preproc(__global const uint *key,
                         ulong *state, ulong padding)
 {
 	uint i;

--- a/run/opencl/krb5_kernel.cl
+++ b/run/opencl/krb5_kernel.cl
@@ -41,7 +41,7 @@ typedef struct {
  * For some reason, ptext_size is ignored and we only use 16. That's just
  * how the CPU code works, I have no idea why.
  */
-inline void dk(uchar *key_out, uchar *key_in, uint key_size,
+INLINE void dk(uchar *key_out, uchar *key_in, uint key_size,
                __constant uchar *ptext, uint ptext_size, __local aes_local_t *lt)
 {
 	uchar iv[16] = { 0 };
@@ -54,7 +54,7 @@ inline void dk(uchar *key_out, uchar *key_in, uint key_size,
 	AES_cbc_encrypt(plaintext, key_out, key_size, &ekey, iv);
 }
 
-inline void krb_decrypt(MAYBE_CONSTANT uchar *ciphertext, uint ctext_size,
+INLINE void krb_decrypt(MAYBE_CONSTANT uchar *ciphertext, uint ctext_size,
                         __global uchar *plaintext, const uchar *key,
                         uint key_size, __local aes_local_t *lt)
 {

--- a/run/opencl/lm_kernel_b.cl
+++ b/run/opencl/lm_kernel_b.cl
@@ -84,7 +84,7 @@
 
 #define vones (~(vtype)0)
 
-inline void lm_loop(vtype *B,
+INLINE void lm_loop(vtype *B,
 #if WORK_GROUP_SIZE
 		__local lm_vector *lm_keys,
 #else

--- a/run/opencl/lm_kernel_f.cl
+++ b/run/opencl/lm_kernel_f.cl
@@ -446,7 +446,7 @@
 #define vzero 0
 #define vones (~(vtype)0)
 
-inline void lm_loop(vtype *B,
+INLINE void lm_loop(vtype *B,
 #if WORK_GROUP_SIZE
 		__local lm_vector *lm_keys,
 #else

--- a/run/opencl/odf_kernel.cl
+++ b/run/opencl/odf_kernel.cl
@@ -52,7 +52,7 @@ typedef struct {
 	uint v[256/32]; /* output from final SHA-1 or SHA-256 */
 } odf_out;
 
-inline void odf_bf(__global const uchar *password,
+INLINE void odf_bf(__global const uchar *password,
                    __constant odf_salt *salt,
                    __global uint *out)
 {
@@ -120,7 +120,7 @@ inline void odf_bf(__global const uchar *password,
 		out[i] = SWAP32(hash[i]);
 }
 
-inline void odf_aes(__global const uchar *password,
+INLINE void odf_aes(__global const uchar *password,
                     __constant odf_salt *salt,
                     __global uint *out,
                     __local aes_local_t *lt)

--- a/run/opencl/opencl_DES_kernel_params.h
+++ b/run/opencl/opencl_DES_kernel_params.h
@@ -90,7 +90,7 @@ typedef unsigned WORD vtype;
 	DES_bs_clear_block_8(48); 			\
 	DES_bs_clear_block_8(56);
 
-inline void cmp(unsigned DES_bs_vector *B,
+INLINE void cmp(unsigned DES_bs_vector *B,
 	  __global int *uncracked_hashes,
 	  int num_uncracked_hashes,
 	  volatile __global uint *hash_ids,

--- a/run/opencl/opencl_blowfish.h
+++ b/run/opencl/opencl_blowfish.h
@@ -342,7 +342,7 @@ __constant uint S[4][256] = {
 	    0xB74E6132L, 0xCE77E25BL, 0x578FDFE3L, 0x3AC372E6L  }
 };
 
-inline uint F(blowfish_context *ctx, uint x)
+INLINE uint F(blowfish_context *ctx, uint x)
 {
 	uint a, b, c, d;
 	uint y;
@@ -361,7 +361,7 @@ inline uint F(blowfish_context *ctx, uint x)
 	return (y);
 }
 
-inline void blowfish_enc(blowfish_context *ctx, uint *xl, uint *xr)
+INLINE void blowfish_enc(blowfish_context *ctx, uint *xl, uint *xr)
 {
 	uint Xl, Xr;
 	uint i;
@@ -382,7 +382,7 @@ inline void blowfish_enc(blowfish_context *ctx, uint *xl, uint *xr)
 	*xr = Xl;
 }
 
-inline void blowfish_dec(blowfish_context *ctx, uint *xl, uint *xr)
+INLINE void blowfish_dec(blowfish_context *ctx, uint *xl, uint *xr)
 {
 	uint Xl, Xr;
 	uint i;
@@ -406,7 +406,7 @@ inline void blowfish_dec(blowfish_context *ctx, uint *xl, uint *xr)
 /*
  * Blowfish key schedule
  */
-inline void blowfish_setkey(blowfish_context *ctx,
+INLINE void blowfish_setkey(blowfish_context *ctx,
                             BF_KEY_TYPE uchar *key,
                             uint keybits)
 {
@@ -453,7 +453,7 @@ inline void blowfish_setkey(blowfish_context *ctx,
 /*
  * Blowfish-ECB, using private (generic) memory
  */
-inline void blowfish_crypt(blowfish_context *ctx,
+INLINE void blowfish_crypt(blowfish_context *ctx,
                            int mode,
                            uchar *input,
                            uchar *output)
@@ -477,7 +477,7 @@ inline void blowfish_crypt(blowfish_context *ctx,
 /*
  * Blowfish-ECB block encryption/decryption
  */
-inline void blowfish_crypt_ecb(blowfish_context *ctx,
+INLINE void blowfish_crypt_ecb(blowfish_context *ctx,
                                int mode,
                                BF_SRC_TYPE uchar *input,
                                BF_DST_TYPE uchar *output)
@@ -501,7 +501,7 @@ inline void blowfish_crypt_ecb(blowfish_context *ctx,
 /*
  * Blowfish-CBC buffer encryption/decryption
  */
-inline void blowfish_crypt_cbc(blowfish_context *ctx,
+INLINE void blowfish_crypt_cbc(blowfish_context *ctx,
                                int mode,
                                uint length,
                                uchar *iv,
@@ -545,7 +545,7 @@ inline void blowfish_crypt_cbc(blowfish_context *ctx,
 /*
  * Blowfish CFB buffer encryption/decryption
  */
-inline void blowfish_crypt_cfb64(blowfish_context *ctx,
+INLINE void blowfish_crypt_cfb64(blowfish_context *ctx,
                                  int mode,
                                  uint length,
                                  uint *iv_off,
@@ -585,7 +585,7 @@ inline void blowfish_crypt_cfb64(blowfish_context *ctx,
 /*
  * Blowfish CTR buffer encryption/decryption
  */
-inline void blowfish_crypt_ctr(blowfish_context *ctx,
+INLINE void blowfish_crypt_ctr(blowfish_context *ctx,
                                uint length,
                                uint *nc_off,
                                uchar *nonce_counter,

--- a/run/opencl/opencl_keccak.h
+++ b/run/opencl/opencl_keccak.h
@@ -54,7 +54,7 @@ __constant uint64_t RC[24] =
   REPEAT5(e; v += s;)
 
 /*** Keccak-f[1600] ***/
-inline void keccakf(void* state)
+INLINE void keccakf(void* state)
 {
 	uint64_t* a = (uint64_t*)state;
 	uint64_t b[5] = { 0 };
@@ -106,14 +106,14 @@ inline void keccakf(void* state)
   _(for (uint i = 0; i < L; i += ST) { S; })
 
 #define mkapply_ds(NAME, S)                                          \
-  inline void NAME(uint8_t* dst,                                     \
+  INLINE void NAME(uint8_t* dst,                                     \
                    const uint8_t* src,                               \
                    uint len) {                                       \
       FOR(i, 1, len, S);                                             \
   }
 
 #define mkapply_sd(NAME, S)                                          \
-  inline void NAME(const uint8_t* src,                               \
+  INLINE void NAME(const uint8_t* src,                               \
                    uint8_t* dst,                                     \
                    uint len) {                                       \
       FOR(i, 1, len, S);                                             \
@@ -135,7 +135,7 @@ mkapply_sd(setout, dst[i] = src[i])  // setout
   }
 
 /** The sponge-based hash construction. **/
-inline void hash(uint8_t* out, uint outlen, const uint8_t* in, uint inlen,
+INLINE void hash(uint8_t* out, uint outlen, const uint8_t* in, uint inlen,
                  uint rate, uint8_t delim)
 {
 	uint8_t a[Plen] = { 0 };
@@ -156,19 +156,19 @@ inline void hash(uint8_t* out, uint outlen, const uint8_t* in, uint inlen,
 
 /*** Helper macros to define SHA3 and SHAKE instances. ***/
 #define defshake(bits)                                            \
-  inline void shake##bits(uint8_t* out, uint outlen,              \
+  INLINE void shake##bits(uint8_t* out, uint outlen,              \
                           const uint8_t* in, uint inlen) {        \
       hash(out, outlen, in, inlen, 200 - (bits / 4), 0x1f);       \
   }
 
 #define defsha3(bits)                                             \
-  inline void sha3_##bits(uint8_t* out, uint outlen,              \
+  INLINE void sha3_##bits(uint8_t* out, uint outlen,              \
                           const uint8_t* in, uint inlen) {        \
       hash(out, outlen, in, inlen, 200 - (bits / 4), 0x06);       \
   }
 
 #define defkeccak(bits)                                           \
-  inline void keccak_##bits(uint8_t* out, uint outlen,            \
+  INLINE void keccak_##bits(uint8_t* out, uint outlen,            \
                             const uint8_t* in, uint inlen) {      \
       hash(out, outlen, in, inlen, 200 - (bits / 4), 0x01);       \
   }

--- a/run/opencl/opencl_lm_finalize_keys.h
+++ b/run/opencl/opencl_lm_finalize_keys.h
@@ -182,7 +182,7 @@
 	kp += NEXT_BIT;					\
 }
 
-inline void lm_bs_finalize_keys(__global opencl_lm_transfer *lm_raw_keys,
+INLINE void lm_bs_finalize_keys(__global opencl_lm_transfer *lm_raw_keys,
 				int section,
 				MAYBE_LOCAL lm_vector *lm_keys,
 #if WORK_GROUP_SIZE

--- a/run/opencl/opencl_lm_kernel_params.h
+++ b/run/opencl/opencl_lm_kernel_params.h
@@ -80,7 +80,7 @@ typedef unsigned WORD vtype;
 	for (bit = bits; bit < k; bit++)		\
 		hash |= ((((uint)B[32 + bit]) >> x) & 1) << bit;
 
-inline void cmp_final(unsigned lm_vector *B,
+INLINE void cmp_final(unsigned lm_vector *B,
 		      unsigned int *binary,
 		      __global unsigned int *offset_table,
 		      __global unsigned int *hash_table,
@@ -116,7 +116,7 @@ inline void cmp_final(unsigned lm_vector *B,
 	}
 }
 
-inline void cmp( unsigned lm_vector *B,
+INLINE void cmp( unsigned lm_vector *B,
 		 __global unsigned int *offset_table,
 		 __global unsigned int *hash_table,
 		  __global unsigned int *bitmaps,

--- a/run/opencl/opencl_md4_ctx.h
+++ b/run/opencl/opencl_md4_ctx.h
@@ -19,7 +19,7 @@ typedef struct {
 	uchar buffer[64];  /* data block being processed */
 } MD4_CTX;
 
-inline void _md4_process(MD4_CTX *ctx, const uchar data[64])
+INLINE void _md4_process(MD4_CTX *ctx, const uchar data[64])
 {
 	uint W[16], A, B, C, D MD4_G_VARS;
 
@@ -78,7 +78,7 @@ inline void _md4_process(MD4_CTX *ctx, const uchar data[64])
 /*
  * MD4 context setup
  */
-inline void MD4_Init(MD4_CTX *ctx)
+INLINE void MD4_Init(MD4_CTX *ctx)
 {
 	ctx->total = 0;
 
@@ -91,7 +91,7 @@ inline void MD4_Init(MD4_CTX *ctx)
 /*
  * MD4 process buffer
  */
-inline void MD4_Update(MD4_CTX *ctx, const uchar *input, uint ilen)
+INLINE void MD4_Update(MD4_CTX *ctx, const uchar *input, uint ilen)
 {
 	uint fill;
 	uint left;
@@ -129,7 +129,7 @@ inline void MD4_Update(MD4_CTX *ctx, const uchar *input, uint ilen)
 /*
  * MD4 final digest
  */
-inline void MD4_Final(uchar output[20], MD4_CTX *ctx)
+INLINE void MD4_Final(uchar output[20], MD4_CTX *ctx)
 {
 	uint last, padn;
 	ulong bits;

--- a/run/opencl/opencl_nonstd.h
+++ b/run/opencl/opencl_nonstd.h
@@ -1,3 +1,5 @@
+#include "opencl_misc.h"
+
 /*
  * Bitslice DES S-boxes for x86 with MMX/SSE2/AVX and for typical RISC
  * architectures.  These use AND, OR, XOR, NOT, and AND-NOT gates.
@@ -132,7 +134,7 @@ s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif !andn || !triop || latency >= 3
 /* s1-00484, 49 gates, 17 regs, 11 andn, 4/9/39/79/120 stalls, 74 biop */
 /* Currently used for MMX/SSE2 and x86-64 SSE2 */
-inline  void
+INLINE void
 s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -292,7 +294,7 @@ s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#if andn && triop && latency <= 4
 /* s2-016251, 44 gates, 14 regs, 13 andn, 1/9/22/61/108 stalls, 66 biop */
 /*
-inline  void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out1, vtype * out2, vtype * out3, vtype * out4)
 {
@@ -367,7 +369,7 @@ s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif !andn && regs >= 15
 /* s2-016276, 44 gates, 15 regs, 11 andn, 1/9/24/59/104 stalls, 67 biop */
 
-inline  void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -445,7 +447,7 @@ s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 /* s2-016277, 44 gates, 15 regs, 12 andn, 4/15/35/74/121 stalls, 65 biop */
 /* Currently used for x86-64 SSE2 */
 /*
-inline  void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -522,7 +524,7 @@ s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif !andn || (triop && latency >= 5)
 /* s2-016380, 44 gates, 14/15 regs, 12 andn, 1/9/27/55/99 stalls, 68 biop */
 /*
-inline  void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -600,7 +602,7 @@ s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 /* s2-016520, 44 gates, 15 regs, 13 andn, 5/17/41/78/125 stalls, 68 biop */
 /* Currently used for MMX/SSE2 */
 /*
-inline  void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -976,7 +978,7 @@ s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif triop && regs >= 17 && latency <= 3
 /* s3-001172, 46 gates, 17 regs, 10 andn, 2/3/19/55/98 stalls, 69 biop */
 /*
-inline  void
+INLINE void
 s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1052,7 +1054,7 @@ s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#else
 /* s3-001283, 46 gates, 16 regs, 14 andn, 2/5/10/30/69 stalls, 69 biop */
 
-inline  void
+INLINE void
 s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1128,7 +1130,7 @@ s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#endif
 
 /* s4, 33 gates, 11/12 regs, 9 andn, 2/21/53/86/119 stalls, 52 biop */
-inline  void
+INLINE void
 s4(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1265,7 +1267,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 /* s5-04829, 48 gates, 15/16 regs, 9 andn, 4/24/65/113/163 stalls, 72 biop */
 /* Currently used for x86-64 SSE2 */
 /*
-inline  void
+INLINE void
 s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1344,7 +1346,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 /* s5-04832, 48 gates, 15/16 regs, 9 andn, 5/23/62/109/159 stalls, 72 biop */
 /* Currently used for MMX/SSE2 */
 
-inline  void
+INLINE void
 s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1426,7 +1428,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 /* s6-000007, 46 gates, 19 regs, 8 andn, 3/19/39/66/101 stalls, 69 biop */
 /* Currently used for x86-64 SSE2 */
 /*
-inline  void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1505,7 +1507,7 @@ s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 /* s6-000009, 46 gates, 19 regs, 8 andn, 3/20/41/69/110 stalls, 69 biop */
 /* Currently used for MMX/SSE2 */
 
-inline  void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1583,7 +1585,7 @@ s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif latency >= 3
 /* s6-000028, 46 gates, 19 regs, 8 andn, 4/16/39/65/101 stalls, 69 biop */
 /*
-inline  void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1661,7 +1663,7 @@ s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#else
 /* s6-000031, 46 gates, 19 regs, 8 andn, 3/16/42/68/111 stalls, 69 biop */
 /*
-inline  void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -2259,7 +2261,7 @@ s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif !andn && triop && regs >= 17 && latency <= 4
 /* s7-036496, 46 gates, 17 regs, 7 andn, 3/9/20/52/95 stalls, 70 biop */
 /*
-inline  void
+INLINE void
 s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -2335,7 +2337,7 @@ s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif !andn && triop && regs >= 17 && latency >= 5
 /* s7-036532, 46 gates, 17 regs, 7 andn, 3/9/23/51/93 stalls, 71 biop */
 /*
-inline  void
+INLINE void
 s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -2411,7 +2413,7 @@ s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif andn && triop && regs <= 16
 /* s7-036610, 46 gates, 16 regs, 9 andn, 1/6/16/53/98 stalls, 70 biop */
 /*
-inline  void
+INLINE void
 s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -2561,7 +2563,7 @@ s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif !andn && triop && latency <= 4
 /* s7-036649, 46 gates, 16 regs, 7 andn, 3/9/20/55/100 stalls, 69 biop */
 /*
-inline  void
+INLINE void
 s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -2713,7 +2715,7 @@ s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 /* s7-056945, 46 gates, 16 regs, 7 andn, 10/31/62/107/156 stalls, 67 biop */
 /* Currently used for MMX/SSE2 */
 
-inline  void
+INLINE void
 s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -2993,7 +2995,7 @@ s8(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif !andn || !triop
 /* s8-019374, 41 gates, 14 regs, 7 andn, 4/25/61/103/145 stalls, 59 biop */
 /* Currently used for x86-64 SSE2 */
-inline  void
+INLINE void
 s8(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)

--- a/run/opencl/opencl_sboxes-s.h
+++ b/run/opencl/opencl_sboxes-s.h
@@ -1,3 +1,5 @@
+#include "opencl_misc.h"
+
 /*
  * Bitslice DES S-boxes making use of a vector conditional select operation
  * (e.g., vsel on PowerPC with AltiVec).
@@ -42,7 +44,7 @@
 //#if regs >= 17 || latency >= 3
 /* s1-000010, 36 gates, 17 regs, 8/28/65/102/139 stall cycles */
 
-inline  void
+INLINE void
 s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -110,7 +112,7 @@ s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#else
 /* s1-000011, 36 gates, 16 regs, 10/37/74/111/148 stall cycles */
 /*
-inline  void
+INLINE void
 s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -180,7 +182,7 @@ s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#if regs >= 18 && latency <= 2
 /* s2-000000, 33 gates, 18 regs, 3/26/57/90/125 stall cycles */
 
-inline  void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -244,7 +246,7 @@ s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif regs >= 18 && latency >= 4
 /* s2-000002, 33 gates, 18 regs, 4/22/49/82/117 stall cycles */
 /*
-inline  void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -308,7 +310,7 @@ s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#else
 /* s2-000012, 33 gates, 17 regs, 5/17/51/86/121 stall cycles */
 /*
-inline  void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -374,7 +376,7 @@ s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#if latency >= 3
 /* s3-000000, 33 gates, 17 regs, 6/10/33/66/102 stall cycles */
 /*
-inline  void
+INLINE void
 s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -437,7 +439,7 @@ s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 */
 //#else
 /* s3-000004, 33 gates, 17 regs, 3/13/41/77/113 stall cycles */
-inline  void
+INLINE void
 s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -502,7 +504,7 @@ s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#if regs >= 13
 /* s4-000014, 26 gates, 13 regs, 2/17/42/70/98 stall cycles */
 
-inline  void
+INLINE void
 s4(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -556,7 +558,7 @@ s4(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#else
 /* s4-000033, 26 gates, 12 regs, 4/22/48/76/104 stall cycles */
 /*
-inline  void
+INLINE void
 s4(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -612,7 +614,7 @@ s4(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#if regs <= 18 && latency <= 2
 /* s5-000000, 35 gates, 18 regs, 7/33/68/105/142 stall cycles */
 /*
-inline  void
+INLINE void
 s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -678,7 +680,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif regs == 19 || (regs >= 20 && latency >= 3)
 /* s5-000005, 35 gates, 19 regs, 7/29/60/95/132 stall cycles */
 /*
-inline  void
+INLINE void
 s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -744,7 +746,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif regs <= 18 && latency >= 5
 /* s5-000011, 35 gates, 18 regs, 9/31/62/95/132 stall cycles */
 /*
-inline  void
+INLINE void
 s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -810,7 +812,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif regs >= 20
 /* s5-000016, 35 gates, 20 regs, 6/30/62/98/135 stall cycles */
 
-inline  void
+INLINE void
 s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -876,7 +878,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#else
 /* s5-000023, 35 gates, 18 regs, 9/30/61/96/133 stall cycles */
 /*
-inline  void
+INLINE void
 s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -944,7 +946,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#if regs >= 16 && latency <= 2
 /* s6-000000, 34 gates, 16 regs, 5/34/70/107/144 stall cycles */
 
-inline  void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1009,7 +1011,7 @@ s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif regs == 15
 /* s6-000008, 34 gates, 15 regs, 6/25/57/94/131 stall cycles */
 /*
-inline  void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1074,7 +1076,7 @@ s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#elif regs <= 14
 /* s6-000082, 34 gates, 14 regs, 8/31/65/102/139 stall cycles */
 /*
-inline  void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1139,7 +1141,7 @@ s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#else
 /* s6-000461, 34 gates, 16 regs, 7/23/48/82/118 stall cycles */
 /*
-inline  void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1205,7 +1207,7 @@ s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#if regs <= 16 || latency >= 3
 /* s7-000013, 34 gates, 15 regs, 9/27/56/88/119 stall cycles */
 /*
-inline  void
+INLINE void
 s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1269,7 +1271,7 @@ s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 */
 //#else
 /* s7-000019, 34 gates, 17 regs, 5/28/57/88/119 stall cycles */
-inline  void
+INLINE void
 s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1335,7 +1337,7 @@ s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 //#if latency >= 3
 /* s8-000035, 32 gates, 15 regs, 6/15/47/79/111 stall cycles */
 /*
-inline  void
+INLINE void
 s8(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)
@@ -1396,7 +1398,7 @@ s8(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 }*/
 //#else
 /* s8-000037, 32 gates, 15 regs, 3/17/49/81/113 stall cycles */
-inline  void
+INLINE void
 s8(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
     vtype * out,
    vtype c1, vtype c2 ,vtype c3 , vtype c4)

--- a/run/opencl/opencl_sboxes.h
+++ b/run/opencl/opencl_sboxes.h
@@ -28,7 +28,7 @@
  * The underlying mathematical formulas are NOT copyrighted.
  */
 
-inline void
+INLINE void
 s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
    vtype *out, vtype c1, vtype c2, vtype c3, vtype c4)
 {
@@ -91,7 +91,7 @@ s1(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 	XOROUT
 }
 
-inline void
+INLINE void
 s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
    vtype *out, vtype c1, vtype c2, vtype c3, vtype c4)
 {
@@ -147,7 +147,7 @@ s2(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 	XOROUT
 }
 
-inline void
+INLINE void
 s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
    vtype *out, vtype c1, vtype c2, vtype c3, vtype c4)
 {
@@ -206,7 +206,7 @@ s3(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 	XOROUT
 }
 
-inline void
+INLINE void
 s4(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
    vtype *out, vtype c1, vtype c2, vtype c3, vtype c4)
 {
@@ -269,7 +269,7 @@ s4(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 	XOROUT
 }
 
-inline void
+INLINE void
 s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
    vtype *out, vtype c1, vtype c2, vtype c3, vtype c4)
 {
@@ -327,7 +327,7 @@ s5(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 	XOROUT
 }
 
-inline void
+INLINE void
 s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
    vtype *out, vtype c1, vtype c2, vtype c3, vtype c4)
 {
@@ -383,7 +383,7 @@ s6(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 	XOROUT
 }
 
-inline void
+INLINE void
 s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
    vtype *out, vtype c1, vtype c2, vtype c3, vtype c4)
 {
@@ -440,7 +440,7 @@ s7(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
 	XOROUT
 }
 
-inline void
+INLINE void
 s8(vtype a1, vtype a2, vtype a3, vtype a4, vtype a5, vtype a6,
    vtype *out, vtype c1, vtype c2, vtype c3, vtype c4)
 {

--- a/run/opencl/pem_kernel.cl
+++ b/run/opencl/pem_kernel.cl
@@ -24,7 +24,7 @@ typedef struct {
 	uchar ciphertext[CTLEN];
 } pem_salt;
 
-inline int pem_decrypt(__global uchar *key, MAYBE_CONSTANT pem_salt *salt, __local aes_local_t *lt)
+INLINE int pem_decrypt(__global uchar *key, MAYBE_CONSTANT pem_salt *salt, __local aes_local_t *lt)
 {
 	uchar out[CTLEN];
 	struct asn1_hdr hdr;

--- a/run/opencl/sha256_kernel.cl
+++ b/run/opencl/sha256_kernel.cl
@@ -43,7 +43,7 @@
     #define USE_LOCAL       1
 #endif
 
-inline void _memcpy(               uint32_t * dest,
+INLINE void _memcpy(               uint32_t * dest,
                     __global const uint32_t * src,
                              const uint32_t   len) {
 
@@ -51,7 +51,7 @@ inline void _memcpy(               uint32_t * dest,
         *dest++ = *src++;
 }
 
-inline void any_hash_cracked(
+INLINE void any_hash_cracked(
 	const uint32_t iter,                        //which candidates_number is this one
 	volatile __global uint32_t * const hash_id, //information about how recover the cracked password
 	const uint32_t * const hash,                //the hash calculated by this kernel
@@ -111,7 +111,7 @@ inline void any_hash_cracked(
  *
  * [1] Of course, one could be a crack.
  */
-inline void sha256_block(	  const uint32_t * const buffer,
+INLINE void sha256_block(	  const uint32_t * const buffer,
 				  const uint32_t total, uint32_t * const H) {
 
     uint32_t a = H0;

--- a/run/opencl/sha512_gpl_kernel.cl
+++ b/run/opencl/sha512_gpl_kernel.cl
@@ -47,7 +47,7 @@
     #define USE_LOCAL       1
 #endif
 
-inline void _memcpy(               uint32_t * dest,
+INLINE void _memcpy(               uint32_t * dest,
                     __global const uint32_t * src,
                              const uint32_t   len) {
 
@@ -55,7 +55,7 @@ inline void _memcpy(               uint32_t * dest,
         *dest++ = *src++;
 }
 
-inline void any_hash_cracked(
+INLINE void any_hash_cracked(
 	const uint32_t iter,                        //which candidates_number is this one
 	volatile __global uint32_t * const hash_id, //information about how recover the cracked password
 	const uint64_t * const hash,                //the hash calculated by this kernel
@@ -115,7 +115,7 @@ inline void any_hash_cracked(
  *
  * [1] Of course, one could be a crack.
  */
-inline void sha512_block(	  const uint64_t * const buffer,
+INLINE void sha512_block(	  const uint64_t * const buffer,
 				  const uint32_t total, uint64_t * const H) {
 
     uint64_t a = H0;

--- a/run/opencl/strip_kernel.cl
+++ b/run/opencl/strip_kernel.cl
@@ -21,7 +21,7 @@ typedef struct {
 #define SQLITE_MAX_PAGE_SIZE 65536
 
 /* verify validity of page */
-inline int verify_page(uchar *page)
+INLINE int verify_page(uchar *page)
 {
 	uint32_t pageSize;
 	uint32_t usableSize;

--- a/run/opencl/telegram_kernel.cl
+++ b/run/opencl/telegram_kernel.cl
@@ -19,7 +19,7 @@ typedef struct {
 	uchar encrypted_blob[ENCRYPTED_BLOB_LEN];
 } telegram_salt;
 
-inline int telegram_decrypt(__global uchar *authkey, MAYBE_CONSTANT telegram_salt *salt, __local aes_local_t *lt)
+INLINE int telegram_decrypt(__global uchar *authkey, MAYBE_CONSTANT telegram_salt *salt, __local aes_local_t *lt)
 {
 	// variables
 	uchar data_a[48];

--- a/run/opencl/tezos_kernel.cl
+++ b/run/opencl/tezos_kernel.cl
@@ -20,7 +20,7 @@ typedef struct {
 	uchar pkh[20];
 } tezos_salt_t;
 
-inline void _tezos_preproc_(const ulong *key, uint keylen,
+INLINE void _tezos_preproc_(const ulong *key, uint keylen,
                             ulong *state, ulong mask)
 {
 	uint i, j;
@@ -55,7 +55,7 @@ inline void _tezos_preproc_(const ulong *key, uint keylen,
 	state[7] = H + SHA512_INIT_H;
 }
 
-inline void _tezos_hmac_(ulong *output, ulong *ipad_state, ulong *opad_state, ulong *salt, uint saltlen)
+INLINE void _tezos_hmac_(ulong *output, ulong *ipad_state, ulong *opad_state, ulong *salt, uint saltlen)
 {
 	uint i, j;
 	ulong W[16] = { 0 };


### PR DESCRIPTION
See #5618 #5638 #5778

I re-ran the tests from #5709 - these changes didn't affect them. Also a test on NVIDIA is successful like before.