### PR TITLE
SM3 format: Change tag from $sm3$ to $raw-sm3$

### DIFF
--- a/src/sm3_fmt_plug.c
+++ b/src/sm3_fmt_plug.c
@@ -31,7 +31,7 @@ john_register_one(&fmt_sm3);
 #include "sm3.h"
 
 #define FORMAT_LABEL       "SM3"
-#define FORMAT_TAG         "$sm3$"
+#define FORMAT_TAG         "$raw-sm3$"
 #define TAG_LENGTH         (sizeof(FORMAT_TAG)-1)
 #define ALGORITHM_NAME     "32/" ARCH_BITS_STR
 #define BENCHMARK_COMMENT  ""
@@ -52,7 +52,7 @@ static struct fmt_tests sm3_tests[] = {
 	{ "66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0", "abc" },
 	{ "debe9ff92275b8a138604889c18e5a4d6fdb70e5387e5765293dcba39c0c5732",
 	  "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd" },
-	{ "$sm3$66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0", "abc" },
+	{ FORMAT_TAG "66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0", "abc" },
 	{ NULL }
 };
 


### PR DESCRIPTION
Apparently libxcrypt implements Drepper style crypt-sm3 using the tag `$sm3$` and the usual B64 encoding with optional `rounds=` defaulting to 5000.

Theoretically we could tell them apart without changing this tag (raw SM3 using hex), but I'm guessing we could end up regretting that.