### PR TITLE
Drop yasm from dependencies and installation instructions

### DIFF
--- a/.ci/install-dependencies.sh
+++ b/.ci/install-dependencies.sh
@@ -78,7 +78,7 @@ case "$CC" in
 		esac
 		;;
 	clang*)
-		apt_get_install $packages "$CC" yasm
+		apt_get_install $packages "$CC"
 		;;
 	*)
 		apt_get_install $packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ jobs:
           - libssl-dev
           - zlib1g-dev
           # Extra formats and performance
-          - yasm
           - libgmp-dev
           - libpcap-dev
           - pkg-config
@@ -41,7 +40,6 @@ jobs:
           - libssl-dev
           - zlib1g-dev
           # Extra formats and performance
-          - yasm
           - libgmp-dev
           - libpcap-dev
           - pkg-config

--- a/doc/INSTALL-FEDORA
+++ b/doc/INSTALL-FEDORA
@@ -30,7 +30,7 @@ build CPU fallback chains for any x86-64 CPU.
 
 ==== Recommended (extra formats and performance)
 
-    sudo dnf install yasm gmp-devel libpcap-devel bzip2-devel
+    sudo dnf install gmp-devel libpcap-devel bzip2-devel
 
 ==== Optional MPI support
 

--- a/doc/INSTALL-UBUNTU
+++ b/doc/INSTALL-UBUNTU
@@ -27,7 +27,7 @@ build CPU fallback chains for any x86-64 CPU.
 
 ==== Recommended (extra formats and performance)
 
-    sudo apt-get -y install yasm pkg-config libgmp-dev libpcap-dev libbz2-dev
+    sudo apt-get -y install pkg-config libgmp-dev libpcap-dev libbz2-dev
 
 ==== If you have NVIDIA GPU(s) (OpenCL support)
 


### PR DESCRIPTION
We used to need `yasm` for AES-NI, but we no longer do.