### PR TITLE
OpenCL: Enable upon seeing /usr/local/cuda

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -13614,6 +13614,10 @@ if test "x$cross_compiling" = xno -a "x$enable_opencl" != xno; then :
 $as_echo_n "checking additional paths for OpenCL... " >&6; }
    ADD_LDFLAGS=""
    ADD_CFLAGS=""
+   if test -d /usr/local/cuda; then
+      ADD_CFLAGS="$ADD_CFLAGS -I/usr/local/cuda/targets/x86_64-linux/include"
+      ADD_LDFLAGS="$ADD_LDFLAGS -L/usr/local/cuda/targets/x86_64-linux/lib"
+   fi
    if test -n "$AMDAPPSDKROOT"; then
       if test -d "$AMDAPPSDKROOT/include"; then
          ADD_CFLAGS="$ADD_CFLAGS -I$AMDAPPSDKROOT/include"

--- a/src/m4/jtr_utility_macros.m4
+++ b/src/m4/jtr_utility_macros.m4
@@ -213,6 +213,10 @@ AC_DEFUN([JTR_SET_OPENCL_INCLUDES],
    AC_MSG_CHECKING([additional paths for OpenCL])
    ADD_LDFLAGS=""
    ADD_CFLAGS=""
+   if test -d /usr/local/cuda; then
+      ADD_CFLAGS="$ADD_CFLAGS -I/usr/local/cuda/targets/x86_64-linux/include"
+      ADD_LDFLAGS="$ADD_LDFLAGS -L/usr/local/cuda/targets/x86_64-linux/lib"
+   fi
    if test -n "$AMDAPPSDKROOT"; then
       if test -d "$AMDAPPSDKROOT/include"; then
          ADD_CFLAGS="$ADD_CFLAGS -I$AMDAPPSDKROOT/include"


### PR DESCRIPTION
Somehow we would auto-enable OpenCL upon seeing some legacy AMD setups, but not for CUDA?!

On a Rocky Linux 9.6 system with CUDA toolkit installed with:

https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Rocky&target_version=9&target_type=rpm_network

```
sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
sudo dnf clean all
sudo dnf -y install cuda-toolkit-12-9
```

I got:

```
$ ls -ld /usr/local/cuda*
lrwxrwxrwx.  1 root root   22 Jul 31 03:15 /usr/local/cuda -> /etc/alternatives/cuda
lrwxrwxrwx.  1 root root   25 Jul 31 03:15 /usr/local/cuda-12 -> /etc/alternatives/cuda-12
drwxr-xr-x. 15 root root 4096 Jul 31 03:15 /usr/local/cuda-12.9
```

but I wasn't getting an OpenCL-enabled build without manually adding:

```
./configure LDFLAGS=-L/usr/local/cuda/targets/x86_64-linux/lib CPPFLAGS=-I/usr/local/cuda/targets/x86_64-linux/include
```

which is consistent with what our `doc/README-OPENCL` suggests, but we should rather avoid this complication.

With this PR's changes, a simple `./configure` on this system enables OpenCL.