### PR TITLE
7z: Change "data length" cost to reflect "data length penalty"

### DIFF
--- a/src/7z_common.h
+++ b/src/7z_common.h
@@ -60,6 +60,6 @@ extern int sevenzip_decrypt(unsigned char *derived_key);
 extern unsigned int sevenzip_iteration_count(void *salt);
 extern unsigned int sevenzip_padding_size(void *salt);
 extern unsigned int sevenzip_compression_type(void *salt);
-extern unsigned int sevenzip_data_len(void *salt);
+extern unsigned int sevenzip_size_penalty(void *salt);
 
 #endif /* _7Z_COMMON_H */

--- a/src/7z_common_plug.c
+++ b/src/7z_common_plug.c
@@ -678,10 +678,21 @@ unsigned int sevenzip_compression_type(void *salt)
 	return my_salt->type;
 }
 
-unsigned int sevenzip_data_len(void *salt)
+unsigned int sevenzip_size_penalty(void *salt)
 {
-	sevenzip_salt_t *my_salt;
+	sevenzip_salt_t *my_salt = *((sevenzip_salt_t**)salt);
+	uint32_t pad_size = sevenzip_padding_size(salt);
+	uint64_t e_size = my_salt->packed_size;
 
-	my_salt = *((sevenzip_salt_t**)salt);
-	return my_salt->packed_size;
+	/* Consider early reject */
+	if (sevenzip_trust_padding) {
+		int shift = pad_size * 8;
+
+		if (shift < 64)
+			e_size >>= shift;
+		else
+			e_size = 0;
+	}
+
+	return (unsigned int)MIN(UINT_MAX, e_size);
 }

--- a/src/7z_fmt_plug.c
+++ b/src/7z_fmt_plug.c
@@ -366,7 +366,7 @@ struct fmt_main fmt_sevenzip = {
 			"iteration count",
 			"padding size",
 			"compression type",
-			"data length"
+			"data size penalty"
 		},
 		{ FORMAT_TAG },
 		sevenzip_tests
@@ -383,7 +383,7 @@ struct fmt_main fmt_sevenzip = {
 			sevenzip_iteration_count,
 			sevenzip_padding_size,
 			sevenzip_compression_type,
-			sevenzip_data_len
+			sevenzip_size_penalty
 		},
 		fmt_default_source,
 		{

--- a/src/opencl_7z_fmt_plug.c
+++ b/src/opencl_7z_fmt_plug.c
@@ -433,7 +433,7 @@ struct fmt_main fmt_opencl_sevenzip = {
 			"iteration count",
 			"padding size",
 			"compression type",
-			"data length"
+			"data size penalty"
 		},
 		{ FORMAT_TAG },
 		sevenzip_tests
@@ -450,7 +450,7 @@ struct fmt_main fmt_opencl_sevenzip = {
 			sevenzip_iteration_count,
 			sevenzip_padding_size,
 			sevenzip_compression_type,
-			sevenzip_data_len
+			sevenzip_size_penalty
 		},
 		fmt_default_source,
 		{


### PR DESCRIPTION
Make this the default as none of the others are very useful other than for information.

I'm still fond of the other costs so this had to bump FMT_TUNABLE_COSTS to 5. I have wanted to do so before, I think it can't hurt - even though some "costs" are more important for information than for filtering.