### PR TITLE
OpenCL formats: Fix many bugs in host code

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -602,11 +602,11 @@ static char* is_key_right(struct fmt_main *format, int index,
 		return err_buf;
 	}
 
-	if (match == 0) {
+	if (match <= 0) {
 		if (options.verbosity > VERB_LEGACY)
-			snprintf(err_buf, sizeof(err_buf), "crypt_all(%d) zero return %s", index + 1, ciphertext);
+			snprintf(err_buf, sizeof(err_buf), "crypt_all(%d) = %d for %s", index + 1, match, ciphertext);
 		else
-			sprintf(err_buf, "crypt_all(%d) zero return", index + 1);
+			sprintf(err_buf, "crypt_all(%d) = %d", index + 1, match);
 		return err_buf;
 	}
 

--- a/src/formats.h
+++ b/src/formats.h
@@ -383,7 +383,8 @@ struct fmt_methods {
  * The count is passed by reference and must be updated by crypt_all() if it
  * computes other than the requested count (such as if it generates additional
  * candidate passwords on its own).  The updated count is used for c/s rate
- * calculation.  The return value is thus in the 0 to updated *count range. */
+ * calculation.  The return value is thus in the 0 to updated *count range.
+ * As an exception, a -1 return is used on error during OpenCL auto-tune. */
 	int (*crypt_all)(int *count, struct db_salt *salt);
 
 /* These functions calculate a hash out of a ciphertext that has just been

--- a/src/formats.h
+++ b/src/formats.h
@@ -384,7 +384,9 @@ struct fmt_methods {
  * computes other than the requested count (such as if it generates additional
  * candidate passwords on its own).  The updated count is used for c/s rate
  * calculation.  The return value is thus in the 0 to updated *count range.
- * As an exception, a -1 return is used on error during OpenCL auto-tune. */
+ * A special case is that during autotune (only), it may return -1 to signal
+ * to the autotune logic that there was an OpenCL failure, so it can silently
+ * back down. */
 	int (*crypt_all)(int *count, struct db_salt *salt);
 
 /* These functions calculate a hash out of a ciphertext that has just been

--- a/src/krb5_tgs_common_plug.c
+++ b/src/krb5_tgs_common_plug.c
@@ -158,7 +158,7 @@ edata:
 
 	/* Now build dynamic salt and return a pointer to a pointer to it */
 	static krb5tgs_salt *psalt;
-	psalt = mem_calloc(1, sizeof(krb5tgs_salt) + edata2len);
+	psalt = mem_calloc(1, sizeof(krb5tgs_salt) + edata2len - 1);
 	memcpy(psalt->edata1, edata1, 16);
 	psalt->edata2len = edata2len;
 

--- a/src/opencl_bitlocker_fmt_plug.c
+++ b/src/opencl_bitlocker_fmt_plug.c
@@ -408,6 +408,8 @@ static int w_block_precomputed(unsigned char *salt)
 
 	HANDLE_CLERROR(clFinish(queue[gpu_id]), "clFinish");
 
+	MEM_FREE(padding);
+
 	return 1;
 }
 

--- a/src/opencl_common.h
+++ b/src/opencl_common.h
@@ -254,10 +254,12 @@ void opencl_process_event(void);
 					NODE, get_error_name(__err), __FILE__, __LINE__, message); \
 			else if (options.verbosity > VERB_LEGACY) \
 				fprintf(stderr, " %u: %s\n", NODE, get_error_name(__err)); \
-			if (!(ocl_autotune_running || bench_or_test_running)) \
-				error(); \
-			else \
+			if (ocl_autotune_running) \
 				return -1; \
+			else if (bench_or_test_running) \
+				return 0; \
+			else \
+				error(); \
 		} \
 	} while (0)
 

--- a/src/opencl_o5logon_fmt_plug.c
+++ b/src/opencl_o5logon_fmt_plug.c
@@ -298,7 +298,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		for (int i = count; i <= gws; i++)
 			key_idx[i] = key_buf_end;
 
-		CLWRITE_CRYPT(cl_key_buf, CL_FALSE, key_offset, key_buf_end - key_offset, key_buf + key_offset, multi_profilingEvent[0]);
+		if (key_buf_end != key_offset)
+			CLWRITE_CRYPT(cl_key_buf, CL_FALSE, key_offset, key_buf_end - key_offset, key_buf + key_offset, multi_profilingEvent[0]);
 		CLWRITE_CRYPT(cl_key_idx, CL_FALSE, idx_offset, 4 * (gws + 1) - idx_offset, key_idx + (idx_offset / 4), multi_profilingEvent[1]);
 
 		if (!mask_gpu_is_static)

--- a/src/opencl_pdf_fmt_plug.c
+++ b/src/opencl_pdf_fmt_plug.c
@@ -348,7 +348,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		for (int i = count; i <= gws; i++)
 			saved_idx[i] = key_idx;
 
-		CLWRITE_CRYPT(cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, multi_profilingEvent[0]);
+		if (key_idx != key_offset)
+			CLWRITE_CRYPT(cl_saved_key, CL_FALSE, key_offset, key_idx - key_offset, saved_key + key_offset, multi_profilingEvent[0]);
 		CLWRITE_CRYPT(cl_saved_idx, CL_FALSE, idx_offset, 4 * (gws + 1) - idx_offset, saved_idx + (idx_offset / 4), multi_profilingEvent[1]);
 
 		if (!mask_gpu_is_static)

--- a/src/opencl_rawmd4_fmt_plug.c
+++ b/src/opencl_rawmd4_fmt_plug.c
@@ -291,7 +291,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 static void *get_binary(char *ciphertext)
 {
-	static uint32_t out[DIGEST_SIZE];
+	static uint32_t out[DIGEST_SIZE / 4];
 	char *p;
 	int i;
 	p = ciphertext + TAG_LENGTH;

--- a/src/opencl_rawmd5_fmt_plug.c
+++ b/src/opencl_rawmd5_fmt_plug.c
@@ -316,7 +316,7 @@ static char *split(char *ciphertext, int index, struct fmt_main *self)
 
 static void *get_binary(char *ciphertext)
 {
-	static uint32_t out[DIGEST_SIZE];
+	static uint32_t out[DIGEST_SIZE / 4];
 	char *p;
 	int i;
 	p = ciphertext + TAG_LENGTH;


### PR DESCRIPTION
Detected through testing with POCL in an ASan-enabled build.

Only the two Argon2 formats are still failing on all POCL, and `krb5tgs-opencl` is failing (but no longer crashing with ASan) on Debian 13's newer POCL (but passes test with older POCL).

Fixes #5882