### PR TITLE
OpenCL: Fix a bug muting nvidia Compute Capability from device list

### DIFF
--- a/src/opencl_common.c
+++ b/src/opencl_common.c
@@ -3236,7 +3236,7 @@ void opencl_list_devices(void)
 				unsigned int major = 0, minor = 0;
 
 				get_compute_capability(sequence_nr, &major, &minor);
-				if (major && minor)
+				if (major)
 					printf("    Compute capability:     %u.%u "
 					       "(sm_%u%u)\n", major, minor, major, minor);
 			}


### PR DESCRIPTION
In --list=opencl-devices, it would erroneously mute when minor == 0, so eg. 12.0 didn't show.

Parameters were still passed in build as -DSM_MAJOR=12 -DSM_MINOR=0.