### PR TITLE
OpenCL streebogcrypt formats: Disable vectors for copy/xor

### DIFF
--- a/run/opencl/opencl_streebog.h
+++ b/run/opencl/opencl_streebog.h
@@ -39,7 +39,7 @@
 #define STREEBOG_LOCAL_C    0
 #endif
 
-#define STREEBOG_VECTOR     1
+#define STREEBOG_VECTOR     0
 #define STREEBOG_UNROLL     0
 
 #if STREEBOG_LOCAL_AX

--- a/src/opencl_gost12256hash_fmt_plug.c
+++ b/src/opencl_gost12256hash_fmt_plug.c
@@ -91,7 +91,7 @@ typedef struct {
 } statebuf;
 
 typedef struct {
-	uint64_t C[8][12];
+	uint64_t C[12][8];
 	uint64_t Ax[8][256];
 } localbuf;
 

--- a/src/opencl_gost12512hash_fmt_plug.c
+++ b/src/opencl_gost12512hash_fmt_plug.c
@@ -91,7 +91,7 @@ typedef struct {
 } statebuf;
 
 typedef struct {
-	uint64_t C[8][12];
+	uint64_t C[12][8];
 	uint64_t Ax[8][256];
 } localbuf;
 


### PR DESCRIPTION
Somehow both formats fail on nvidia 50x0 with driver 575.57.08 or 575.64.03 without disabling this. This is @solardiz workaround verbatim from #5815.

I intend to look closer into why it's failing using vectors, and do some optimizations while at it. At some point in time.

The struct definition on host side doesn't matter really - only the size is used: Host side passes the size as `sizeof(localbuf)` and a NULL pointer as a kernel argument, the kernel does the allocation. But it doesn't hurt of course.

Also, the unions on GPU side are supposedly fine:
```c
/* QWORD on top because declarations depend on it. */
typedef union {
	ulong  QWORD[4];
	uint   DWORD[8];
	uint8  VWORD;
	uchar  BYTES[32];
} uint256_u;

typedef union {
	ulong  QWORD[8];
	uint   DWORD[16];
	uint16 VWORD;
	uchar  BYTES[64];
} uint512_u;
```
The alignment for uint8 is 32 and for uint16 it's 64. I just double checked that it's on the compiler to ensure the union is safe for all members, so the order listed is not important.