### PR TITLE
SM3crypt

### DIFF
--- a/run/opencl/opencl_sm3.h
+++ b/run/opencl/opencl_sm3.h
@@ -1,4 +1,9 @@
 /*
+ * This software is Copyright (c) 2025 magnum,
+ * and it is hereby released to the general public under the following terms:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
  *  Copyright 2014-2023 The GmSSL Project. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the License); you may
@@ -6,17 +11,23 @@
  *
  *  http://www.apache.org/licenses/LICENSE-2.0
  */
- /*
-  *  Original taken from https://github.com/guanzhi/GmSSL.
-  *  Modified slightly.
-  *
-  *  SM3 specification: https://datatracker.ietf.org/doc/html/draft-sca-cfrg-sm3
-  *  Standardized in GM/T 0004-2012, GB/T 32905-201 and ISO/IEC 10118-3:2018
-  */
-#include "sm3.h"
-#include "int-util.h"
+#ifndef OPENCL_SM3_H
+#define OPENCL_SM3_H
 
-static const uint32_t K[64] = {
+#include "opencl_misc.h"
+
+#define SM3_BLOCK_SIZE  64
+#define SM3_HASH_LENGTH 32
+
+/* algorithm context */
+typedef struct sm3_ctx {
+	uint32_t hash[8];       /* 256-bit hash */
+	uchar block[SM3_BLOCK_SIZE];    /* 512-bit message block */
+	uint64_t num_blocks;    /* processed number of blocks */
+	uint64_t num;           /* index in the buffer of the last byte stored */
+} sm3_ctx;
+
+__constant uint32_t K[64] = {
 	0x79cc4519U, 0xf3988a32U, 0xe7311465U, 0xce6228cbU,
 	0x9cc45197U, 0x3988a32fU, 0x7311465eU, 0xe6228cbcU,
 	0xcc451979U, 0x988a32f3U, 0x311465e7U, 0x6228cbceU,
@@ -42,23 +53,29 @@ static const uint32_t K[64] = {
      (uint32_t)(x)[3])
 
 #define PUTU32(x,y)                 \
-    ((x)[0] = (uint8_t)((y) >> 24), \
-     (x)[1] = (uint8_t)((y) >> 16), \
-     (x)[2] = (uint8_t)((y) >>  8), \
-     (x)[3] = (uint8_t)(y))
+    ((x)[0] = (uchar)((y) >> 24), \
+     (x)[1] = (uchar)((y) >> 16), \
+     (x)[2] = (uchar)((y) >>  8), \
+     (x)[3] = (uchar)(y))
 
 #define P0(x) ((x) ^ rol32((x), 9) ^ rol32((x),17))
 #define P1(x) ((x) ^ rol32((x),15) ^ rol32((x),23))
 
-/*
- * FF00 and GG00 are same as MD4/MD5 H:          lut3(x, y, z, 0x96)
- * FF16 is same as MD4 G, SHA-1 G, SHA-2 Maj:    lut3(x, y, z, 0xE8)
- * GG16 is same as MD4/MD5 F, SHA-1 F, SHA-2 Ch: lut3(x, y, z, 0xCA)
- */
+#define SM3_LUT3	HAVE_LUT3
+
+#if SM3_LUT3
+#define FF00(x, y, z)  lut3(x, y, z, 0x96)
+#define FF16(x, y, z)  lut3(x, y, z, 0xE8)
+#define GG00(x, y, z)  lut3(x, y, z, 0x96)
+#define GG16(x, y, z)  lut3(x, y, z, 0xCA)
+#else
 #define FF00(x,y,z)  ((x) ^ (y) ^ (z))
-#define FF16(x,y,z)  (((x)&(y)) | ((x)&(z)) | ((y)&(z)))
+#define FF16(x,y,z)  (((x) & (y)) | ((x) & (z)) | ((y) & (z)))
 #define GG00(x,y,z)  ((x) ^ (y) ^ (z))
-#define GG16(x,y,z)  ((((y)^(z)) & (x)) ^ (z))
+#define GG16(x,y,z)  ((((y) ^ (z)) & (x)) ^ (z))
+#endif
+
+#define rol32(a, b)	rotate((a), (uint)(b))
 
 #define SM3_ROUND_0(j,A,B,C,D,E,F,G,H)              \
     SS0 = rol32(A, 12);                             \
@@ -93,7 +110,7 @@ static const uint32_t K[64] = {
     F = rol32(F, 19);
 
 
-void sm3_compress_blocks(uint32_t hash[8], const uint8_t *data, size_t blocks)
+INLINE void sm3_compress_blocks(uint32_t *hash, const uchar *data, size_t blocks)
 {
 	uint32_t A, B, C, D, E, F, G, H;
 	uint32_t W[68];
@@ -193,22 +210,23 @@ void sm3_compress_blocks(uint32_t hash[8], const uint8_t *data, size_t blocks)
 	}
 }
 
-void sm3_init(sm3_ctx *ctx)
+INLINE void sm3_init(sm3_ctx *ctx)
 {
-	memset(ctx, 0, sizeof(sm3_ctx));
+	memset_p(ctx, 0, sizeof(sm3_ctx));
 	/* Set IV */
-	ctx->hash[0] = 0x7380166f;
-	ctx->hash[1] = 0x4914b2b9;
-	ctx->hash[2] = 0x172442d7;
-	ctx->hash[3] = 0xda8a0600;
-	ctx->hash[4] = 0xa96f30bc;
-	ctx->hash[5] = 0x163138aa;
-	ctx->hash[6] = 0xe38dee4d;
-	ctx->hash[7] = 0xb0fb0e4e;
+	ctx->hash[0] = 0x7380166fU;
+	ctx->hash[1] = 0x4914b2b9U;
+	ctx->hash[2] = 0x172442d7U;
+	ctx->hash[3] = 0xda8a0600U;
+	ctx->hash[4] = 0xa96f30bcU;
+	ctx->hash[5] = 0x163138aaU;
+	ctx->hash[6] = 0xe38dee4dU;
+	ctx->hash[7] = 0xb0fb0e4eU;
 }
 
-void sm3_update(sm3_ctx *ctx, const unsigned char *data, size_t size)
+INLINE void sm3_update(sm3_ctx *ctx, const void *_data, size_t size)
 {
+	const uchar *data = _data;
 	size_t blocks;
 
 	ctx->num &= 0x3f;
@@ -216,11 +234,11 @@ void sm3_update(sm3_ctx *ctx, const unsigned char *data, size_t size)
 		size_t left = SM3_BLOCK_SIZE - ctx->num;
 
 		if (size < left) {
-			memcpy(ctx->block + ctx->num, data, size);
+			memcpy_pp(ctx->block + ctx->num, data, size);
 			ctx->num += size;
 			return;
 		} else {
-			memcpy(ctx->block + ctx->num, data, left);
+			memcpy_pp(ctx->block + ctx->num, data, left);
 			sm3_compress_blocks(ctx->hash, ctx->block, 1);
 			ctx->num_blocks++;
 			data += left;
@@ -238,23 +256,24 @@ void sm3_update(sm3_ctx *ctx, const unsigned char *data, size_t size)
 
 	ctx->num = size;
 	if (size) {
-		memcpy(ctx->block, data, size);
+		memcpy_pp(ctx->block, data, size);
 	}
 }
 
-void sm3_final(sm3_ctx *ctx, unsigned char *result)
+INLINE void sm3_final(sm3_ctx *ctx, void *_result)
 {
+	uchar *result = _result;
 	int i;
 
 	ctx->num &= 0x3f;
 	ctx->block[ctx->num] = 0x80;
 
 	if (ctx->num <= SM3_BLOCK_SIZE - 9) {
-		memset(ctx->block + ctx->num + 1, 0, SM3_BLOCK_SIZE - ctx->num - 9);
+		memset_p(ctx->block + ctx->num + 1, 0, SM3_BLOCK_SIZE - ctx->num - 9);
 	} else {
-		memset(ctx->block + ctx->num + 1, 0, SM3_BLOCK_SIZE - ctx->num - 1);
+		memset_p(ctx->block + ctx->num + 1, 0, SM3_BLOCK_SIZE - ctx->num - 1);
 		sm3_compress_blocks(ctx->hash, ctx->block, 1);
-		memset(ctx->block, 0, SM3_BLOCK_SIZE - 8);
+		memset_p(ctx->block, 0, SM3_BLOCK_SIZE - 8);
 	}
 
 	PUTU32(ctx->block + 56, ctx->num_blocks >> 23);
@@ -265,3 +284,5 @@ void sm3_final(sm3_ctx *ctx, unsigned char *result)
 		PUTU32(result + i * 4, ctx->hash[i]);
 	}
 }
+
+#endif	/* OPENCL_SM3_H */

--- a/run/opencl/sm3crypt_kernel.cl
+++ b/run/opencl/sm3crypt_kernel.cl
@@ -1,0 +1,261 @@
+/*
+ * This software is Copyright 2025 magnum
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#include "opencl_misc.h"
+#include "opencl_sm3.h"
+
+#define SALT_LENGTH     16
+#define BINARY_SIZE     SM3_HASH_LENGTH
+
+typedef struct {
+	uint len;
+	uchar key[PLAINTEXT_LENGTH];
+} inbuf;
+
+typedef struct {
+	uint rounds;
+	uint len;
+	uchar salt[SALT_LENGTH];
+} saltstruct;
+
+typedef struct {
+	uchar p_bytes[PLAINTEXT_LENGTH];
+	uchar s_bytes[SALT_LENGTH];
+} statebuf;
+
+typedef struct {
+	uint v[BINARY_SIZE / sizeof(uint)];
+} outbuf;
+
+__kernel void sm3crypt_init(__global inbuf *in,
+                            MAYBE_CONSTANT saltstruct *ssalt,
+                            __global statebuf *state,
+                            __global outbuf *out)
+{
+	sm3_ctx ctx;
+	sm3_ctx alt_ctx;
+	uchar result[BINARY_SIZE];
+	uchar temp_result[BINARY_SIZE];
+	uint gid = get_global_id(0);
+	uint cnt;
+	uint len = in[gid].len;
+	uint saltlen = ssalt->len;
+	uchar *cp;
+	uchar p_bytes[PLAINTEXT_LENGTH];
+	uchar s_bytes[SALT_LENGTH];
+	uchar key[PLAINTEXT_LENGTH];
+	uchar salt[SALT_LENGTH];
+
+	/* Copy to private memory */
+	memcpy_gp(key, in[gid].key, len);
+	memcpy_mcp(salt, ssalt->salt, saltlen);
+
+	/* Prepare for the real work. */
+	sm3_init(&ctx);
+
+	/* Add the key string. */
+	sm3_update(&ctx, key, len);
+
+	/* The last part is the salt string.  This must be at most 16
+	   characters and it ends at the first `$' character (for
+	   compatibility with existing implementations). */
+	sm3_update(&ctx, salt, saltlen);
+
+
+	/* Compute alternate SM3 sum with input KEY, SALT, and KEY.  The
+	   final result will be added to the first context. */
+	sm3_init(&alt_ctx);
+
+	/* Add key. */
+	sm3_update(&alt_ctx, key, len);
+
+	/* Add salt. */
+	sm3_update(&alt_ctx, salt, saltlen);
+
+	/* Add key again. */
+	sm3_update(&alt_ctx, key, len);
+
+	/* Now get result of this (32 bytes) and add it to the other
+	   context. */
+	sm3_final(&alt_ctx, result);
+
+	/* Add for any character in the key one byte of the alternate sum. */
+#if PLAINTEXT_LENGTH > BINARY_SIZE
+	for (cnt = len; cnt > BINARY_SIZE; cnt -= BINARY_SIZE)
+		sm3_update(&ctx, result, BINARY_SIZE);
+#else
+	cnt = len;
+#endif
+	sm3_update(&ctx, result, cnt);
+
+	/* Take the binary representation of the length of the key and for every
+	   1 add the alternate sum, for every 0 the key. */
+	for (cnt = len; cnt > 0; cnt >>= 1)
+		if ((cnt & 1) != 0)
+			sm3_update(&ctx, result, BINARY_SIZE);
+		else
+			sm3_update(&ctx, key, len);
+
+	/* Create intermediate result. */
+	sm3_final(&ctx, result);
+
+	/* Start computation of P byte sequence. */
+	sm3_init(&alt_ctx);
+
+	/* For every character in the password add the entire password. */
+	for (cnt = 0; cnt < len; ++cnt)
+		sm3_update(&alt_ctx, key, len);
+
+	/* Finish the digest. */
+	sm3_final(&alt_ctx, temp_result);
+
+	/* Create byte sequence P. */
+	cp = p_bytes;
+#if PLAINTEXT_LENGTH > BINARY_SIZE
+	for (cnt = len; cnt > BINARY_SIZE; cnt -= BINARY_SIZE) {
+		memcpy_pp(cp, temp_result, BINARY_SIZE);
+		cp += BINARY_SIZE;
+	}
+#else
+	cnt = len;
+#endif
+	memcpy_pp(cp, temp_result, cnt);
+
+	/* Start computation of S byte sequence. */
+	sm3_init(&alt_ctx);
+
+	/* repeat the following 16+A[0] times, where A[0] represents the
+	   first byte in digest A interpreted as an 8-bit uvalue */
+	for (cnt = 0; cnt < 16 + result[0]; ++cnt)
+		sm3_update(&alt_ctx, salt, saltlen);
+
+	/* Finish the digest. */
+	sm3_final(&alt_ctx, temp_result);
+
+	/* Create byte sequence S. */
+	cp = s_bytes;
+#if SALT_LENGTH > BINARY_SIZE
+	for (cnt = saltlen; cnt > BINARY_SIZE; cnt -= BINARY_SIZE) {
+		memcpy_pp(cp, temp_result, BINARY_SIZE);
+		cp += BINARY_SIZE;
+	}
+#else
+	cnt = saltlen;
+#endif
+	memcpy_pp(cp, temp_result, cnt);
+
+	/* Here's everything we need for the loop kernel */
+	memcpy_pg(out[gid].v, result, sizeof(result));
+	memcpy_pg(state[gid].p_bytes, p_bytes, len);
+	memcpy_pg(state[gid].s_bytes, s_bytes, saltlen);
+}
+
+__kernel void sm3crypt_loop(__global inbuf *in,
+                            MAYBE_CONSTANT saltstruct *ssalt,
+                            __global statebuf *state,
+                            __global outbuf *out)
+{
+	sm3_ctx ctx;
+	uchar result[BINARY_SIZE];
+	uint gid = get_global_id(0);
+	uchar p_bytes[PLAINTEXT_LENGTH];
+	uchar s_bytes[SALT_LENGTH];
+	uint cnt;
+	uint saltlen = ssalt->len;
+	uint len = in[gid].len;
+
+	memcpy_gp(result, out[gid].v, sizeof(result));
+	memcpy_gp(p_bytes, state[gid].p_bytes, len);
+	memcpy_gp(s_bytes, state[gid].s_bytes, saltlen);
+
+	/* Repeatedly run the collected hash value through SM3 to burn CPU cycles. */
+	for (cnt = 0; cnt < HASH_LOOPS; ++cnt) {
+		/* New context. */
+		sm3_init(&ctx);
+
+		/* Add key or last result. */
+		if (cnt & 1)
+			sm3_update(&ctx, p_bytes, len);
+		else
+			sm3_update(&ctx, result, BINARY_SIZE);
+
+		/* Add salt for numbers not divisible by 3. */
+		if (cnt % 3)
+			sm3_update(&ctx, s_bytes, saltlen);
+
+		/* Add key for numbers not divisible by 7. */
+		if (cnt % 7)
+			sm3_update(&ctx, p_bytes, len);
+
+		/* Add key or last result. */
+		if (cnt & 1)
+			sm3_update(&ctx, result, BINARY_SIZE);
+		else
+			sm3_update(&ctx, p_bytes, len);
+
+		/* Create intermediate result. */
+		sm3_final(&ctx, result);
+	}
+
+	memcpy_pg(out[gid].v, result, sizeof(result));
+}
+
+__kernel void sm3crypt_final(__global inbuf *in,
+                            MAYBE_CONSTANT saltstruct *ssalt,
+                            __global statebuf *state,
+                            __global outbuf *out)
+{
+	sm3_ctx ctx;
+	uchar result[BINARY_SIZE];
+	uint gid = get_global_id(0);
+	uchar p_bytes[PLAINTEXT_LENGTH];
+	uchar s_bytes[SALT_LENGTH];
+	uint saltlen, len;
+	uint cnt;
+	uint rounds = ssalt->rounds % HASH_LOOPS;
+
+	memcpy_gp(result, out[gid].v, sizeof(result));
+
+	if (rounds) {
+		saltlen = ssalt->len;
+		len = in[gid].len;
+		memcpy_gp(p_bytes, state[gid].p_bytes, len);
+		memcpy_gp(s_bytes, state[gid].s_bytes, saltlen);
+	}
+
+	/* Repeatedly run the collected hash value through SM3 to burn CPU cycles. */
+	for (cnt = 0; cnt < rounds; ++cnt) {
+		/* New context. */
+		sm3_init(&ctx);
+
+		/* Add key or last result. */
+		if (cnt & 1)
+			sm3_update(&ctx, p_bytes, len);
+		else
+			sm3_update(&ctx, result, BINARY_SIZE);
+
+		/* Add salt for numbers not divisible by 3. */
+		if (cnt % 3)
+			sm3_update(&ctx, s_bytes, saltlen);
+
+		/* Add key for numbers not divisible by 7. */
+		if (cnt % 7)
+			sm3_update(&ctx, p_bytes, len);
+
+		/* Add key or last result. */
+		if (cnt & 1)
+			sm3_update(&ctx, result, BINARY_SIZE);
+		else
+			sm3_update(&ctx, p_bytes, len);
+
+		/* Create intermediate result. */
+		sm3_final(&ctx, result);
+	}
+
+	memcpy_pg(out[gid].v, result, sizeof(result));
+}

--- a/src/opencl_sm3crypt_fmt_plug.c
+++ b/src/opencl_sm3crypt_fmt_plug.c
@@ -1,0 +1,474 @@
+/*
+ * This software is Copyright (c) 2025 magnum,
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#ifdef HAVE_OPENCL
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_opencl_cryptsm3;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_opencl_cryptsm3);
+#else
+
+#include <string.h>
+
+#include "arch.h"
+#include "params.h"
+#include "common.h"
+#include "formats.h"
+#include "options.h"
+#include "opencl_common.h"
+#include "opencl_helper_macros.h"
+
+#define FORMAT_LABEL        "sm3crypt-opencl"
+#define FORMAT_NAME         "crypt(3) " FORMAT_TAG
+#define ALGORITHM_NAME      "SM3 OpenCL"
+
+#define PLAINTEXT_LENGTH    MAX_PLAINTEXT_LENGTH
+
+#define BINARY_SIZE         (256/8) // 32
+#define BINARY_ALIGN        4
+#define SALT_SIZE           sizeof(saltstruct)
+#define SALT_ALIGN          4
+
+#define SALT_LENGTH         16
+
+#define MIN_KEYS_PER_CRYPT  1
+#define MAX_KEYS_PER_CRYPT  1
+
+#define CIPHERTEXT_LENGTH   43
+
+/* ------ Contains (at least) prepare(), valid() and split() ------ */
+/* Prefix for optional rounds specification.  */
+#define ROUNDS_PREFIX       "rounds="
+/* Default number of rounds if not explicitly specified.  */
+#define ROUNDS_DEFAULT      5000
+/* Minimum number of rounds. Libs usually have it as 1000 but we accept any */
+#define ROUNDS_MIN          1
+/* Maximum number of rounds.  */
+#define ROUNDS_MAX          999999999
+
+#define BENCHMARK_COMMENT   " (rounds=5000)"
+#define BENCHMARK_LENGTH    0x107
+#define FORMAT_TAG          "$sm3$"
+#define FORMAT_TAG_LEN      (sizeof(FORMAT_TAG)-1)
+
+static struct fmt_tests tests[] = {
+	{"$sm3$short$25nyMuun660zbmb99lNsRuPcp8Xnnxo3DzAp6/PXLg8", "abcdefg"},
+	{"$sm3$rounds=5000$saltstring$341ZVXHGiF5lVl6/blvPdxBm9OOel8BBlZ968uFss22", "01234567"},
+	{"$sm3$short$l7cf63qpDl6T3LiQe2BflvskU.ROdXVoK4MRMfv5kN7", "cr1234567"},
+	{"$sm3$short$kBQlhEiwZoX5oNxAampnJBOlAR.rlPC/0LRvR76Sh26", "ab1234567"},
+	{"$sm3$rounds=1000$short$6BJR/TAUf/WrA.mVRBafKccfX4CnqvKZAWgdVeLUdu4", "*U*U*U*U*U*U*U*U*"},
+#if PLAINTEXT_LENGTH >= 60
+	{"$sm3$rounds=1000$saltstring$rhtCacI9n9hLTXouopGunTofK4hDbU3PYZeKSbVlY5D", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"},
+	{"$sm3$short$4r1RgwZCB.EQL/MJnaw0hxGdvJ0aFp3Wg0FJf7bs6O8", "THE YEAR 1866 was marked by a bizarre development, an unexplained and downright inexplicable phenomenon that surely no one has f"},
+#endif
+	{NULL}
+};
+
+typedef struct {
+	unsigned int len;
+	char key[PLAINTEXT_LENGTH];
+} inbuf;
+
+typedef struct {
+	unsigned int v[BINARY_SIZE / sizeof(unsigned int)];
+} outbuf;
+static outbuf *crypt_out;
+
+typedef struct {
+	unsigned int rounds;
+	unsigned int len;
+	unsigned char salt[SALT_LENGTH];
+} saltstruct;
+static saltstruct cur_salt;
+
+typedef struct {
+	unsigned char p_bytes[PLAINTEXT_LENGTH];
+	unsigned char s_bytes[SALT_LENGTH];
+} statebuf;
+
+#define STEP			0
+#define SEED			128
+#define HASH_LOOPS		(42 * 24) // Must be multiple of 42 (2 * 3 * 7)
+#define ITERATIONS		5004
+
+static inbuf *inbuffer;
+static cl_mem mem_in, mem_out, mem_salt, mem_state;
+static cl_kernel init_kernel, final_kernel;
+static int new_keys;
+static struct fmt_main *self;
+
+static const char *warn[] = {
+	"keys ", ", init ", ", loop ", ", final ", ", result "
+};
+
+static int split_events[] = { 2, -1, -1 };
+
+// This file contains auto-tuning routine(s). Has to be included after formats definitions.
+#include "opencl_autotune.h"
+
+static void release_clobj(void);
+
+static void create_clobj(size_t gws, struct fmt_main *self)
+{
+	release_clobj();
+
+	inbuffer = mem_calloc(gws, sizeof(inbuf));
+	crypt_out = mem_calloc(gws, sizeof(outbuf));
+
+	CLCREATEBUFFER(mem_in, CL_RO, gws * sizeof(inbuf));
+	CLCREATEBUFFER(mem_out, CL_WO, gws * sizeof(outbuf));
+	CLCREATEBUFFER(mem_state, CL_RW, gws * sizeof(statebuf));
+	CLCREATEBUFFER(mem_salt, CL_RO, sizeof(saltstruct));
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_TRUE, 0, gws * sizeof(inbuf), inbuffer, 0, NULL, NULL), "Copy data to gpu");
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_salt, CL_TRUE, 0, sizeof(saltstruct), &cur_salt, 0, NULL, NULL), "Salt transfer");
+
+	CLKERNELARG(init_kernel, 0, mem_in);
+	CLKERNELARG(init_kernel, 1, mem_salt);
+	CLKERNELARG(init_kernel, 2, mem_state);
+	CLKERNELARG(init_kernel, 3, mem_out);
+
+	CLKERNELARG(crypt_kernel, 0, mem_in);
+	CLKERNELARG(crypt_kernel, 1, mem_salt);
+	CLKERNELARG(crypt_kernel, 2, mem_state);
+	CLKERNELARG(crypt_kernel, 3, mem_out);
+
+	CLKERNELARG(final_kernel, 0, mem_in);
+	CLKERNELARG(final_kernel, 1, mem_salt);
+	CLKERNELARG(final_kernel, 2, mem_state);
+	CLKERNELARG(final_kernel, 3, mem_out);
+
+	global_work_size = gws;
+}
+
+/* ------- Helper functions ------- */
+static size_t get_task_max_work_group_size()
+{
+	size_t s = autotune_get_task_max_work_group_size(FALSE, 0, init_kernel);
+	s = MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, crypt_kernel));
+	return MIN(s, autotune_get_task_max_work_group_size(FALSE, 0, final_kernel));
+}
+
+static void release_clobj(void)
+{
+	if (crypt_out) {
+		HANDLE_CLERROR(clReleaseMemObject(mem_in), "Release mem in");
+		HANDLE_CLERROR(clReleaseMemObject(mem_salt), "Release mem salt");
+		HANDLE_CLERROR(clReleaseMemObject(mem_state), "Release mem state");
+		HANDLE_CLERROR(clReleaseMemObject(mem_out), "Release mem out");
+
+		MEM_FREE(inbuffer);
+		MEM_FREE(crypt_out);
+	}
+}
+
+static void init(struct fmt_main *_self)
+{
+	self = _self;
+
+	opencl_prepare_dev(gpu_id);
+}
+
+static void reset(struct db_main *db)
+{
+	if (!program[gpu_id]) {
+		char build_opts[64];
+
+		snprintf(build_opts, sizeof(build_opts), "-DPLAINTEXT_LENGTH=%u -DHASH_LOOPS=%u",
+		         PLAINTEXT_LENGTH, HASH_LOOPS);
+		opencl_init("$JOHN/opencl/sm3crypt_kernel.cl", gpu_id, build_opts);
+
+		init_kernel = clCreateKernel(program[gpu_id], "sm3crypt_init", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+
+		crypt_kernel = clCreateKernel(program[gpu_id], "sm3crypt_loop", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+
+		final_kernel = clCreateKernel(program[gpu_id], "sm3crypt_final", &ret_code);
+		HANDLE_CLERROR(ret_code, "Error creating kernel");
+	}
+
+	// Initialize openCL tuning (library) for this format.
+	opencl_init_auto_setup(SEED, HASH_LOOPS, split_events, warn,
+	                       2, self, create_clobj, release_clobj,
+	                       sizeof(mem_state), 0, db);
+
+	// Auto tune execution from shared/included code.
+	autotune_run(self, ITERATIONS, 0, 200);
+}
+
+static void done(void)
+{
+	if (program[gpu_id]) {
+		release_clobj();
+
+		HANDLE_CLERROR(clReleaseKernel(final_kernel), "Release kernel");
+		HANDLE_CLERROR(clReleaseKernel(crypt_kernel), "Release kernel");
+		HANDLE_CLERROR(clReleaseKernel(init_kernel), "Release kernel");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program");
+
+		program[gpu_id] = NULL;
+	}
+}
+
+static int valid(char * ciphertext, struct fmt_main * self) {
+	char *pos, *start;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+			return 0;
+
+	ciphertext += FORMAT_TAG_LEN;
+
+	if (!strncmp(ciphertext, ROUNDS_PREFIX, sizeof(ROUNDS_PREFIX) - 1)) {
+		const char *num = ciphertext + sizeof(ROUNDS_PREFIX) - 1;
+		char *endp;
+		if (!strtoul(num, &endp, 10))
+					return 0;
+		if (*endp == '$')
+			ciphertext = endp + 1;
+	}
+	for (pos = ciphertext; *pos && *pos != '$'; pos++);
+	if (!*pos || pos < ciphertext || pos > &ciphertext[SALT_LENGTH]) return 0;
+
+	start = ++pos;
+	while (atoi64[ARCH_INDEX(*pos)] != 0x7F) pos++;
+	if (*pos || pos - start != CIPHERTEXT_LENGTH) return 0;
+	return 1;
+}
+
+/* ------- To binary functions ------- */
+#define TO_BINARY(b1, b2, b3) \
+	value = (uint32_t)atoi64[ARCH_INDEX(pos[0])] | \
+		((uint32_t)atoi64[ARCH_INDEX(pos[1])] << 6) | \
+		((uint32_t)atoi64[ARCH_INDEX(pos[2])] << 12) | \
+		((uint32_t)atoi64[ARCH_INDEX(pos[3])] << 18); \
+	pos += 4; \
+	out[b1] = value >> 16; \
+	out[b2] = value >> 8; \
+	out[b3] = value;
+
+static void * get_binary(char * ciphertext) {
+	static uint32_t outbuf[BINARY_SIZE/4];
+	uint32_t value;
+	char *pos = strrchr(ciphertext, '$') + 1;
+	unsigned char *out = (unsigned char*)outbuf;
+	int i=0;
+
+	do {
+		TO_BINARY(i, (i+10)%30, (i+20)%30);
+		i = (i+21)%30;
+	} while (i != 0);
+	value = (uint32_t)atoi64[ARCH_INDEX(pos[0])] |
+		((uint32_t)atoi64[ARCH_INDEX(pos[1])] << 6) |
+		((uint32_t)atoi64[ARCH_INDEX(pos[2])] << 12);
+	out[31] = value >> 8;
+	out[30] = value;
+	return (void *)out;
+}
+
+static void set_salt(void *salt)
+{
+	memcpy(&cur_salt, salt, sizeof(saltstruct));
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_salt, CL_FALSE, 0, sizeof(saltstruct), &cur_salt, 0, NULL, NULL), "Salt transfer");
+	HANDLE_CLERROR(clFlush(queue[gpu_id]), "clFlush failed in set_salt()");
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	size_t *lws = local_work_size ? &local_work_size : NULL;
+	size_t gws = GET_KPC_MULTIPLE(count, local_work_size);
+	int index;
+
+	// Copy data to gpu
+	if (new_keys) {
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], mem_in, CL_FALSE, 0, gws * sizeof(inbuf), inbuffer, 0, NULL, multi_profilingEvent[0]), "Copy data to gpu");
+
+		new_keys = 0;
+	}
+
+	// Run kernel
+	CLRUNKERNEL(init_kernel, &gws, lws, multi_profilingEvent[1]);
+
+	uint loops = (ocl_autotune_running ? 1 : cur_salt.rounds / HASH_LOOPS);
+	WAIT_INIT(gws)
+	for (index = 0; index < loops; index++) {
+		CLRUNKERNEL(crypt_kernel, &gws, lws, multi_profilingEvent[2]);
+		WAIT_SLEEP
+		CLFINISH();
+		WAIT_UPDATE
+		opencl_process_event();
+	}
+	WAIT_DONE
+
+	CLRUNKERNEL(final_kernel, &gws, lws, multi_profilingEvent[3]);
+
+	// Read the result back
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], mem_out, CL_TRUE, 0, gws * sizeof(outbuf), crypt_out, 0, NULL, multi_profilingEvent[4]), "Copy result back");
+
+	return count;
+}
+
+static void *get_salt(char *ciphertext)
+{
+	int len;
+
+	memset(&cur_salt, 0, sizeof(cur_salt));
+	cur_salt.rounds = ROUNDS_DEFAULT;
+	ciphertext += FORMAT_TAG_LEN;
+	if (!strncmp(ciphertext, ROUNDS_PREFIX,
+	             sizeof(ROUNDS_PREFIX) - 1)) {
+		const char *num = ciphertext + sizeof(ROUNDS_PREFIX) - 1;
+		char *endp;
+		unsigned long int srounds = strtoul(num, &endp, 10);
+		if (*endp == '$')
+		{
+			ciphertext = endp + 1;
+			srounds = srounds < ROUNDS_MIN ?
+				ROUNDS_MIN : srounds;
+			cur_salt.rounds = srounds > ROUNDS_MAX ?
+				ROUNDS_MAX : srounds;
+		}
+	}
+
+	for (len = 0; ciphertext[len] != '$'; len++);
+
+	if (len > SALT_LENGTH)
+		len = SALT_LENGTH;
+
+	memcpy(cur_salt.salt, ciphertext, len);
+	cur_salt.len = len;
+	return &cur_salt;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (!memcmp(binary, crypt_out[index].v, ARCH_SIZE))
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index].v, BINARY_SIZE);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+static void set_key(char *key, int index)
+{
+	inbuffer[index].len = strlen(key);
+
+	memcpy(inbuffer[index].key, key, inbuffer[index].len);
+
+	new_keys = 1;
+}
+
+static char* get_key(int index)
+{
+	static char out[PLAINTEXT_LENGTH + 1];
+
+	memcpy(out, inbuffer[index].key, inbuffer[index].len);
+	out[inbuffer[index].len] = 0;
+
+	return out;
+}
+
+// Public domain hash function by DJ Bernstein
+// We are hashing the entire struct, so rounds get included
+static int salt_hash(void *salt)
+{
+	unsigned char *s = salt;
+	unsigned int hash = 5381;
+	unsigned int i;
+
+	for (i = 0; i < SALT_SIZE; i++)
+		hash = ((hash << 5) + hash) ^ s[i];
+
+	return hash & (SALT_HASH_SIZE - 1);
+}
+
+static unsigned int iteration_count(void *salt)
+{
+	saltstruct *p = salt;
+	return p->rounds;
+}
+
+#define COMMON_GET_HASH_VAR crypt_out
+#include "common-get-hash.h"
+
+struct fmt_main fmt_opencl_cryptsm3 = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT,
+		{
+			"iteration count",
+		},
+		{ FORMAT_TAG },
+		tests
+	}, {
+		init,
+		done,
+		reset,
+		fmt_default_prepare,
+		valid,
+		fmt_default_split,
+		get_binary,
+		get_salt,
+		{
+			iteration_count,
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
+		},
+		salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+#define COMMON_GET_HASH_LINK
+#include "common-get-hash.h"
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */
+#endif /* HAVE_OPENCL */

--- a/src/rawSM3_fmt_plug.c
+++ b/src/rawSM3_fmt_plug.c
@@ -38,7 +38,7 @@ john_register_one(&fmt_sm3);
 #define BENCHMARK_COMMENT  ""
 #define BENCHMARK_LENGTH   0x107
 #define PLAINTEXT_LENGTH   MAX_PLAINTEXT_LENGTH
-#define BINARY_SIZE        sm3_hash_length
+#define BINARY_SIZE        SM3_HASH_LENGTH
 #define BINARY_ALIGN       4
 #define SALT_SIZE          0
 #define SALT_ALIGN         1
@@ -85,7 +85,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 
 	if (!strncmp(p, FORMAT_TAG, TAG_LENGTH))
 		p += TAG_LENGTH;
-	if (hexlenl(p, &extra) != (2 * sm3_hash_length) || extra)
+	if (hexlenl(p, &extra) != (2 * SM3_HASH_LENGTH) || extra)
 		return 0;
 
 	return 1;

--- a/src/rawSM3_fmt_plug.c
+++ b/src/rawSM3_fmt_plug.c
@@ -30,10 +30,11 @@ john_register_one(&fmt_sm3);
 
 #include "sm3.h"
 
-#define FORMAT_LABEL       "SM3"
+#define FORMAT_LABEL       "Raw-SM3"
+#define FORMAT_NAME        "ShangMi 3"
 #define FORMAT_TAG         "$raw-sm3$"
 #define TAG_LENGTH         (sizeof(FORMAT_TAG)-1)
-#define ALGORITHM_NAME     "32/" ARCH_BITS_STR
+#define ALGORITHM_NAME     "SM3 32/" ARCH_BITS_STR
 #define BENCHMARK_COMMENT  ""
 #define BENCHMARK_LENGTH   0x107
 #define PLAINTEXT_LENGTH   MAX_PLAINTEXT_LENGTH
@@ -179,7 +180,7 @@ static char *get_key(int index)
 struct fmt_main fmt_sm3 = {
 	{
 		FORMAT_LABEL,
-		"",
+		FORMAT_NAME,
 		ALGORITHM_NAME,
 		BENCHMARK_COMMENT,
 		BENCHMARK_LENGTH,

--- a/src/simd-intrinsics.c
+++ b/src/simd-intrinsics.c
@@ -1727,7 +1727,7 @@ void SIMDSHA1body(vtype* _data, uint32_t *out, uint32_t *reload_state,
 #define Maj(x,y,z) vor(vand(x, y), vand(vor(x, y), z))
 #endif
 
-#define Ch(x,y,z) vcmov(y, z, x)
+#define Ch(x,y,z) vcmov(y, z, x) // Same as vternarylogic(x, y, z, 0xCA)
 
 #undef R
 #define R(t)                                                \

--- a/src/sm3.c
+++ b/src/sm3.c
@@ -184,7 +184,7 @@ void sm3_compress_blocks(uint32_t hash[8], const uint8_t *data, size_t blocks)
 		hash[6] ^= G;
 		hash[7] ^= H;
 
-		data += sm3_block_size;
+		data += SM3_BLOCK_SIZE;
 	}
 }
 
@@ -208,7 +208,7 @@ void sm3_update(sm3_ctx *ctx, const unsigned char *data, size_t size)
 
 	ctx->num &= 0x3f;
 	if (ctx->num) {
-		size_t left = sm3_block_size - ctx->num;
+		size_t left = SM3_BLOCK_SIZE - ctx->num;
 
 		if (size < left) {
 			memcpy(ctx->block + ctx->num, data, size);
@@ -223,12 +223,12 @@ void sm3_update(sm3_ctx *ctx, const unsigned char *data, size_t size)
 		}
 	}
 
-	blocks = size / sm3_block_size;
+	blocks = size / SM3_BLOCK_SIZE;
 	if (blocks) {
 		sm3_compress_blocks(ctx->hash, data, blocks);
 		ctx->num_blocks += blocks;
-		data += sm3_block_size * blocks;
-		size -= sm3_block_size * blocks;
+		data += SM3_BLOCK_SIZE * blocks;
+		size -= SM3_BLOCK_SIZE * blocks;
 	}
 
 	ctx->num = size;
@@ -244,12 +244,12 @@ void sm3_final(sm3_ctx *ctx, unsigned char *result)
 	ctx->num &= 0x3f;
 	ctx->block[ctx->num] = 0x80;
 
-	if (ctx->num <= sm3_block_size - 9) {
-		memset(ctx->block + ctx->num + 1, 0, sm3_block_size - ctx->num - 9);
+	if (ctx->num <= SM3_BLOCK_SIZE - 9) {
+		memset(ctx->block + ctx->num + 1, 0, SM3_BLOCK_SIZE - ctx->num - 9);
 	} else {
-		memset(ctx->block + ctx->num + 1, 0, sm3_block_size - ctx->num - 1);
+		memset(ctx->block + ctx->num + 1, 0, SM3_BLOCK_SIZE - ctx->num - 1);
 		sm3_compress_blocks(ctx->hash, ctx->block, 1);
-		memset(ctx->block, 0, sm3_block_size - 8);
+		memset(ctx->block, 0, SM3_BLOCK_SIZE - 8);
 	}
 
 	PUTU32(ctx->block + 56, ctx->num_blocks >> 23);

--- a/src/sm3.h
+++ b/src/sm3.h
@@ -19,13 +19,13 @@
 extern "C" {
 #endif
 
-#define sm3_block_size 64
-#define sm3_hash_length 32
+#define SM3_BLOCK_SIZE 64
+#define SM3_HASH_LENGTH 32
 
 /* algorithm context */
 typedef struct sm3_ctx {
 	uint32_t hash[8];       /* 256-bit hash */
-	unsigned char block[sm3_block_size];    /* 512-bit message block */
+	unsigned char block[SM3_BLOCK_SIZE];    /* 512-bit message block */
 	uint64_t num_blocks;    /* processed number of blocks */
 	uint64_t num;           /* index in the buffer of the last byte stored */
 } sm3_ctx;

--- a/src/sm3crypt_fmt_plug.c
+++ b/src/sm3crypt_fmt_plug.c
@@ -1,0 +1,443 @@
+/*
+ * This software is Copyright (c) 2025 magnum,
+ * and it is hereby released to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * Based on Drepper's sha2crypt spec at
+ * http://www.akkadia.org/drepper/SHA-crypt.txt
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_sm3crypt;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_sm3crypt);
+#else
+
+#define _GNU_SOURCE 1
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "arch.h"
+#include "sm3.h"
+#include "params.h"
+#include "common.h"
+#include "formats.h"
+#include "johnswap.h"
+
+#ifndef OMP_SCALE
+#define OMP_SCALE               16
+#endif
+
+#define FORMAT_LABEL            "sm3crypt"
+#define FORMAT_NAME             "crypt(3) " FORMAT_TAG
+
+#define ALGORITHM_NAME          "SM3 32/" ARCH_BITS_STR
+
+#define PLAINTEXT_LENGTH        MAX_PLAINTEXT_LENGTH
+
+#define SALT_SIZE               sizeof(struct saltstruct)
+
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+
+#define BLKS                    MIN_KEYS_PER_CRYPT
+
+/* Prefix for optional rounds specification. */
+#define ROUNDS_PREFIX           "rounds="
+/* Default number of rounds if not explicitly specified. */
+#define ROUNDS_DEFAULT          5000
+/* Minimum number of rounds. */
+#define ROUNDS_MIN              1   /* Drepper has it as 1000 */
+/* Maximum number of rounds. */
+#define ROUNDS_MAX              999999999
+
+#define BENCHMARK_COMMENT       " (rounds=5000)"
+#define BENCHMARK_LENGTH        0x107
+#define CIPHERTEXT_LENGTH       43
+
+#define BINARY_SIZE             32
+#define BINARY_ALIGN            4
+#define SALT_LENGTH             16
+#define SALT_ALIGN              4
+#define FORMAT_TAG              "$sm3$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG)-1)
+
+static int (*saved_len);
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static uint32_t (*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+
+static struct saltstruct {
+	unsigned int len;
+	unsigned int rounds;
+	unsigned char salt[SALT_LENGTH];
+} *cur_salt;
+
+static struct fmt_tests tests[] = {
+	{"$sm3$short$25nyMuun660zbmb99lNsRuPcp8Xnnxo3DzAp6/PXLg8", "abcdefg"},
+	{"$sm3$saltstring$341ZVXHGiF5lVl6/blvPdxBm9OOel8BBlZ968uFss22", "01234567"},
+	{"$sm3$short$l7cf63qpDl6T3LiQe2BflvskU.ROdXVoK4MRMfv5kN7", "cr1234567"},
+	{"$sm3$rounds=5000$short$kBQlhEiwZoX5oNxAampnJBOlAR.rlPC/0LRvR76Sh26", "ab1234567"},
+	{"$sm3$rounds=1000$short$6BJR/TAUf/WrA.mVRBafKccfX4CnqvKZAWgdVeLUdu4", "*U*U*U*U*U*U*U*U*"},
+#if PLAINTEXT_LENGTH >= 60
+	{"$sm3$rounds=1000$saltstring$rhtCacI9n9hLTXouopGunTofK4hDbU3PYZeKSbVlY5D", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"},
+	{"$sm3$short$4r1RgwZCB.EQL/MJnaw0hxGdvJ0aFp3Wg0FJf7bs6O8", "THE YEAR 1866 was marked by a bizarre development, an unexplained and downright inexplicable phenomenon that surely no one has f"},
+#endif
+	{NULL}
+};
+
+static int valid(char * ciphertext, struct fmt_main * self) {
+	char *pos, *start;
+
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN))
+		return 0;
+
+	ciphertext += FORMAT_TAG_LEN;
+
+	if (!strncmp(ciphertext, ROUNDS_PREFIX, sizeof(ROUNDS_PREFIX) - 1)) {
+		const char *num = ciphertext + sizeof(ROUNDS_PREFIX) - 1;
+		char *endp;
+		if (!strtoul(num, &endp, 10))
+			return 0;
+		if (*endp == '$')
+			ciphertext = endp + 1;
+	}
+	for (pos = ciphertext; *pos && *pos != '$'; pos++);
+	if (!*pos || pos < ciphertext) return 0;
+
+	start = ++pos;
+	while (atoi64[ARCH_INDEX(*pos)] != 0x7F) pos++;
+	if (*pos || pos - start != CIPHERTEXT_LENGTH) return 0;
+	return 1;
+}
+
+/* ------- To binary functions ------- */
+#define TO_BINARY(b1, b2, b3)	  \
+	value = (uint32_t)atoi64[ARCH_INDEX(pos[0])] | \
+		((uint32_t)atoi64[ARCH_INDEX(pos[1])] << 6) | \
+		((uint32_t)atoi64[ARCH_INDEX(pos[2])] << 12) | \
+		((uint32_t)atoi64[ARCH_INDEX(pos[3])] << 18); \
+	pos += 4; \
+	out[b1] = value >> 16; \
+	out[b2] = value >> 8; \
+	out[b3] = value;
+
+static void * get_binary(char * ciphertext) {
+	static uint32_t outbuf[BINARY_SIZE/4];
+	uint32_t value;
+	char *pos = strrchr(ciphertext, '$') + 1;
+	unsigned char *out = (unsigned char*)outbuf;
+	int i=0;
+
+	do {
+		TO_BINARY(i, (i+10)%30, (i+20)%30);
+		i = (i+21)%30;
+	} while (i != 0);
+	value = (uint32_t)atoi64[ARCH_INDEX(pos[0])] |
+		((uint32_t)atoi64[ARCH_INDEX(pos[1])] << 6) |
+		((uint32_t)atoi64[ARCH_INDEX(pos[2])] << 12);
+	out[31] = value >> 8;
+	out[30] = value;
+	return (void *)out;
+}
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+
+	saved_len = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_len));
+	saved_key = mem_calloc(self->params.max_keys_per_crypt, sizeof(*saved_key));
+	crypt_out = mem_calloc(self->params.max_keys_per_crypt, sizeof(*crypt_out));
+}
+
+static void done(void)
+{
+	MEM_FREE(crypt_out);
+	MEM_FREE(saved_key);
+	MEM_FREE(saved_len);
+}
+
+#define COMMON_GET_HASH_VAR crypt_out
+#include "common-get-hash.h"
+
+static void set_key(char *key, int index)
+{
+	saved_len[index] = strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+}
+
+static char *get_key(int index)
+{
+	saved_key[index][saved_len[index]] = 0;
+	return saved_key[index];
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	int index;
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+	for (index = 0; index < count; index++) {
+		unsigned char temp_result[BINARY_SIZE];
+		sm3_ctx ctx;
+		sm3_ctx alt_ctx;
+		size_t cnt;
+		unsigned char *cp;
+		unsigned char p_bytes[PLAINTEXT_LENGTH + 1];
+		unsigned char s_bytes[PLAINTEXT_LENGTH + 1];
+
+		/* Prepare for the real work. */
+		sm3_init(&ctx);
+
+		/* Add the key string. */
+		sm3_update(&ctx, (unsigned char*)saved_key[index], saved_len[index]);
+
+		/* The last part is the salt string.  This must be at most 16
+		   characters and it ends at the first `$' character (for
+		   compatibility with existing implementations). */
+		sm3_update(&ctx, cur_salt->salt, cur_salt->len);
+
+
+		/* Compute alternate SM3 hash with input KEY, SALT, and KEY.  The
+		   final result will be added to the first context. */
+		sm3_init(&alt_ctx);
+
+		/* Add key. */
+		sm3_update(&alt_ctx, (unsigned char*)saved_key[index], saved_len[index]);
+
+		/* Add salt. */
+		sm3_update(&alt_ctx, cur_salt->salt, cur_salt->len);
+
+		/* Add key again. */
+		sm3_update(&alt_ctx, (unsigned char*)saved_key[index], saved_len[index]);
+
+		/* Now get result of this (32 bytes) and add it to the other context. */
+		sm3_final(&alt_ctx, (unsigned char*)crypt_out[index]);
+
+		/* Add for any character in the key one byte of the alternate sum. */
+		for (cnt = saved_len[index]; cnt > BINARY_SIZE; cnt -= BINARY_SIZE)
+			sm3_update(&ctx, (unsigned char*)crypt_out[index], BINARY_SIZE);
+		sm3_update(&ctx, (unsigned char*)crypt_out[index], cnt);
+
+		/* Take the binary representation of the length of the key and for every
+		   1 add the alternate sum, for every 0 the key. */
+		for (cnt = saved_len[index]; cnt > 0; cnt >>= 1)
+			if ((cnt & 1) != 0)
+				sm3_update(&ctx, (unsigned char*)crypt_out[index], BINARY_SIZE);
+			else
+				sm3_update(&ctx, (unsigned char*)saved_key[index], saved_len[index]);
+
+		/* Create intermediate result. */
+		sm3_final(&ctx, (unsigned char*)crypt_out[index]);
+
+		/* Start computation of P byte sequence. */
+		sm3_init(&alt_ctx);
+
+		/* For every character in the password add the entire password. */
+		for (cnt = 0; cnt < saved_len[index]; ++cnt)
+			sm3_update(&alt_ctx, (unsigned char*)saved_key[index], saved_len[index]);
+
+		/* Finish the digest. */
+		sm3_final(&alt_ctx, temp_result);
+
+		/* Create byte sequence P. */
+		cp = p_bytes;
+		for (cnt = saved_len[index]; cnt >= BINARY_SIZE; cnt -= BINARY_SIZE)
+			cp = (unsigned char*)memcpy(cp, temp_result, BINARY_SIZE) + BINARY_SIZE;
+		memcpy(cp, temp_result, cnt);
+
+		/* Start computation of S byte sequence. */
+		sm3_init(&alt_ctx);
+
+		/* For every character in the password add the entire password. */
+		for (cnt = 0; cnt < 16 + ((unsigned char*)crypt_out[index])[0]; ++cnt)
+			sm3_update(&alt_ctx, cur_salt->salt, cur_salt->len);
+
+		/* Finish the digest. */
+		sm3_final(&alt_ctx, temp_result);
+
+		/* Create byte sequence S. */
+		cp = s_bytes;
+		for (cnt = cur_salt->len; cnt >= BINARY_SIZE; cnt -= BINARY_SIZE)
+			cp = (unsigned char*)memcpy(cp, temp_result, BINARY_SIZE) + BINARY_SIZE;
+		memcpy(cp, temp_result, cnt);
+
+		/* Repeatedly run the collected hash value through SM3 to burn CPU cycles. */
+		for (cnt = 0; cnt < cur_salt->rounds; ++cnt) {
+			/* New context. */
+			sm3_init(&ctx);
+
+			/* Add key or last result. */
+			if ((cnt & 1) != 0)
+				sm3_update(&ctx, p_bytes, saved_len[index]);
+			else
+				sm3_update(&ctx, (unsigned char*)crypt_out[index], BINARY_SIZE);
+
+			/* Add salt for numbers not divisible by 3. */
+			if (cnt % 3 != 0)
+				sm3_update(&ctx, s_bytes, cur_salt->len);
+
+			/* Add key for numbers not divisible by 7. */
+			if (cnt % 7 != 0)
+				sm3_update(&ctx, p_bytes, saved_len[index]);
+
+			/* Add key or last result. */
+			if ((cnt & 1) != 0)
+				sm3_update(&ctx, (unsigned char*)crypt_out[index], BINARY_SIZE);
+			else
+				sm3_update(&ctx, p_bytes, saved_len[index]);
+
+			/* Create intermediate result. */
+			sm3_final(&ctx, (unsigned char*)crypt_out[index]);
+		}
+	}
+
+	return count;
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = salt;
+}
+
+static void *get_salt(char *ciphertext)
+{
+	static struct saltstruct out;
+	int len;
+
+	memset(&out, 0, sizeof(out));
+	out.rounds = ROUNDS_DEFAULT;
+	ciphertext += FORMAT_TAG_LEN;
+	if (!strncmp(ciphertext, ROUNDS_PREFIX,
+	             sizeof(ROUNDS_PREFIX) - 1)) {
+		const char *num = ciphertext + sizeof(ROUNDS_PREFIX) - 1;
+		char *endp;
+		unsigned long int srounds = strtoul(num, &endp, 10);
+		if (*endp == '$')
+		{
+			ciphertext = endp + 1;
+			srounds = srounds < ROUNDS_MIN ?
+				ROUNDS_MIN : srounds;
+			out.rounds = srounds > ROUNDS_MAX ?
+				ROUNDS_MAX : srounds;
+		}
+	}
+
+	for (len = 0; ciphertext[len] != '$'; len++);
+
+	if (len > SALT_LENGTH)
+		len = SALT_LENGTH;
+
+	memcpy(out.salt, ciphertext, len);
+	out.len = len;
+	return &out;
+}
+
+static int cmp_all(void *binary, int count)
+{
+	int index;
+
+	for (index = 0; index < count; index++)
+		if (!memcmp(binary, crypt_out[index], ARCH_SIZE))
+			return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+static unsigned int iteration_count(void *salt)
+{
+	struct saltstruct *sm3crypt_salt;
+
+	sm3crypt_salt = salt;
+	return (unsigned int)sm3crypt_salt->rounds;
+}
+
+// We are hashing the entire struct
+static int salt_hash(void *salt)
+{
+	unsigned char *s = salt;
+	unsigned int hash = 5381;
+	unsigned int i;
+
+	for (i = 0; i < SALT_SIZE; i++)
+		hash = ((hash << 5) + hash) ^ s[i];
+
+	return hash & (SALT_HASH_SIZE - 1);
+}
+
+struct fmt_main fmt_sm3crypt = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		{
+			"iteration count",
+		},
+		{ FORMAT_TAG },
+		tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		valid,
+		fmt_default_split,
+		get_binary,
+		get_salt,
+		{
+			iteration_count,
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
+		},
+		salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+#define COMMON_GET_HASH_LINK
+#include "common-get-hash.h"
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif /* plugin stanza */


### PR DESCRIPTION
Add SM3crypt formats. These are Drepper-style crypt(3) formats, using Shang Mi 3 hash (SM3) which is a Chinese replacement for SHA-256.
    
They were seen in CMIYC 2024 but are also used in the wild, presumably in Chinese Linux distros.