### PR TITLE
Format selection: Add an "after" option

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -202,7 +202,15 @@ static int exit_status = 0;
 static void john_register_one(struct fmt_main *format)
 {
 	if (options.format) {
-		if (options.format[0] == '-' && options.format[1]) {
+		if (options.format[0] == '/' && options.format[1]) {
+			static int drop = 1;
+
+			if (drop) {
+				if (fmt_match(&options.format[1], format, 1))
+					drop = 0;
+				return;
+			}
+		} else if (options.format[0] == '-' && options.format[1]) {
 			if (fmt_match(&options.format[1], format, 1))
 				return;
 		} else if (options.format[0] == '+' && options.format[1]) {


### PR DESCRIPTION
Matches all formats after a specific one. Put in other words, skip all formats up to and including the named one.

This is for situations where you test all formats and it segfaults on eg. foo-opencl.  You can now resume the tests from the next format, using --format=/foo-opencl.