### PR TITLE
Fixed multiple resource leaks in error handling paths across the codebase

### DIFF
--- a/src/base64_convert.c
+++ b/src/base64_convert.c
@@ -1100,6 +1100,7 @@ static void do_convert_wholefile(char *fname, char *outfname, b64_convert_type i
 
 	fp = fopen(outfname, "wb");
 	if (!fp) {
+		MEM_FREE(in_str);
 		fprintf(stderr, "Error, could not open file [%s]\n", outfname);
 		exit(-1);
 	}

--- a/src/racf2john.c
+++ b/src/racf2john.c
@@ -174,6 +174,7 @@ static void process_file(const char *filename)
 
 	if (stat(filename, &sb) == -1) {
 		perror("stat");
+		fclose(fp);
 		exit(EXIT_FAILURE);
 	}
 
@@ -184,6 +185,7 @@ static void process_file(const char *filename)
 	buffer = (unsigned char *)malloc(size);
 	if (!buffer) {
 		fprintf(stderr, "malloc failed in process_file, aborting!\n");
+		fclose(fp);
 		exit(-1);
 	}
 	count = fread(buffer, size, 1, fp);


### PR DESCRIPTION
## Description
Fixed multiple resource leaks in error handling paths across the codebase.

## Problems Fixed

### 1. Memory leak in base64_convert.c
In `do_convert_wholefile()`, when `fopen()` fails while opening the output file, the function calls `exit(-1)` without freeing the `in_str` buffer that was allocated earlier with `mem_calloc()`, causing a memory leak.

### 2. File handle leaks in racf2john.c
In `process_file()`, if `stat()` or `malloc()` fails, the function exits without closing the previously opened file pointer, causing file handle leaks in two separate error paths.

## Solution
- Added `MEM_FREE(in_str)` before `exit()` in base64_convert.c
- Added `fclose(fp)` before `exit()` in both error paths in racf2john.c

## Impact
- Fixes resource leaks in error paths
- No functional changes to normal operation
- Follows existing code patterns in the respective functions
- Improves resource cleanup consistency across the codebase

## Note
This PR fixes straightforward resource leaks found. The fixes are minimal and follow existing error-handling patterns in the codebase. If you'd prefer these be discussed first via issue or mailing list, please let me know. I opened an issue already: [Issue 5870](https://github.com/openwall/john/issues/5870).