### PR TITLE
Change the behavior of SIGUSR1 to emit a *delayed* status

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -1,8 +1,11 @@
 /*
  * This file is part of John the Ripper password cracker,
  * Copyright (c) 1996-2003,2006,2010-2013,2015,2017 by Solar Designer
+ * Copyright (c) 2009-2018 by JimF
+ * Copyright (c) 2011-2025 by magnum
  *
- * ...with heavy changes in the jumbo patch, by magnum & JimF
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  */
 
 #define NEED_OS_TIMER
@@ -158,6 +161,8 @@ static void crk_help(void)
 #else
 		        "or send SIGHUP to john process for status\n");
 #endif
+	if (event_delayed_status)
+		fprintf(stderr, "Delayed status pending...\r");
 
 	printed = 1;
 }

--- a/src/signals.c
+++ b/src/signals.c
@@ -1,8 +1,8 @@
 /*
  * This file is part of John the Ripper password cracker,
  * Copyright (c) 1996-2003,2006,2010,2013,2015 by Solar Designer
- *
- * ...with changes in the jumbo patch, by JimF and magnum.
+ * Copyright (c) 2009-2018 by JimF
+ * Copyright (c) 2009-2025 by magnum
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -539,7 +539,15 @@ static void sig_handle_status(int signum)
 	if (mpi_p > 1 || getenv("OMPI_COMM_WORLD_SIZE"))
 		event_save = 1;
 #endif
-	event_status = event_pending = 1;
+	/* SIGUSR1 now requests delayed status and a second one during the
+	 * delay will promote it to immediate. */
+	if (event_delayed_status) {
+		event_status = event_pending = 1;
+		event_delayed_status = 0;
+	} else {
+		event_delayed_status = 1;
+		write_loop(2, "Delayed status pending...\r", 26);
+	}
 #ifndef SA_RESTART
 	sig_install(sig_handle_status, signum);
 #endif

--- a/src/suppressor.c
+++ b/src/suppressor.c
@@ -15,6 +15,7 @@
 #include "logger.h"
 #include "options.h"
 #include "status.h"
+#include "signals.h"
 #include "suppressor.h"
 
 #define DEFAULT_SIZE 256 /* MiB */
@@ -74,6 +75,10 @@ void suppressor_init(unsigned int new_flags)
 				fprintf(stderr, "%d: %s\n", NODE, msg);
 			else
 				fprintf(stderr, "%s\n", msg);
+
+			/* The output above may have overwritten a delayed status message */
+            if (john_main_process && event_delayed_status)
+                fprintf(stderr, "Delayed status pending...\r");
 			return;
 		}
 


### PR DESCRIPTION
If a second SIGUSR1 is received, we promote it to immediate.