### PR TITLE
Convert NOTE to lowercase for `stderr` messages

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -705,7 +705,7 @@ int benchmark_all(void)
 #ifndef BENCH_BUILD
 #if defined(WITH_ASAN) || defined(WITH_UBSAN) || defined(DEBUG)
 	if (benchmark_time)
-		puts_color(color_notice, "NOTE: This is a debug build, speed will be lower than normal");
+		puts_color(color_notice, "Note: This is a debug build, speed will be lower than normal");
 #endif
 
 	if ((options.flags & FLG_LOOPTEST_CHK) && system("which nvidia-smi >/dev/null") == 0) {

--- a/src/unique.c
+++ b/src/unique.c
@@ -563,7 +563,7 @@ int unique(int argc, char **argv)
 "-ex_file_only=FILE assumes the input is already unique, and only checks\n"
 "                   against FILE (again the latter is not written to)\n"
 "\n"
-"NOTE that if you try to use more memory than actually available physical\n"
+"Note that if you try to use more memory than actually available physical\n"
 "memory, performance will just drop.\n\n",
 		        UNIQUE_HASH_LOG,
 			human_prefix(UNIQUE_HASH_SIZE * sizeof(buffer.hash) +

--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -962,7 +962,7 @@ static void print_and_cleanup(zip_context *ctx)
 
 	if (ctx->num_candidates > 1 && !once++)
 		fprintf(stderr,
-			"NOTE: It is assumed that all files in each archive have the same password.\n"
+			"Note: It is assumed that all files in each archive have the same password.\n"
 			"If that is not the case, the hash may be uncrackable. To avoid this, use\n"
 			"option -o to pick a file at a time.\n");
 


### PR DESCRIPTION
@solardiz mentioned in [this PR](https://github.com/openwall/john/pull/5837#issuecomment-3240327509):

> Actually, it is "Note" in many other messages, and "NOTE" in only 3 other messages (but one of them is in zip2john). So we may want to get the rest of them changed to "Note".

So this PR changes the other 3 instances where NOTE is seen in all caps to lowercase for `stderr` messages.