### PR TITLE
Makefile: Have 'make clean' force a rescan of plugins

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -588,7 +588,7 @@ kernel-cache-clean-john:
 kernel-cache-clean: kernel-cache-clean-nvidia kernel-cache-clean-john
 
 clean:
-	$(RM) $(PROJ)
+	$(RM) $(PROJ) fmt_registers.h fmt_externs.h
 	@for exe in ${PROJ}; do \
 	  ($(RM) $$exe.exe) \
 	done


### PR DESCRIPTION
Re-running configure could result in a different set of formats included/excluded, resulting in very confusing problems despite a "make clean".