### PR TITLE
OpenCL formats: Drop all _attribute__((max_constant_size(n)))

### DIFF
--- a/run/opencl/DES_bs_finalize_keys_kernel.cl
+++ b/run/opencl/DES_bs_finalize_keys_kernel.cl
@@ -230,11 +230,8 @@ __kernel void DES_bs_finalize_keys(__global opencl_DES_bs_transfer *des_raw_keys
 #else
 				   __global
 #endif
-				   unsigned int *des_int_keys
-#if !defined(__OS_X__) && USE_CONST_CACHED_INT_KEYS && gpu_amd(DEVICE_INFO)
-				   __attribute__((max_constant_size((ACTIVE_PLACEHOLDER * 32 * ITER_COUNT))))
-#endif
-				   , __global unsigned int *des_int_key_loc,
+				   unsigned int *des_int_keys,
+				   __global unsigned int *des_int_key_loc,
 				   __global DES_bs_vector *des_bs_keys) {
 
 	int section = get_global_id(0);

--- a/run/opencl/DES_bs_kernel.cl
+++ b/run/opencl/DES_bs_kernel.cl
@@ -127,15 +127,9 @@
 	SWAP(31, 63);  	\
 }
 
-__kernel void DES_bs_25_b(constant uint *key_map
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-                          __attribute__((max_constant_size(3072)))
-#endif
-                          , constant int *processed_salt
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-                          __attribute__((max_constant_size(192)))
-#endif
-			  , __global DES_bs_vector *des_bs_key,
+__kernel void DES_bs_25_b(constant uint *key_map,
+                          constant int *processed_salt,
+                          __global DES_bs_vector *des_bs_key,
                           __global vtype *unchecked_hashes)
 {
 	int section = get_global_id(0);

--- a/run/opencl/DES_bs_kernel_h.cl
+++ b/run/opencl/DES_bs_kernel_h.cl
@@ -123,11 +123,8 @@
 	SWAP(31, 63);  	\
 }
 
-__kernel void DES_bs_25( constant uint *key_map
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-                         __attribute__((max_constant_size(3072)))
-#endif
-                         , __global DES_bs_vector *des_bs_key,
+__kernel void DES_bs_25( constant uint *key_map,
+                         __global DES_bs_vector *des_bs_key,
                          __global vtype *unchecked_hashes) {
 
 		int section = get_global_id(0);

--- a/run/opencl/bf_cpu_kernel.cl
+++ b/run/opencl/bf_cpu_kernel.cl
@@ -179,23 +179,13 @@
 	      Sptr[i + 7] = R00 ;					\
 	     }
 
-__kernel void blowfish(	constant uint *salt
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-	__attribute__((max_constant_size(16)))
-#endif
-	, constant uint *P_box
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-	__attribute__((max_constant_size(72)))
-#endif
-	, __global uint *BF_out,
+__kernel void blowfish(	constant uint *salt,
+	constant uint *P_box,
+	__global uint *BF_out,
 	__global uint *BF_current_S,
 	__global uint *BF_current_P_global,
 	uint rounds,
-	constant uint *S_box
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-	__attribute__((max_constant_size(4096)))
-#endif
-	)
+	constant uint *S_box)
 {
 		int index = 2 * get_global_id(0);
 

--- a/run/opencl/bf_kernel.cl
+++ b/run/opencl/bf_kernel.cl
@@ -112,23 +112,13 @@
               Sptr[i + 7] = R0 ;					\
 	    }
 
-__kernel void blowfish(	constant uint *salt
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-	__attribute__((max_constant_size(16)))
-#endif
-	, constant uint *P_box
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-	__attribute__((max_constant_size(72)))
-#endif
-	, __global uint *BF_out,
+__kernel void blowfish(	constant uint *salt,
+	constant uint *P_box,
+	__global uint *BF_out,
 	__global uint *BF_current_S,
 	__global uint *BF_current_P_global,
 	uint rounds,
-	constant uint *S_box
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-	__attribute__((max_constant_size(4096)))
-#endif
-	)
+	constant uint *S_box)
 {
 		int index = get_global_id(0) ;
 		int lid   = get_local_id(0) ;

--- a/run/opencl/krb5pa-md5_kernel.cl
+++ b/run/opencl/krb5pa-md5_kernel.cl
@@ -336,11 +336,8 @@ void krb5pa_md5(__global const uint *keys,
 #else
                 __global
 #endif
-                uint *int_keys
-#if !defined(__OS_X__) && USE_CONST_CACHE && gpu_amd(DEVICE_INFO)
-                __attribute__((max_constant_size (NUM_INT_KEYS * 4)))
-#endif
-                , __global uint *bitmaps,
+                uint *int_keys,
+                __global uint *bitmaps,
                 __global uint *offset_table,
                 __global uint *hash_table,
                 __global uint *return_hashes,

--- a/run/opencl/lm_kernel_b.cl
+++ b/run/opencl/lm_kernel_b.cl
@@ -140,20 +140,14 @@ __kernel void lm_bs_b(__global opencl_lm_transfer *lm_raw_keys,
 #if (WORK_GROUP_SIZE == 0)
 		    __global lm_vector *lm_keys,
 #endif
-		   constant uint *lm_key_idx
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-                   __attribute__((max_constant_size(3072)))
-#endif
+		    constant uint *lm_key_idx,
 #if USE_CONST_CACHED_INT_KEYS
-		    , constant
+		    constant
 #else
-		    , __global
+		    __global
 #endif
-		    unsigned int *lm_int_keys /* Memory allocated on host side must not exceed CONST_CACHE_SIZE if constant is used. */
-#if !defined(__OS_X__) && USE_CONST_CACHED_INT_KEYS && gpu_amd(DEVICE_INFO)
-		__attribute__((max_constant_size ((ACTIVE_PLACEHOLDER * 32 * ITER_COUNT))))
-#endif
-		   , __global unsigned int *offset_table,
+		    unsigned int *lm_int_keys,
+		    __global unsigned int *offset_table,
 		   __global unsigned int *hash_table,
 		   __global unsigned int *bitmaps,
                    volatile __global uint *hash_ids,

--- a/run/opencl/lm_kernel_f.cl
+++ b/run/opencl/lm_kernel_f.cl
@@ -515,11 +515,8 @@ __kernel void lm_bs_f(__global opencl_lm_transfer *lm_raw_keys, // Do not change
 #else
 		    __global
 #endif
-		    unsigned int *lm_int_keys /* Memory allocated on host side must not exceed CONST_CACHE_SIZE if constant is used. */
-#if !defined(__OS_X__) && USE_CONST_CACHED_INT_KEYS && gpu_amd(DEVICE_INFO)
-		__attribute__((max_constant_size ((ACTIVE_PLACEHOLDER * 32 * ITER_COUNT))))
-#endif
-		    , __global unsigned int *offset_table,
+		    unsigned int *lm_int_keys,
+		    __global unsigned int *offset_table,
 		    __global unsigned int *hash_table,
 		    __global unsigned int *bitmaps,
                     volatile __global uint *hash_ids,

--- a/run/opencl/md4_kernel.cl
+++ b/run/opencl/md4_kernel.cl
@@ -239,11 +239,8 @@ __kernel void md4(__global uint *keys,
 #else
 		  __global
 #endif
-		  uint *int_keys
-#if !defined(__OS_X__) && USE_CONST_CACHE && gpu_amd(DEVICE_INFO)
-		__attribute__((max_constant_size (NUM_INT_KEYS * 4)))
-#endif
-		 , __global uint *bitmaps,
+		  uint *int_keys,
+		  __global uint *bitmaps,
 		  __global uint *offset_table,
 		  __global uint *hash_table,
 		  __global uint *return_hashes,

--- a/run/opencl/md5_kernel.cl
+++ b/run/opencl/md5_kernel.cl
@@ -263,11 +263,8 @@ __kernel void md5(__global uint *keys,
 #else
 		  __global
 #endif
-		  uint *int_keys
-#if !defined(__OS_X__) && USE_CONST_CACHE && gpu_amd(DEVICE_INFO)
-		__attribute__((max_constant_size (NUM_INT_KEYS * 4)))
-#endif
-		 , __global uint *bitmaps,
+		  uint *int_keys,
+		  __global uint *bitmaps,
 		  __global uint *offset_table,
 		  __global uint *hash_table,
 		  __global uint *return_hashes,

--- a/run/opencl/mscash_kernel.cl
+++ b/run/opencl/mscash_kernel.cl
@@ -448,21 +448,15 @@ INLINE void cmp(uint gid,
  * words. MD4 hash of a key is 128 bit (uint4). */
 __kernel void mscash(__global uint *keys,
 		  __global uint *index,
-		  constant uint *salt
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-		__attribute__((max_constant_size(17 * sizeof(uint))))
-#endif
-		  , __global uint *int_key_loc,
+		  constant uint *salt,
+		  __global uint *int_key_loc,
 #if USE_CONST_CACHE
 		  constant
 #else
 		  __global
 #endif
-		  uint *int_keys
-#if !defined(__OS_X__) && USE_CONST_CACHE && gpu_amd(DEVICE_INFO)
-		__attribute__((max_constant_size (NUM_INT_KEYS * 4)))
-#endif
-		 , __global uint *bitmaps,
+		  uint *int_keys,
+		  __global uint *bitmaps,
 		  __global uint *offset_table,
 		  __global uint *hash_table,
 		  __global uint *return_hashes,

--- a/run/opencl/ntlmv2_kernel.cl
+++ b/run/opencl/ntlmv2_kernel.cl
@@ -277,11 +277,8 @@ ntlmv2(const __global uint *keys,
 #else
        __global
 #endif
-       uint *int_keys
-#if !defined(__OS_X__) && USE_CONST_CACHE && gpu_amd(DEVICE_INFO)
-       __attribute__((max_constant_size (NUM_INT_KEYS * 4)))
-#endif
-       , __global uint *bitmaps,
+       uint *int_keys,
+       __global uint *bitmaps,
        __global uint *offset_table,
        __global uint *hash_table,
        __global uint *return_hashes,

--- a/run/opencl/oldoffice_kernel.cl
+++ b/run/opencl/oldoffice_kernel.cl
@@ -553,11 +553,7 @@ void oldoffice(__global const uchar *password,
 #else
                __global
 #endif
-               uint *int_keys
-#if !defined(__OS_X__) && USE_CONST_CACHE && gpu_amd(DEVICE_INFO)
-               __attribute__((max_constant_size (NUM_INT_KEYS * 4)))
-#endif
-               )
+               uint *int_keys)
 {
 #ifdef RC4_USE_LOCAL
 	__local

--- a/run/opencl/pbkdf2_kernel.cl
+++ b/run/opencl/pbkdf2_kernel.cl
@@ -616,11 +616,7 @@ INLINE void hmac_sha1(uint *istate, uint *ostate, uint *buf)
 
 __kernel
 void pbkdf2_preprocess_short(	const __global unsigned int *dccHahses,
-				constant unsigned int *salt
-#if !defined(__OS_X__) && gpu_amd(DEVICE_INFO)
-	__attribute__((max_constant_size(SALT_BUFFER_SIZE)))
-#endif
-				, int usrlen,
+				constant unsigned int *salt, int usrlen,
 				__global temp_buf *tmp	)
 {
 	init_preprocess();

--- a/run/opencl/salted_sha_kernel.cl
+++ b/run/opencl/salted_sha_kernel.cl
@@ -144,11 +144,7 @@ void sha1(__global uint *keys,
 #else
           __global
 #endif
-#if !defined(__OS_X__) && USE_CONST_CACHE && gpu_amd(DEVICE_INFO)
-          uint *int_keys __attribute__((max_constant_size (NUM_INT_KEYS * 4))),
-#else
           uint *int_keys,
-#endif
           __constant uchar *salt,
           __global uint *bitmaps,
           __global uint *offset_table,

--- a/run/opencl/sha1_kernel.cl
+++ b/run/opencl/sha1_kernel.cl
@@ -131,11 +131,8 @@ __kernel void sha1(__global uint *keys,
 #else
 		  __global
 #endif
-		  uint *int_keys
-#if !defined(__OS_X__) && USE_CONST_CACHE && gpu_amd(DEVICE_INFO)
-		__attribute__((max_constant_size (NUM_INT_KEYS * 4)))
-#endif
-		 , __global uint *bitmaps,
+		  uint *int_keys,
+		  __global uint *bitmaps,
 		  __global uint *offset_table,
 		  __global uint *hash_table,
 		  __global uint *return_hashes,


### PR DESCRIPTION
It was never in any OpenCL standard. It was deprecated ages ago and is allegedly unsupported on any AMD driver since 2018. But it has produced annoying warnings ever since.

As far as I know it was never supported on Nvidia although they just silently ignore it.