### PR TITLE
Self test worksizes

### DIFF
--- a/src/opencl_autotune.h
+++ b/src/opencl_autotune.h
@@ -112,10 +112,12 @@ static void autotune_run_extra(struct fmt_main *self, unsigned int rounds,
 	if (options.flags & FLG_SHOW_CHK)
 		return;
 
-	// FIXME add optional test-same-sizes
 	if (self_test_running) {
-		local_work_size = 7;
-		global_work_size = 49;
+		if (cpu(device_info[gpu_id]))
+			local_work_size = get_platform_vendor_id(platform_id) == DEV_INTEL ? 8 : 1;
+		else
+			local_work_size = get_device_max_lws(gpu_id);
+		global_work_size = local_work_size;
 	}
 
 	ocl_autotune_running = 1;

--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -1099,22 +1099,21 @@ void opencl_get_user_preferences(const char *format)
 
 void opencl_get_sane_lws_gws_values()
 {
-	if (self_test_running) {
-		local_work_size = 7;
-		global_work_size = 49;
-	}
 
-	if (!local_work_size) {
+	if (!local_work_size || self_test_running) {
 		if (cpu(device_info[gpu_id]))
 			local_work_size =
-				get_platform_vendor_id(platform_id) == DEV_INTEL ?
-			8 : 1;
+				get_platform_vendor_id(platform_id) == DEV_INTEL ? 8 : 1;
+		else if (self_test_running)
+			local_work_size = get_device_max_lws(gpu_id);
 		else
-			local_work_size = 64;
+			local_work_size = 2 * get_device_warp_size(gpu_id);
 	}
 
-	if (!global_work_size)
-		global_work_size = 768;
+	if (self_test_running)
+		global_work_size = local_work_size;
+	else if (!global_work_size)
+		global_work_size = 12 * local_work_size;
 }
 
 char* get_device_name_(int sequential_id)

--- a/src/opencl_ethereum_presale_fmt_plug.c
+++ b/src/opencl_ethereum_presale_fmt_plug.c
@@ -142,6 +142,7 @@ static size_t get_task_max_work_group_size()
 
 	s = autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel);
 	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, split_kernel));
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, decrypt_kernel));
 	return s;
 }
 

--- a/src/opencl_gpg_fmt_plug.c
+++ b/src/opencl_gpg_fmt_plug.c
@@ -121,7 +121,12 @@ static const char *warn[] = {
 /* ------- Helper functions ------- */
 static size_t get_task_max_work_group_size()
 {
-	return autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel);
+	size_t s;
+
+	s = autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel);
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel_sha256));
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel_sha512));
+	return s;
 }
 
 static void release_clobj(void);


### PR DESCRIPTION
Self-test with default LWS at device maximum

Also with a default GWS of 2x that LWS.  The new figures are better at triggering bugs. If a kernel needs a lower LWS than device max. our code already handles that.

We previously had it as LWS=7 GWS=49 for speed and for checking heuristics that could bug out on non-log2 values but that was introduced before our autotune was sped up with orders of magnitude (and the heuristics has been stable for many years).

Like before, the self-test will obey any given lws/gws options or environment variables.

Closes #5822