### PR TITLE
rar2john: Distinguish unexpected EOF from other errors

### DIFF
--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -209,12 +209,12 @@ static void process_KDBX2_database(FILE *fp, char* encryptedDatabase)
 
 	if (fread(final_randomseed, 16, 1, fp) != 1) {
 		warn("%s: Error: read failed: %s.", encryptedDatabase,
-			strerror(errno));
+			feof(fp) ? "Unexpected end of file" : strerror(errno));
 		return;
 	}
 	if (fread(enc_iv, 16, 1, fp) != 1) {
 		warn("%s: Error: read failed: %s.", encryptedDatabase,
-			strerror(errno));
+			feof(fp) ? "Unexpected end of file" : strerror(errno));
 		return;
 	}
 
@@ -225,12 +225,12 @@ static void process_KDBX2_database(FILE *fp, char* encryptedDatabase)
 
 	if (fread(contents_hash, 32, 1, fp) != 1) {
 		warn("%s: Error: read failed: %s.", encryptedDatabase,
-			strerror(errno));
+			feof(fp) ? "Unexpected end of file" : strerror(errno));
 		return;
 	}
 	if (fread(transf_randomseed, 32, 1, fp) != 1) {
 		warn("%s: Error: read failed: %s.", encryptedDatabase,
-			strerror(errno));
+			feof(fp) ? "Unexpected end of file" : strerror(errno));
 		return;
 	}
 
@@ -287,7 +287,7 @@ static void process_KDBX2_database(FILE *fp, char* encryptedDatabase)
 	fseek(fp, 124, SEEK_SET);
 	if (fread(buffer, datasize, 1, fp) != 1) {
 		warn("%s: Error: read failed: %s.",
-		          encryptedDatabase, strerror(errno));
+		          encryptedDatabase, feof(fp) ? "Unexpected end of file" : strerror(errno));
 		MEM_FREE(buffer);
 		return;
 	}
@@ -300,7 +300,7 @@ static void process_KDBX2_database(FILE *fp, char* encryptedDatabase)
 		printf("*1*64*"); /* inline keyfile content or hash - always 32 bytes */
 		if (fread(buffer, filesize_keyfile, 1, kfp) != 1) {
 			warn("%s: Error: read failed: %s.",
-				encryptedDatabase, strerror(errno));
+				encryptedDatabase, feof(kfp) ? "Unexpected end of file" : strerror(errno));
 			return;
 		}
 
@@ -851,7 +851,7 @@ static void process_database(char* encryptedDatabase)
 		printf("*1*64*"); /* inline keyfile content or hash - always 32 bytes */
 		if (fread(buffer, filesize_keyfile, 1, kfp) != 1) {
 			warn("%s: Error: read failed: %s.",
-				encryptedDatabase, strerror(errno));
+				encryptedDatabase, feof(kfp) ? "Unexpected end of file" : strerror(errno));
 			return;
 		}
 

--- a/src/rar2john.c
+++ b/src/rar2john.c
@@ -275,7 +275,7 @@ static void process_file(const char *archive_name)
 	/* archive header block */
 	if (fread(archive_hdr_block, 13, 1, fp) != 1) {
 		fprintf(stderr, "%s: Error: read failed: %s.\n",
-			archive_name, strerror(errno));
+			archive_name, feof(fp) ? "Unexpected end of file" : strerror(errno));
 		goto err;
 	}
 	if (archive_hdr_block[2] != 0x73) {
@@ -346,7 +346,7 @@ next_file_header:
 		jtr_fseek64(fp, -24, SEEK_END);
 		if (fread(buf, 24, 1, fp) != 1) {
 			fprintf(stderr, "%s: Error: read failed: %s.\n",
-				archive_name, strerror(errno));
+				archive_name, feof(fp) ? "Unexpected end of file" : strerror(errno));
 			goto err;
 		}
 
@@ -413,7 +413,7 @@ next_file_header:
 			uint64_t ex;
 			if (fread(rejbuf, 4, 1, fp) != 1) {
 				fprintf(stderr, "\n! %s: Error: read failed: %s.\n",
-					archive_name, strerror(errno));
+					archive_name, feof(fp) ? "Unexpected end of file" : strerror(errno));
 				goto err;
 			}
 			if (verbose) {
@@ -431,7 +431,7 @@ next_file_header:
 
 			if (fread(rejbuf, 4, 1, fp) != 1) {
 				fprintf(stderr, "\n! %s: Error: read failed: %s.\n",
-					archive_name, strerror(errno));
+					archive_name, feof(fp) ? "Unexpected end of file" : strerror(errno));
 				goto err;
 			}
 			if (verbose) {
@@ -470,7 +470,7 @@ next_file_header:
 			goto err;
 		if (fread(file_name, file_name_size, 1, fp) != 1) {
 			fprintf(stderr, "! %s: Error: read failed: %s.\n",
-				archive_name, strerror(errno));
+				archive_name, feof(fp) ? "Unexpected end of file" : strerror(errno));
 			goto err;
 		}
 
@@ -514,7 +514,7 @@ next_file_header:
 			ext_time_size -= 8;
 			if (fread(salt, 8, 1, fp) != 1) {
 				fprintf(stderr, "! %s: Error: read failed: %s.\n",
-					archive_name, strerror(errno));
+					archive_name, feof(fp) ? "Unexpected end of file" : strerror(errno));
 				goto err;
 			}
 
@@ -532,7 +532,7 @@ next_file_header:
 
 			if (fread(rejbuf, ext_time_size, 1, fp) != 1) {
 				fprintf(stderr, "! %s: Error: read failed: %s.\n",
-					archive_name, strerror(errno));
+					archive_name, feof(fp) ? "Unexpected end of file" : strerror(errno));
 				goto err;
 			}
 		}
@@ -648,7 +648,7 @@ next_file_header:
 				to_read = bytes_left;
 			bytes_left -= to_read;
 			if (fread(bytes, 1, to_read, fp) != to_read)
-				fprintf(stderr, "! Error while reading archive: %s\n", strerror(errno));
+				fprintf(stderr, "! Error while reading archive: %s\n", feof(fp) ? "Unexpected end of file" : strerror(errno));
 			for (x = 0; x < to_read; ++x) {
 				s = bytes[x];
 				*p++ = itoa16[s >> 4];

--- a/src/rar2john.c
+++ b/src/rar2john.c
@@ -647,8 +647,10 @@ next_file_header:
 			if (bytes_left < 64*1024)
 				to_read = bytes_left;
 			bytes_left -= to_read;
-			if (fread(bytes, 1, to_read, fp) != to_read)
+			if (fread(bytes, 1, to_read, fp) != to_read) {
 				fprintf(stderr, "! Error while reading archive: %s\n", feof(fp) ? "Unexpected end of file" : strerror(errno));
+				goto err;
+			}
 			for (x = 0; x < to_read; ++x) {
 				s = bytes[x];
 				*p++ = itoa16[s >> 4];


### PR DESCRIPTION
Check for feof() before parsing errno. Similar fixes should probably be made to a lot of other files throughout our tree.

See #5860