### PR TITLE
Fix missing fclose calls to prevent file descriptor leaks

### DIFF
--- a/src/base64_convert.c
+++ b/src/base64_convert.c
@@ -1085,8 +1085,10 @@ static void do_convert_wholefile(char *fname, char *outfname, b64_convert_type i
 	fseek(fp, 0, SEEK_END);
 	in_len = ftell(fp);
 	fseek(fp, 0, SEEK_SET);
-	if (in_len == 0)
+	if (in_len == 0) {
+		fclose(fp);
 		return;
+	}
 	in_str = (char*)mem_calloc(1, in_len+4);
 	if (fread(in_str, 1, in_len, fp) != in_len) {
 		MEM_FREE(in_str);

--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -265,6 +265,7 @@ static void process_KDBX2_database(FILE *fp, char* encryptedDatabase)
 	datasize = filesize - 124;
 	if (datasize < 0) {
 		warn("%s: Error in validating datasize.", encryptedDatabase);
+		if (kfp) fclose(kfp);
 		return;
 	}
 	printf("%s:$keepass$*1*%d*%d*", dbname, key_transf_rounds, algorithm);

--- a/src/undrop.c
+++ b/src/undrop.c
@@ -42,12 +42,14 @@ int undrop(int argc, char *argv[]) {
     }
 
 
-    if (fgets(t_line, sizeof(t_line) - 1, userfile) == NULL)
+    if (fgets(t_line, sizeof(t_line) - 1, userfile) == NULL) {
+	if (userfile != stdin) fclose(userfile);
 	return 1;
+    }
 
     if (strncmp(t_line, USERFILE_HEADER, strlen(USERFILE_HEADER)) != 0) {
 	fprintf(stderr, "usefile format is wrong\n");
-	fclose(userfile);
+	if (userfile != stdin) fclose(userfile);
 	return 1;
     } else {
 	printf("# userfile format OK\n\n");


### PR DESCRIPTION
### Describe

This PR fixes several instances of missing `fclose()` calls that could lead to file descriptor leaks.

The affected functions are:

- `undrop()`
- `process_KDBX2_database()`
- `do_convert_wholefile()`

Each function previously returned early in some error paths without properly releasing the opened file handles.

### Expected Behavior

- All opened files should be properly closed before any `return`, regardless of success or failure.
- No file descriptor should be left open after the function returns.

### Actual Behavior

- In several paths (e.g., `fgets()` failure, invalid `datasize`, empty input file), the function returns without calling `fclose()`.
- This causes a resource leak and could eventually lead to **file descriptor exhaustion** if such functions are called repeatedly.

This is a **safe and minimal change** with **no behavioral impact** other than proper resource cleanup.

Thanks for reviewing.