### PR TITLE
Add a valid_luhn() function, and use it for SL3

### DIFF
--- a/src/jumbo.c
+++ b/src/jumbo.c
@@ -470,3 +470,39 @@ char *replace(char *string, char c, char n)
 
 	return string;
 }
+
+/*
+ * This is based on the pseudo-code from wikipedia and not meant to be fast.
+ */
+int valid_luhn(char *s)
+{
+	if (s == NULL)
+		return 0;
+
+	int len;
+	if ((len = strlen(s)) < 2)
+		return 0;
+
+	uint8_t expected = s[--len];
+	if (expected < '0' || expected > '9')
+		return 0;
+	expected -= '0';
+
+	int parity = len % 2;
+	int i, sum = 0;
+
+	for (i = 0; i < len; i++) {
+		if (s[i] < '0' || s[i] > '9')
+			return 0;
+		int digit = s[i] - '0';
+		if ((i + 1) % 2 != parity)
+			sum += digit;
+		else if (digit > 4)
+			sum += 2 * digit - 9;
+		else
+			sum += 2 * digit;
+	}
+	sum = (10 - (sum % 10)) % 10;
+
+	return (sum == expected);
+}

--- a/src/jumbo.h
+++ b/src/jumbo.h
@@ -440,4 +440,11 @@ extern int check_pkcs_pad(const unsigned char* data, size_t len, int blocksize);
  */
 extern char *replace(char *string, char c, char n);
 
+/*
+ * Input is a string of digits supposedly ending with a Luhn digit.
+ * Output is true if the string is digits-only and the Luhn digit is correct,
+ * and false otherwise including for empty or NULL string.
+ */
+extern int valid_luhn(char *s);
+
 #endif /* _JTR_JUMBO_H */


### PR DESCRIPTION
https://github.com/openwall/john/issues/5767#issuecomment-2862115937

I wanted to base it on https://rosettacode.org/wiki/Luhn_test_of_credit_card_numbers#C which is nice code, but it appears the licensing would be tricky so here's instead my C implementation of the pseudo code on Wikipedia.

There were actually a mockup SL3 test vector featuring an incorrect Luhn so I had to correct that as well.