### PR TITLE
Minor fixes for some formats where cmp_all() often returned non-zero

### DIFF
--- a/src/bestcrypt_ve_fmt_plug.c
+++ b/src/bestcrypt_ve_fmt_plug.c
@@ -388,11 +388,14 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		SHA256_Init(&ctx);
 		SHA256_Update(&ctx, out, 0x40);
 		SHA256_Final(sha256_hash, &ctx);
-		cracked[index] = (0 == memcmp(sha256_hash, out + 0x40, 0x20));
+
+		if (!memcmp(sha256_hash, out + 0x40, 0x20)) {
+			cracked[index] = 1;
 #ifdef _OPENMP
 #pragma omp atomic
 #endif
-		any_cracked |= 1;
+			any_cracked |= 1;
+		}
 	}
 
 	if (failed) {

--- a/src/bks_fmt_plug.c
+++ b/src/bks_fmt_plug.c
@@ -339,7 +339,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 					keys, lens, cur_salt->salt,
 					cur_salt->saltlen, mackey, mackeylen);
 
-			for (j = 0; j < SSE_GROUP_SZ_SHA1; ++j) {
+			for (j = 0; j < SSE_GROUP_SZ_SHA1 && index+j < count; ++j) {
 				hmac_sha1(mackey[j], mackeylen, cur_salt->store_data,
 						cur_salt->store_data_length,
 						store_hmac_calculated, 20);
@@ -380,7 +380,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 					keys,
 					lens, cur_salt->salt,
 					cur_salt->saltlen, ckey, 32);
-			for (j = 0; j < SSE_GROUP_SZ_SHA1; ++j) {
+			for (j = 0; j < SSE_GROUP_SZ_SHA1 && index+j < count; ++j) {
 				unsigned char compute_checkum[20];
 				Twofish_prepare_key(ckey[j], 32, &tkey);
 				datalen = Twofish_Decrypt(&tkey, cur_salt->store_data, store_data_decrypted, cur_salt->store_data_length, iv[j]);

--- a/src/bks_fmt_plug.c
+++ b/src/bks_fmt_plug.c
@@ -89,6 +89,8 @@ static char (*saved_key)[PLAINTEXT_LENGTH + 1];
 static size_t *saved_len;
 static int *cracked, any_cracked;  // "cracked array" approach is required for UBER keystores
 
+struct fmt_main fmt_bks; /* patched by crypt_all() */
+
 static void init(struct fmt_main *self)
 {
 	omp_autotune(self, OMP_SCALE);
@@ -267,6 +269,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 			if (!memcmp(store_hmac_calculated, cur_salt->store_hmac, 20))
 			{
+				if (mackeylen < 7)
+					fmt_bks.params.flags |= FMT_NOT_EXACT;
 				cracked[index] = 1;
 #ifdef _OPENMP
 #pragma omp atomic
@@ -342,6 +346,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 				if (!memcmp(store_hmac_calculated, cur_salt->store_hmac, 20))
 				{
+					if (mackeylen < 7)
+						fmt_bks.params.flags |= FMT_NOT_EXACT;
 					cracked[index+j] = 1;
 #ifdef _OPENMP
 #pragma omp atomic

--- a/src/opencl_argon2_fmt_plug.c
+++ b/src/opencl_argon2_fmt_plug.c
@@ -1003,6 +1003,16 @@ static void kp_set_salt(void *salt)
 // Compare result hashes with db hashes
 static int cmp_all(void *binary, int count)
 {
+	int i;
+
+	for (i = 0; i < count; i++)
+		if (*(uint8_t *)binary == crypted[i][0] && !memcmp(binary, crypted[i], saved_salt.hash_size))
+			return 1;
+	return 0;
+}
+
+static int kp_cmp_all(void *binary, int count)
+{
 	return 1;
 }
 
@@ -1328,7 +1338,7 @@ struct fmt_main fmt_opencl_keepass_argon2 = {
 		{
 			fmt_default_get_hash
 		},
-		cmp_all,
+		kp_cmp_all,
 		kp_cmp_one,
 		cmp_exact
 	}

--- a/src/opencl_zip_fmt_plug.c
+++ b/src/opencl_zip_fmt_plug.c
@@ -364,7 +364,12 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 
 static int cmp_all(void *binary, int count)
 {
-	return crack_count_ret;
+	int i;
+
+	for (i = 0; i < count; i++)
+		if (*(uint8_t *)binary == outbuffer[i].v[0] && !memcmp(outbuffer[i].v, binary, WINZIP_BINARY_SIZE))
+			return 1;
+	return 0;
 }
 
 static int cmp_one(void *binary, int index)


### PR DESCRIPTION
I tried benchmarking all formats with `bench.c` patched to alert when `cmp_all` returns non-zero. Here's the list I got:

```
Benchmarking: BestCryptVE4, BestCrypt Volume Encryption v4 (32768, 16, 1) [scrypt Salsa20/8 128/128 AVX512VL, AES/TwoFish/Serpent/Camellia]... (4xOMP) 
Benchmarking: BKS, BouncyCastle [PKCS#12 PBE (SHA1) 512/512 AVX-512 16x]... (4xOMP) 
Benchmarking: krb4, Kerberos v4 TGT [DES 32/64]... 
Benchmarking: openssl-enc, OpenSSL "enc" encryption (AES-128, MD5) [32/64]... (4xOMP) 
Benchmarking: PKZIP [32/64]... (4xOMP) 
Benchmarking: Siemens-S7 [HMAC-SHA1 32/64]... (4xOMP) 
```

It's not that bad. I expected it'd be the case for many more.

Out of these:
- `BestCryptVE4` had a bug (fixed here, so would no longer get on the above list)
- `BKS` turned out to have frequent collisions (true or false positives? either way, we now dynamically set `FMT_NOT_EXACT`)
- `krb4` only has parity check in `cmp_all` and real computation and check in `cmp_one` (not changed here, but ideally we'd make bigger changes also adding OpenMP)
- `openssl-enc` is known to have frequent false positives (no good fix)
- `PKZIP` only checks short checksums, deferring further checking to `cmp_exact` (this may be fine, albeit not optimal with OpenMP if `cmp_exact` is reached so often)
- `Siemens-S7` pre-checks 32 bits in `cmp_all` and is fast, so it's just luck that one 32-bit collision occurred for it during my testing (that's fine, could also occur for many other formats - but maybe a reminder that we could prefer `ARCH_WORD` or 64-bit checks now that we mostly care about performance on 64-bit archs)

Also patched here is "BKS format: With SIMD, limit final scalar loops to actual key count", but I'm not sure we should. The same could apply to some other formats.

Other observations:

In `PKZIP`, the `chk` array is always fully written to by all threads, which means the cache lines holding it are bounced between CPUs. We could want to add our `any_cracked` logic and conditionally `memset` the array instead.

In `PKZIP`, `cmp_all` uses an add loop unlike what we have in other formats. This optimizes for the case of no matches (so having to run the loop to the end anyway), but with high keys counts there are quite often some matches. Maybe this optimization is outdated by increasing key counts.