### PR TITLE
o5logon-opencl: Switch to bitsliced AES

### DIFF
--- a/run/opencl/o5logon_kernel.cl
+++ b/run/opencl/o5logon_kernel.cl
@@ -15,6 +15,7 @@
 #include "opencl_sha1.h"
 #include "opencl_md5_ctx.h"
 #include "opencl_mask.h"
+#define AES_BITSLICE
 #include "opencl_aes.h"
 
 typedef struct {


### PR DESCRIPTION
While this doesn't fully help on all device/runtime combos, it seems to help a lot on several.

See #5827