### PR TITLE
OpenCL SHA-512 "free" formats: Fix double race conditions

### DIFF
--- a/run/opencl/sha512_kernel.cl
+++ b/run/opencl/sha512_kernel.cl
@@ -113,15 +113,10 @@ __kernel void kernel_sha512(
 __kernel void kernel_cmp(
 	__constant uint64_t *binary,
 	__global uint64_t *hash,
-	__global uint32_t *result)
+	__global volatile uint32_t *result)
 {
 	uint32_t idx = get_global_id(0);
 
-	if (idx == 0)
-		*result = 0;
-
-	barrier(CLK_GLOBAL_MEM_FENCE);
-
 	if (*binary == hash[idx])
-		*result = 1;
+		atomic_or(result, 1);
 }

--- a/run/opencl/xsha512_kernel.cl
+++ b/run/opencl/xsha512_kernel.cl
@@ -119,15 +119,10 @@ __kernel void kernel_xsha512(
 __kernel void kernel_cmp(
 	__constant uint64_t *binary,
 	__global uint64_t *hash,
-	__global uint32_t *result)
+	__global volatile uint32_t *result)
 {
 	uint32_t idx = get_global_id(0);
 
-	if (idx == 0)
-		*result = 0;
-
-	barrier(CLK_GLOBAL_MEM_FENCE);
-
 	if (*binary == hash[idx])
-		*result = 1;
+		atomic_or(result, 1);
 }

--- a/src/opencl_rawsha512_fmt_plug.c
+++ b/src/opencl_rawsha512_fmt_plug.c
@@ -73,6 +73,7 @@ static sha512_key *gkey;
 static sha512_hash *ghash;
 static uint8_t new_keys;
 static uint8_t hash_copy_back;
+static uint32_t zero;
 
 //OpenCL variables:
 static cl_mem mem_in, mem_out, mem_binary, mem_cmp;
@@ -328,9 +329,14 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 static int cmp_all(void *binary, int count)
 {
 	uint32_t result;
+
 	///Copy binary to GPU memory
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_binary, CL_FALSE,
 		0, sizeof(uint64_t), ((uint64_t*)binary)+3, 0, NULL, multi_profilingEvent[2]), "Copy mem_binary");
+
+	// Clear result (race condition if done in kernel)
+	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_cmp, CL_FALSE, 0,
+		sizeof(uint32_t), &zero, 0, NULL, NULL), "Clear result buffer");
 
 	///Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel

--- a/src/opencl_xsha512_fmt_plug.c
+++ b/src/opencl_xsha512_fmt_plug.c
@@ -83,6 +83,7 @@ static xsha512_hash *ghash;
 static xsha512_salt gsalt;
 static uint8_t new_keys;
 static uint8_t hash_copy_back;
+static uint32_t zero;
 
 //OpenCL variables:
 static cl_mem mem_in, mem_out, mem_salt, mem_binary, mem_cmp;
@@ -383,6 +384,10 @@ static int cmp_all(void *binary, int count)
 	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_binary,
 		CL_FALSE, 0, sizeof(uint64_t), ((uint64_t *) binary) + 3, 0,
 		NULL, multi_profilingEvent[2]), "Copy mem_binary");
+
+	// Clear result (race condition if done in kernel)
+	BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_cmp, CL_FALSE, 0,
+		sizeof(uint32_t), &zero, 0, NULL, NULL), "Clear result buffer");
 
 	///Run kernel
 	BENCH_CLERROR(clEnqueueNDRangeKernel


### PR DESCRIPTION
Found when reviewing all uses of barriers in our kernels.

I recall we've had problems with intermittent failures from these two formats. The global barrier was added by me in good faith at some point in time. It did help a little but still not safe. Before that, there wasn't even the barrier...

I believe all other kernels' use of barriers are just fine.