### PR TITLE
LM formats: Fix for 8-bit self-tests

### DIFF
--- a/src/LM_fmt.c
+++ b/src/LM_fmt.c
@@ -17,6 +17,8 @@
 #include "DES_bs.h"
 #include "common.h"
 #include "formats.h"
+#include "color.h"
+#include "unicode.h"
 
 #define FORMAT_LABEL			"LM"
 #define FORMAT_NAME			""
@@ -48,6 +50,7 @@ static struct fmt_tests tests[] = {
 	{"$LM$1d91a081d4b37861", "Z"},
 	{"$LM$" LM_EMPTY, ""},
 	{"$LM$fea4ab7d7b7d0452", "0688648"},
+	/* tests[16] and up may be disabled in init() */
 	{"$LM$2734832a3bee748c", "273.15\xf8"}, /* 8-bit, 273.15° using DOS codepage */
 	{"$LM$db82323cb0693862", "2275490"},
 	{"$LM$44b3b60db75c15c1", "2716388"},
@@ -120,6 +123,16 @@ static void init(struct fmt_main *self)
 	fmt_LM.params.min_keys_per_crypt = DES_bs_min_kpc;
 	fmt_LM.params.max_keys_per_crypt = DES_bs_max_kpc;
 #endif
+
+	static int warned;
+	if (!warned && options.target_enc > CP_DOS_HI && !options.listconf &&
+		sizeof(tests) / sizeof(tests[0]) > 16) {
+		fprintf_color(color_warning, stderr,
+		              "Warning: LM formats incompatible with %s encoding, disabling some tests\n",
+		              cp_id2name(options.target_enc));
+		tests[16].ciphertext = NULL; // Truncates the array after 16 entries
+		warned = 1;
+	}
 }
 
 static char *prepare(char *fields[10], struct fmt_main *self)

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -403,6 +403,12 @@ extern void utf8_to_utf8_32(UTF32 *dst, UTF8 *src);
 /* Convert UTF-32 to UTF-8-32, in place */
 extern void utf32_to_utf8_32(UTF32 *in_place_string);
 
+/* Return codepage class (eg. CP_DOS) of a specific encoding */
+extern int cp_class(int encoding);
+
+/* Convert numerical encoding ID to canonical name */
+char *cp_id2name(int encoding);
+
 /*
  * NOTE! Please read the comments in formats.h for FMT_UNICODE and FMT_ENC
  */


### PR DESCRIPTION
The test vectors we ended up with in d7a4b6d are only compatible with DOS codepages. We now detect if running with non-DOS codepage or UTF8, and emit a warning. We then also truncate the array of self-tests so they don't fail.

Closes #5887