### PR TITLE
--show=formats: Fix broken json in case of no net output

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1094,7 +1094,10 @@ static void john_load(void)
 			options.loader.flags |= DB_CRACKED;
 			ldr_init_database(&database, &options.loader);
 
-			if (!options.loader.showformats) {
+			if (options.loader.showformats) {
+				if (!options.loader.showformats_old)
+					fputs("[", stdout);
+			} else {
 				ldr_show_pot_file(&database, options.activepot);
 /*
  * Load optional extra (read-only) pot files. If an entry is a directory,

--- a/src/showformats.c
+++ b/src/showformats.c
@@ -66,9 +66,9 @@ void showformats_skipped(const char *origin, char **login, char **ciphertext,
 	int fs = db_opts->field_sep_char;
 
 	if (!db_opts->showformats_old) {
-		/* NOTE: closing "]" for JSON is in john.c. */
+		/* NOTE: outer "[" and "]" for JSON are printed in john.c. */
 		printf("%s{\"lineNo\":%d,",
-		       line_no == 1 ? "[" : ",\n",
+		       line_no == 1 ? "" : ",\n",
 		       line_no);
 		if (login && **login)
 			printf("\"login\":\"%s\",",
@@ -158,9 +158,9 @@ void showformats_regular(char **login, char **ciphertext,
 	 * by number of line.
 	 */
 	if (!db_opts->showformats_old) {
-		/* NOTE: closing "]" for JSON is in john.c. */
+		/* NOTE: outer "[" and "]" for JSON are printed in john.c. */
 		printf("%s{\"lineNo\":%d,",
-		       line_no == 1 ? "[" : ",\n",
+		       line_no == 1 ? "" : ",\n",
 		       line_no);
 		if (strcmp(*login, "?"))
 			printf("\"login\":\"%s\",",


### PR DESCRIPTION
This (example) produced a single "]":
```
touch empty && ./john --show=formats empty
```
It now emits "[]" instead, which should be the Right Thing[tm].