### PR TITLE
Include the session name in exit messages.

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -196,7 +196,6 @@ static struct db_main database;
 static int loaded_extra_pots;
 static struct fmt_main dummy_format;
 
-static char *mode_exit_message = "";
 static int exit_status = 0;
 
 static void john_register_one(struct fmt_main *format)
@@ -1833,7 +1832,7 @@ static void john_run(void)
 			event_pending = event_status = 1;
 
 		if (options.flags & FLG_SINGLE_CHK)
-			mode_exit_message = do_single_crack(&database);
+			do_single_crack(&database);
 		else
 		if (options.flags & FLG_WORDLIST_CHK)
 			do_wordlist_crack(&database, options.wordlist,
@@ -1962,9 +1961,8 @@ static void john_done(void)
 			log_event("%s", abort_msg);
 		} else if (children_ok) {
 			log_event("Session completed");
-			if (john_main_process) {
-				fprintf(stderr, "Session%s completed. %s\n", john_session_name, mode_exit_message);
-			}
+			if (john_main_process)
+				fprintf(stderr, "Session%s completed\n", john_session_name);
 		} else {
 			log_event("Main process session completed, but some child processes failed");
 			fprintf(stderr, "Main process session%s completed, but some child processes failed\n", john_session_name);

--- a/src/john.h
+++ b/src/john.h
@@ -43,6 +43,12 @@ extern char *john_terminal_locale;
 /* Current target for options.max_cands */
 extern uint64_t john_max_cands;
 
+/*
+ * Current session name enclosed in single quotes and with a leading space.
+ * If no name was given, this is just the empty string.
+ */
+extern char *john_session_name;
+
 /* Print loaded/remaining counts */
 extern char *john_loaded_counts(struct db_main *db, char *prelude);
 

--- a/src/single.c
+++ b/src/single.c
@@ -190,27 +190,18 @@ static void single_init(void)
 	 *
 	 * Bodge for deprecated syntax. When dropping it we'll drop this interim variable
 	 */
-	int option_retest = 0;
+	int option_retest = parse_bool(options.single_retest_guess);
 
-	option_retest = parse_bool(options.single_retest_guess);
-
-	if ((retest_guessed = option_retest) == -1) {
-
+	if ((retest_guessed = option_retest) == -1)
 		retest_guessed = cfg_get_bool(SECTION_OPTIONS, NULL, "SingleRetestGuessed", 1);
 
-		if (!retest_guessed && single_db->salt_count == 1) {
-			retest_guessed = 0;
-			if (john_main_process)
-				fprintf(stderr, "Note: Ignoring SingleRetestGuessed option because only one salt is loaded.\n"
-				                "      You can force it with --single-retest-guess\n");
-		}
+	if (john_main_process && single_db->salt_count > 1) {
+		if (!retest_guessed)
+			fprintf(stderr, "Will not try cracked passwords against other salts\n");
+
+		if (options.seed_per_user && !retest_guessed && option_retest == -1)
+			fprintf(stderr, "Note: You might want --single-retest-guess when using --single-user-seed\n");
 	}
-
-	if (!retest_guessed && john_main_process)
-		fprintf(stderr, "Will not try cracked passwords against other salts\n");
-
-	if (options.seed_per_user && retest_guessed && option_retest == -1)
-		fprintf(stderr, "Note: You might want --single-retest-guess when using --single-user-seed\n");
 
 	if ((words_pair_max = options.single_pair_max) < 0)
 	if ((words_pair_max = cfg_get_int(SECTION_OPTIONS, NULL, "SingleWordsPairMax")) < 0)

--- a/src/single.c
+++ b/src/single.c
@@ -943,24 +943,23 @@ static void single_done(void)
 	crk_done();
 }
 
-char* do_single_crack(struct db_main *db)
+void do_single_crack(struct db_main *db)
 {
 	struct rpp_context ctx;
-	int initial_num_salts;
 
 	single_db = db;
-	initial_num_salts = db->salt_count;
 	rule_ctx = &ctx;
 	single_init();
 	single_run();
 	single_done();
 	rule_ctx = NULL; /* Just for good measure */
 
-	if (initial_num_salts > 1 && status.guess_count && !retest_guessed) {
+	if (john_main_process && db->salt_count > 1 &&
+	    status.guess_count && !retest_guessed) {
 		if (single_disabled_recursion)
-			return "Warning: Disabled SingleRetestGuessed due to deep recursion. Consider running '--loopback --rules=none' next.";
+			fprintf(stderr, "Warning: Disabled SingleRetestGuessed due to deep recursion. Consider running '--loopback --rules=none' next.\n");
 		else
-			return "Consider running '--loopback --rules=none' next.";
-	} else
-		return "";
+			fprintf(stderr, "Consider running '--loopback --rules=none' next.\n");
+	}
+	return;
 }

--- a/src/single.h
+++ b/src/single.h
@@ -20,6 +20,6 @@ extern struct list_main *single_seed;
 /*
  * Runs the cracker.
  */
-extern char* do_single_crack(struct db_main *db);
+extern void do_single_crack(struct db_main *db);
 
 #endif


### PR DESCRIPTION
If session name given, the name is enclosed in single quotes such as:
```
Session 'rockyou' aborted
```

I've used this for years in a private branch so it's well tested.