### PR TITLE
Unify MD4 and MD5 raw formats (CPU and OpenCL)

### DIFF
--- a/src/opencl_rawmd5_fmt_plug.c
+++ b/src/opencl_rawmd5_fmt_plug.c
@@ -1,9 +1,10 @@
 /*
  * MD5 OpenCL code is based on Alain Espinosa's OpenCL patches.
  *
- * This software is Copyright (c) 2010, Dhiru Kholia <dhiru.kholia at gmail.com>
- * and Copyright (c) 2012, magnum
- * and Copyright (c) 2015, Sayantan Datta <std2048@gmail.com>
+ * This software is
+ * Copyright (c) 2010, Dhiru Kholia <dhiru.kholia at gmail.com>
+ * Copyright (c) 2012-2025, magnum
+ * Copyright (c) 2015, Sayantan Datta <std2048@gmail.com>
  * and it is hereby released to the general public under the following terms:
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted.
@@ -46,10 +47,10 @@ john_register_one(&FMT_STRUCT);
 #define SALT_SIZE           0
 #define SALT_ALIGN          1
 
-#define FORMAT_TAG				"$dynamic_0$"
-#define TAG_LENGTH				(sizeof(FORMAT_TAG) - 1)
-#define FORMAT_TAG2				"{MD5}"
-#define FORMAT_TAG2_LEN			(sizeof(FORMAT_TAG2) - 1)
+#define FORMAT_TAG			"$dynamic_0$"
+#define TAG_LENGTH			(sizeof(FORMAT_TAG) - 1)
+#define FORMAT_TAG2			"{MD5}"
+#define FORMAT_TAG2_LEN		(sizeof(FORMAT_TAG2) - 1)
 
 static cl_mem pinned_saved_keys, pinned_saved_idx, pinned_int_key_loc;
 static cl_mem buffer_keys, buffer_idx, buffer_int_keys, buffer_int_key_loc;
@@ -389,7 +390,6 @@ static char *get_key(int index)
 	}
 
 	if (t >= global_work_size) {
-		//fprintf(stderr, "Get key error! %d %d\n", t, index);
 		t = 0;
 	}
 
@@ -420,8 +420,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 	size_t *lws = local_work_size ? &local_work_size : NULL;
 
 	global_work_size = GET_NEXT_MULTIPLE(count, local_work_size);
-
-	//fprintf(stderr, "%s(%d) lws "Zu" gws "Zu" idx %u int_cand%d\n", __FUNCTION__, count, local_work_size, global_work_size, key_idx, mask_int_cand.num_int_cand);
 
 	// copy keys to the device
 	if (key_idx)

--- a/src/rawMD5_fmt_plug.c
+++ b/src/rawMD5_fmt_plug.c
@@ -1,11 +1,10 @@
 /*
- * Raw-MD5 (thick) based on Raw-MD4 w/ mmx/sse/intrinsics
- * This software is Copyright (c) 2011 magnum, and it is hereby released to the
- * general public under the following terms:  Redistribution and use in source
- * and binary forms, with or without modification, are permitted.
- *
- * OMP added May 2013, JimF
- * BE SIMD logic added 2017, JimF
+ * This software is
+ * Copyright (c) 2011-2025 magnum
+ * Copyright (c) 2013-2017 by JimF
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
  */
 
 #if FMT_EXTERNS_H
@@ -17,6 +16,7 @@ john_register_one(&fmt_rawMD5);
 #include <string.h>
 
 #include "arch.h"
+
 #if !FAST_FORMATS_OMP
 #undef _OPENMP
 #endif
@@ -33,7 +33,7 @@ john_register_one(&fmt_rawMD5);
 #include "simd-intrinsics.h"
 
 #ifndef OMP_SCALE
-#define OMP_SCALE				16 // Tuned after MKPC for core i7 incl non-SIMD
+#define OMP_SCALE				16
 #endif
 
 #define FORMAT_LABEL			"Raw-MD5"
@@ -254,7 +254,6 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 {
 	const int count = *pcount;
 	int index;
-
 	int loops = (count + MIN_KEYS_PER_CRYPT - 1) / MIN_KEYS_PER_CRYPT;
 
 #ifdef _OPENMP
@@ -270,6 +269,7 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		MD5_Final((unsigned char *)crypt_key[index], &ctx);
 #endif
 	}
+
 	return count;
 }
 
@@ -283,6 +283,7 @@ static int cmp_all(void *binary, int count) {
 			if ( ((uint32_t*)binary)[0] == ((uint32_t*)crypt_key)[y*SIMD_COEF_32*4+x] )
 				return 1;
 		}
+
 	return 0;
 #else
 	unsigned int index;


### PR DESCRIPTION
Unify as in make almost identical - we could also create a mdX_common.h and stuff and share some functions, but that's too much work.

The MD4 ones were initially very close to copies of MD5 with s/MD5/MD4). Over the years they always start to differ unneededly and I use to re-unify them now and then, so a bugfix or improvement in one isn't missing in the other.

Basically I run Meld with the two files and throw things left or right.

This time we got added support for the "{MD4}<base64>" input format as a result, needed or not. Can't hurt.