### PR TITLE
Fix a "format order" regression from the autodep branch

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -257,10 +257,11 @@ version.h: version.h.new
 
 # These are SLOW nowadays, lots of plugins.
 fmt_externs.h: .plugin_fmt_list
-	$(CC) -DFMT_EXTERNS_H -E -P $(CFLAGS) $(PLUGFORMATS_SRCS) | grep -F "extern struct fmt_main" | $(SORT) -f > $@
+	$(CC) -DFMT_EXTERNS_H -E -P $(CFLAGS) $(PLUGFORMATS_SRCS) | grep -F "extern struct fmt_main" > $@ || true
 
 fmt_registers.h: .plugin_fmt_list
-	$(CC) -DFMT_REGISTERS_H -E -P $(CFLAGS) $(PLUGFORMATS_SRCS) | grep -F "john_register_one" | $(SORT) -f > $@
+	$(CC) -DFMT_REGISTERS_H -E -P $(CFLAGS) $(filter-out opencl_%_fmt_plug.c, $(wildcard *_fmt_plug.c)) | grep -F "john_register_one" | $(SORT) -f > $@ || true
+	$(CC) -DFMT_REGISTERS_H -E -P $(CFLAGS) $(wildcard opencl_*_fmt_plug.c) | grep -F "john_register_one" | $(SORT) -f >> $@ || true
 
 .PHONY: subdirs $(SUBDIRS)
 


### PR DESCRIPTION
We're sorting the format list in struct name order, but we want the OpenCL formats last in the list.

Closes #5863