### PR TITLE
Make-charset: Fix integer overflow

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1335,12 +1335,12 @@ static void john_load(void)
 		} while ((current = current->next));
 
 		if (loop_db.plaintexts->count) {
-			log_event("- Reassembled %d split passwords for "
+			log_event("- Reassembled %ld split passwords for "
 			          "loopback", loop_db.plaintexts->count);
 			if (john_main_process &&
 			    options.verbosity >= VERB_DEFAULT)
 				fprintf(stderr,
-				        "Reassembled %d split passwords for "
+				        "Reassembled %ld split passwords for "
 				        "loopback\n",
 				        loop_db.plaintexts->count);
 		}

--- a/src/list.h
+++ b/src/list.h
@@ -31,7 +31,7 @@ struct list_entry {
 struct list_main {
 	struct list_entry *head, *tail;
 
-	int count;
+	long count;
 };
 
 /*

--- a/src/single.c
+++ b/src/single.c
@@ -403,7 +403,7 @@ static void single_init(void)
 	 */
 	if (words_pair_max && single_seed->count) {
 		words_pair_max += single_seed->count;
-		log_event("- SingleWordsPairMax increased for %d global seed words",
+		log_event("- SingleWordsPairMax increased for %ld global seed words",
 		          single_seed->count);
 	}
 	if (words_pair_max && log2(key_count) > words_pair_max) {


### PR DESCRIPTION
I got "Loaded 18446744072007505554 plaintexts" after actually loading slightly over `__INT_MAX__`. It did work just fine anyway, this was merely a cosmetic issue.

I'm not sure it's ever a good idea to train Incremental mode on that big a dataset, I was just playing around comparing modes. For my particular case we could make it `unsigned int` instead but that would only hit us again later.