### PR TITLE
Make tag checks case-sensitive in a few formats that had it wrong

### DIFF
--- a/src/oracle12c_fmt_plug.c
+++ b/src/oracle12c_fmt_plug.c
@@ -100,7 +100,7 @@ static int valid(char *ciphertext, struct fmt_main *self)
 {
 	char *p = ciphertext;
 
-	if (strncasecmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
 		return 0;
 
 	if (strlen(ciphertext) > (FORMAT_TAG_LENGTH + CIPHERTEXT_LENGTH))

--- a/src/pbkdf2_hmac_common_plug.c
+++ b/src/pbkdf2_hmac_common_plug.c
@@ -382,7 +382,7 @@ int pbkdf2_hmac_sha1_valid(char *ciphertext, struct fmt_main *self) {
 	size_t len;
 	char *delim;
 
-	if (strncasecmp(ciphertext, PBKDF2_SHA1_FORMAT_TAG, PBKDF2_SHA1_TAG_LEN))
+	if (strncmp(ciphertext, PBKDF2_SHA1_FORMAT_TAG, PBKDF2_SHA1_TAG_LEN))
 		return 0;
 	if (strlen(ciphertext) > PBKDF2_SHA1_MAX_CIPHERTEXT_LENGTH)
 		return 0;

--- a/src/pfx_common_plug.c
+++ b/src/pfx_common_plug.c
@@ -14,7 +14,7 @@ int pfx_valid(char *ciphertext, struct fmt_main *self)
 	char *p = ciphertext, *ctcopy, *keeptr;
 	int mac_algo, saltlen, hashhex, extra;
 
-	if (strncasecmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
 		return 0;
 	ctcopy = xstrdup(ciphertext);
 	keeptr = ctcopy;

--- a/src/rawSHA512_common_plug.c
+++ b/src/rawSHA512_common_plug.c
@@ -152,7 +152,7 @@ int sha512_common_valid_nsldap(char *ciphertext, struct fmt_main *self)
 {
 	int len;
 
-	if (strncasecmp(ciphertext, NSLDAP_FORMAT_TAG, NSLDAP_TAG_LENGTH))
+	if (strncmp(ciphertext, NSLDAP_FORMAT_TAG, NSLDAP_TAG_LENGTH))
 		return 0;
 	ciphertext += NSLDAP_TAG_LENGTH;
 

--- a/src/salted_sha1_common_plug.c
+++ b/src/salted_sha1_common_plug.c
@@ -51,7 +51,7 @@ int salted_sha1_common_valid(char *ciphertext, struct fmt_main *self)
 	int len, real_len;
 	char buf[MAX_SALT_LEN+BINARY_SIZE+8];
 
-	if (strncasecmp(ciphertext, NSLDAP_MAGIC, NSLDAP_MAGIC_LENGTH))
+	if (strncmp(ciphertext, NSLDAP_MAGIC, NSLDAP_MAGIC_LENGTH))
 		return 0;
 	ciphertext += NSLDAP_MAGIC_LENGTH;
 

--- a/src/sapH_fmt_plug.c
+++ b/src/sapH_fmt_plug.c
@@ -648,10 +648,10 @@ static void *get_binary(char *ciphertext)
 	char *cp = ciphertext;
 
 	memset(b.cp, 0, sizeof(b.cp));
-	if (!strncasecmp(cp, FORMAT_TAG, FORMAT_TAG_LEN)) { cp += FORMAT_TAG_LEN; }
-	else if (!strncasecmp(cp, FORMAT_TAG256, FORMAT_TAG256_LEN)) { cp += FORMAT_TAG256_LEN; }
-	else if (!strncasecmp(cp, FORMAT_TAG384, FORMAT_TAG384_LEN)) { cp += FORMAT_TAG384_LEN; }
-	else if (!strncasecmp(cp, FORMAT_TAG512, FORMAT_TAG512_LEN)) { cp += FORMAT_TAG512_LEN; }
+	if (!strncmp(cp, FORMAT_TAG, FORMAT_TAG_LEN)) { cp += FORMAT_TAG_LEN; }
+	else if (!strncmp(cp, FORMAT_TAG256, FORMAT_TAG256_LEN)) { cp += FORMAT_TAG256_LEN; }
+	else if (!strncmp(cp, FORMAT_TAG384, FORMAT_TAG384_LEN)) { cp += FORMAT_TAG384_LEN; }
+	else if (!strncmp(cp, FORMAT_TAG512, FORMAT_TAG512_LEN)) { cp += FORMAT_TAG512_LEN; }
 	else { fprintf(stderr, "error, bad signature in sap-H format!\n"); error(); }
 	while (*cp != '}') ++cp;
 	++cp;
@@ -669,10 +669,10 @@ static void *get_salt(char *ciphertext)
 	int total_len, hash_len = 0;
 
 	memset(&s, 0, sizeof(s));
-	if (!strncasecmp(cp, FORMAT_TAG, FORMAT_TAG_LEN)) { s.type = 1; cp += FORMAT_TAG_LEN; hash_len = SHA1_BINARY_SIZE; }
-	else if (!strncasecmp(cp, FORMAT_TAG256, FORMAT_TAG256_LEN)) { s.type = 2; cp += FORMAT_TAG256_LEN; hash_len = SHA256_BINARY_SIZE; }
-	else if (!strncasecmp(cp, FORMAT_TAG384, FORMAT_TAG384_LEN)) { s.type = 3; cp += FORMAT_TAG384_LEN; hash_len = SHA384_BINARY_SIZE; }
-	else if (!strncasecmp(cp, FORMAT_TAG512, FORMAT_TAG512_LEN)) { s.type = 4; cp += FORMAT_TAG512_LEN; hash_len = SHA512_BINARY_SIZE; }
+	if (!strncmp(cp, FORMAT_TAG, FORMAT_TAG_LEN)) { s.type = 1; cp += FORMAT_TAG_LEN; hash_len = SHA1_BINARY_SIZE; }
+	else if (!strncmp(cp, FORMAT_TAG256, FORMAT_TAG256_LEN)) { s.type = 2; cp += FORMAT_TAG256_LEN; hash_len = SHA256_BINARY_SIZE; }
+	else if (!strncmp(cp, FORMAT_TAG384, FORMAT_TAG384_LEN)) { s.type = 3; cp += FORMAT_TAG384_LEN; hash_len = SHA384_BINARY_SIZE; }
+	else if (!strncmp(cp, FORMAT_TAG512, FORMAT_TAG512_LEN)) { s.type = 4; cp += FORMAT_TAG512_LEN; hash_len = SHA512_BINARY_SIZE; }
 	else { fprintf(stderr, "error, bad signature in sap-H format!\n"); error(); }
 	sscanf(cp, "%u", &s.iter);
 	while (*cp != '}') ++cp;

--- a/src/zed_common_plug.c
+++ b/src/zed_common_plug.c
@@ -25,7 +25,7 @@ int zed_valid(char *ciphertext, struct fmt_main *self)
 	char *p = ciphertext, *ctcopy, *keeptr;
 	int version, algo, extra;
 
-	if (strncasecmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
+	if (strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LENGTH))
 		return 0;
 	ctcopy = xstrdup(ciphertext);
 	keeptr = ctcopy;


### PR DESCRIPTION
Tags could very well be case insensitive, but only if we see that in a spec or in the wild and to the best of my knowledge this doesn't apply to any of these formats.  Some of them even have their tags made with our own *2john tools (which I then checked).

I also made sure nothing in our tree nor in the Test Suite has these tags in a different case.

The only format that had me uncertain was sapH but some googling seemed to confirm our tags for it are the correct (sometimes mixed) case.

The LDAP tags I included here, {SSHA} and {SSHA512}, are not likely to exist in lowercase anywhere while older ones such as {md5} or {sha} theoretically could, but we only ever supported those in uppercase and no-one ever complained.