### PR TITLE
WPA OpenCL formats: Bugfix for adding vector size to algorithm_name

### DIFF
--- a/src/opencl_wpapmk_fmt_plug.c
+++ b/src/opencl_wpapmk_fmt_plug.c
@@ -198,7 +198,7 @@ static char* get_key(int index)
 
 static void init(struct fmt_main *_self)
 {
-	static char valgo[32] = "";
+	static char valgo[sizeof(ALGORITHM_NAME) + 12] = "";
 
 	self = _self;
 

--- a/src/opencl_wpapsk_fmt_plug.c
+++ b/src/opencl_wpapsk_fmt_plug.c
@@ -214,7 +214,7 @@ static char* get_key(int index)
 
 static void init(struct fmt_main *_self)
 {
-	static char valgo[32] = "";
+	static char valgo[sizeof(ALGORITHM_NAME) + 12] = "";
 
 	self = _self;
 


### PR DESCRIPTION
An snprintf always ended up truncated after some change to ALGORITHM_NAME made it too long. Pure cosmetic issue and I actually never saw it - I got a compiler warning.

This fix is future safe as it sizes the new variable with the actual size of the algo macro in mind.