### PR TITLE
Bugfix: Avoid a use-after-free due to late use of tiny-alloc'd buffer

### DIFF
--- a/src/john.c
+++ b/src/john.c
@@ -1995,7 +1995,6 @@ static void john_done(void)
 	path_done();
 
 	ldr_free_db(&database, 0);
-	cleanup_tiny_memory();
 	check_abort(0);
 }
 
@@ -2034,6 +2033,8 @@ int main(int argc, char **argv)
 	if (strlen(name) > 4 && !strcmp(name + strlen(name) - 4, ".exe"))
 		name[strlen(name) - 4] = 0;
 #endif
+
+	atexit(cleanup_tiny_memory);
 
 #ifdef _MSC_VER
 /*

--- a/src/memory.c
+++ b/src/memory.c
@@ -58,7 +58,7 @@ static void add_memory_link(void *v) {
 	p->mem = v;
 	mem_alloc_tiny_memory = p;
 }
-// call at program exit.
+
 void cleanup_tiny_memory()
 {
 	struct rm_list *p = mem_alloc_tiny_memory, *p2;

--- a/src/memory.h
+++ b/src/memory.h
@@ -177,7 +177,7 @@ extern char *str_alloc_copy(const char *src);
 /*
  * This will 'cleanup' the memory allocated by mem_alloc_tiny().  All
  * of that memory was 'blindly' allocated, and not freed up during
- * the run of john.  Now, it is 'cleaned' up.
+ * the run of john.  Called via atexit().
  */
 extern void cleanup_tiny_memory();
 

--- a/src/options.c
+++ b/src/options.c
@@ -653,7 +653,6 @@ void opt_init(char *name, int argc, char **argv)
 		}
 #endif
 		path_done();
-		cleanup_tiny_memory();
 		exit(0);
 	}
 	if (costs_str) {

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -489,7 +489,6 @@ void rec_done(int save)
 static void rec_format_error(char *fn)
 {
 	path_done();
-	cleanup_tiny_memory();
 
 	if (fn && errno && ferror(rec_file))
 		pexit("%s", fn);

--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -1186,7 +1186,5 @@ int zip2john(int argc, char **argv)
 		}
 	}
 
-	cleanup_tiny_memory();
-
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
When check_abort() printed the session name, we had already called cleanup_tiny_memory() which resulted in segfault and ASan trigger.

We now call cleanup_tiny_memory() via atexit() instead.