### PR TITLE
Add generic support for Iterated-SHA256 hashes

### DIFF
--- a/run/opencl/iterated_sha256_kernel.cl
+++ b/run/opencl/iterated_sha256_kernel.cl
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2025, magnum
+ * This software is hereby released to the general public under
+ * the following terms: Redistribution and use in source and binary
+ * forms, with or without modification, are permitted.
+ */
+
+#include "opencl_device_info.h"
+#define AMD_PUTCHAR_NOCAST
+#include "opencl_misc.h"
+#include "opencl_mask.h"
+#include "opencl_sha2_ctx.h"
+
+#define SWAP32(n) (((n) << 24) | (((n) & 0xff00U) << 8) | (((n) >> 8) & 0xff00U) | ((n) >> 24))
+
+/* This handles an input of 0xffffffffU correctly */
+#define BITMAP_SHIFT ((BITMAP_MASK >> 5) + 1)
+
+#define sha256_single(W, out) { \
+        uint ctx[8]; \
+        sha256_init(ctx); \
+        sha256_block(W, ctx); \
+        for (int _i = 0; _i < 8; _i++) \
+            (out)[_i] = ctx[_i]; \
+    }
+
+INLINE void cmp_final(uint gid,
+                      uint iter,
+                      uint *hash,
+                      __global uint *offset_table,
+                      __global uint *hash_table,
+                      __global uint *return_hashes,
+                      volatile __global uint *output,
+                      volatile __global uint *bitmap_dupe)
+{
+
+	uint t, offset_table_index, hash_table_index;
+	ulong LO, MI, HI;
+	ulong p;
+
+	HI = ((ulong)hash[5] << 32) | (ulong)hash[4];
+	MI = ((ulong)hash[3] << 32) | (ulong)hash[2];
+	LO = ((ulong)hash[1] << 32) | (ulong)hash[0];
+
+	p = (HI % OFFSET_TABLE_SIZE) * SHIFT128_OT_SZ;
+	p += (MI % OFFSET_TABLE_SIZE) * SHIFT64_OT_SZ;
+	p += LO % OFFSET_TABLE_SIZE;
+	p %= OFFSET_TABLE_SIZE;
+	offset_table_index = (uint)p;
+
+	//error: chances of overflow is extremely low.
+	LO += (ulong)offset_table[offset_table_index];
+
+	p = (HI % HASH_TABLE_SIZE) * SHIFT128_HT_SZ;
+	p += (MI % HASH_TABLE_SIZE) * SHIFT64_HT_SZ;
+	p += LO % HASH_TABLE_SIZE;
+	p %= HASH_TABLE_SIZE;
+	hash_table_index = (uint)p;
+
+	if (hash_table[hash_table_index] == hash[0])
+		if (hash_table[HASH_TABLE_SIZE + hash_table_index] == hash[1]) {
+			/*
+			 * Prevent duplicate keys from cracking same hash
+			 */
+			if (!(atomic_or(&bitmap_dupe[hash_table_index / 32],
+			                (1U << (hash_table_index % 32))) & (1U << (hash_table_index % 32)))) {
+				t = atomic_inc(&output[0]);
+				output[1 + 3 * t] = gid;
+				output[2 + 3 * t] = iter;
+				output[3 + 3 * t] = hash_table_index;
+				return_hashes[2 * t] = hash[6];
+				return_hashes[2 * t + 1] = hash[7];
+			}
+		}
+}
+
+INLINE void cmp(uint gid,
+                uint iter,
+                uint *hash,
+#if USE_LOCAL_BITMAPS
+                __local
+#else
+                __global
+#endif
+                uint *bitmaps,
+                __global uint *offset_table,
+                __global uint *hash_table,
+                __global uint *return_hashes,
+                volatile __global uint *output,
+                volatile __global uint *bitmap_dupe)
+{
+	uint bitmap_index, tmp = 1;
+
+#if SELECT_CMP_STEPS > 4
+	bitmap_index = hash[0] & BITMAP_MASK;
+	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[0] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) &
+	       1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >>
+	        (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[1] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >>
+	        (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 4 + (bitmap_index >> 5)] >>
+	        (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[2] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 5 + (bitmap_index >> 5)] >>
+	        (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[3] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 6 + (bitmap_index >> 5)] >>
+	        (bitmap_index & 31)) & 1U;
+	bitmap_index = (hash[3] >> 16) & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 7 + (bitmap_index >> 5)] >>
+	        (bitmap_index & 31)) & 1U;
+#elif SELECT_CMP_STEPS > 2
+	bitmap_index = hash[3] & BITMAP_MASK;
+	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) &
+	       1U;
+	bitmap_index = hash[1] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 2 + (bitmap_index >> 5)] >>
+	        (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[0] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT * 3 + (bitmap_index >> 5)] >>
+	        (bitmap_index & 31)) & 1U;
+#elif SELECT_CMP_STEPS > 1
+	bitmap_index = hash[3] & BITMAP_MASK;
+	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
+	bitmap_index = hash[2] & BITMAP_MASK;
+	tmp &= (bitmaps[BITMAP_SHIFT + (bitmap_index >> 5)] >> (bitmap_index & 31)) &
+	       1U;
+#else
+	bitmap_index = hash[3] & BITMAP_MASK;
+	tmp &= (bitmaps[bitmap_index >> 5] >> (bitmap_index & 31)) & 1U;
+#endif
+
+	if (tmp)
+		cmp_final(gid, iter, hash, offset_table, hash_table, return_hashes, output,
+		          bitmap_dupe);
+}
+
+#define USE_CONST_CACHE \
+    (CONST_CACHE_SIZE >= (NUM_INT_KEYS * 4))
+
+typedef struct {
+	uint iter;
+	uint len;
+	uchar salt[MAX_SALT_SIZE];
+} salt_t;
+
+__kernel
+void sha256(__global uint *keys,
+            __global uint *index,
+            __global uint *int_key_loc,
+#if USE_CONST_CACHE
+            constant
+#else
+            __global
+#endif
+            uint *int_keys,
+            __constant salt_t *salt,
+            __global uint *bitmaps,
+            __global uint *offset_table,
+            __global uint *hash_table,
+            __global uint *return_hashes,
+            volatile __global uint *out_hash_ids,
+            volatile __global uint *bitmap_dupe)
+{
+	uint i;
+	uint gid = get_global_id(0);
+	uint base = index[gid];
+	uint len = base & 63;
+	uint T[16] = { 0 };
+
+#if NUM_INT_KEYS > 1 && !IS_STATIC_GPU_MASK
+	uint ikl = int_key_loc[gid];
+	uint loc0 = ikl & 0xff;
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+	uint loc1 = (ikl & 0xff00) >> 8;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+	uint loc2 = (ikl & 0xff0000) >> 16;
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+	uint loc3 = (ikl & 0xff000000) >> 24;
+#endif
+#endif
+#endif
+
+#if !IS_STATIC_GPU_MASK
+#define GPU_LOC_0 loc0
+#define GPU_LOC_1 loc1
+#define GPU_LOC_2 loc2
+#define GPU_LOC_3 loc3
+#else
+#define GPU_LOC_0 LOC_0
+#define GPU_LOC_1 LOC_1
+#define GPU_LOC_2 LOC_2
+#define GPU_LOC_3 LOC_3
+#endif
+
+#if USE_LOCAL_BITMAPS
+	uint lid = get_local_id(0);
+	uint lws = get_local_size(0);
+	__local uint s_bitmaps[BITMAP_SHIFT * SELECT_CMP_STEPS];
+
+	for (i = lid; i < BITMAP_SHIFT * SELECT_CMP_STEPS; i += lws)
+		s_bitmaps[i] = bitmaps[i];
+
+	barrier(CLK_LOCAL_MEM_FENCE);
+#endif
+
+	keys += base >> 6;
+
+	for (i = 0; i < salt->len; i++)
+		PUTCHAR_BE(T, i, salt->salt[i]);
+
+	__global uchar *key = (__global uchar *)keys;
+	for (; i < salt->len + len; i++)
+		PUTCHAR_BE(T, i, *key++);
+
+	PUTCHAR_BE(T, (salt->len + len), 0x80);
+	T[15] = (salt->len + len) << 3;
+
+	for (uint idx = 0; idx < NUM_INT_KEYS; idx++) {
+#if NUM_INT_KEYS > 1
+		PUTCHAR_BE(T, salt->len + GPU_LOC_0, (int_keys[idx] & 0xff));
+#if MASK_FMT_INT_PLHDR > 1
+#if LOC_1 >= 0
+		PUTCHAR_BE(T, salt->len + GPU_LOC_1, ((int_keys[idx] & 0xff00) >> 8));
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+#if LOC_2 >= 0
+		PUTCHAR_BE(T, salt->len + GPU_LOC_2, ((int_keys[idx] & 0xff0000) >> 16));
+#endif
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+#if LOC_3 >= 0
+		PUTCHAR_BE(T, salt->len + GPU_LOC_3, ((int_keys[idx] & 0xff000000) >> 24));
+#endif
+#endif
+#endif
+		uint W[16];
+		uint hash[8];
+
+		memcpy_macro(W, T, 16);
+		sha256_single(W, hash);
+
+		uint iter = salt->iter;
+		while (--iter) {
+			// Copy hash directly for next iteration
+			memcpy_macro(W, hash, 8);
+			W[8] = 0x80000000U;
+			W[9] = 0;
+			W[10] = 0;
+			W[11] = 0;
+			W[12] = 0;
+			W[13] = 0;
+			W[14] = 0;
+			W[15] = 32 << 3;
+			sha256_single(W, hash);
+		}
+
+		// Swap hash to match endianness of bitmap/hash table
+		for (uint j = 0; j < 8; j++)
+			hash[j] = SWAP32(hash[j]);
+
+		cmp(gid, idx, hash,
+#if USE_LOCAL_BITMAPS
+		    s_bitmaps
+#else
+		    bitmaps
+#endif
+		    , offset_table, hash_table, return_hashes, out_hash_ids, bitmap_dupe);
+	}
+}

--- a/src/iterated_sha256_common.h
+++ b/src/iterated_sha256_common.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, Dhiru Kholia
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#ifndef ITERATED_SHA256_COMMON_H__
+#define ITERATED_SHA256_COMMON_H__
+
+#include "formats.h"
+
+#define FORMAT_NAME             "salted"
+
+#define FORMAT_TAG              "$sisha256$"
+#define FORMAT_TAG_LEN          (sizeof(FORMAT_TAG) - 1)
+
+#define BINARY_SIZE             32
+#define BINARY_ALIGN            4
+#define SALT_ALIGN              4
+
+#define BENCHMARK_COMMENT       ""
+#define BENCHMARK_LENGTH        7
+
+#define CIPHERTEXT_LENGTH       128
+#define SALT_BYTES              32
+#define MAX_SALT_BYTES          64
+#define MAX_SALT_SIZE           MAX_SALT_BYTES
+
+#ifndef PLAINTEXT_LENGTH
+#define PLAINTEXT_LENGTH        MAX_PLAINTEXT_LENGTH
+#endif
+
+#define ISE_ITERATIONS          128
+#define ISE_TOTAL_ROUNDS        (ISE_ITERATIONS + 1)
+#define MAX_ITERATIONS          (1 << 20)
+
+typedef struct {
+	uint32_t iter;
+	uint32_t len;
+	uint32_t salt[MAX_SALT_BYTES / sizeof(uint32_t)];
+} salt_t;
+
+#define SALT_SIZE               sizeof(salt_t)
+
+extern struct fmt_tests iterated_sha256_tests[];
+
+extern int iterated_sha256_valid(char *ciphertext, struct fmt_main *self);
+extern void *iterated_sha256_get_binary(char *ciphertext);
+extern void *iterated_sha256_get_salt(char *ciphertext);
+extern int iterated_sha256_salt_hash(void *salt);
+extern unsigned int iterated_sha256_iterations(void *salt);
+
+#endif /* ITERATED_SHA256_COMMON_H__ */

--- a/src/iterated_sha256_common_plug.c
+++ b/src/iterated_sha256_common_plug.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, Dhiru Kholia
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ */
+
+#include <string.h>
+
+#include "formats.h"
+#include "common.h"
+#include "iterated_sha256_common.h"
+
+struct fmt_tests iterated_sha256_tests[] = {
+	// Cisco-ISE-SHA256
+	{"465865d4226c4d9696e601f2c99b25ae2c194ec01806bafc93933331acfc1a60e8bdcca8be9fa245a5fa16029bb52480915746f47d1c539d01da7ec6f37468d1", "hashcat"},
+	// {"$sisha256$129$e8bdcca8be9fa245a5fa16029bb52480915746f47d1c539d01da7ec6f37468d1465865d4226c4d9696e601f2c99b25ae2c194ec01806bafc93933331acfc1a60", "hashcat"},
+
+	// Synthetic test vectors
+	{"a6c9702dae629b71383eb2819f00464985c2188db7ff83a9cb5137eb6ee975d500112233445566778899aabbccddeeff00112233445566778899aabbccddeeff", "OpenAI2026!"},
+	// {"$sisha256$129$00112233445566778899aabbccddeeff00112233445566778899aabbccddeeffa6c9702dae629b71383eb2819f00464985c2188db7ff83a9cb5137eb6ee975d5", "OpenAI2026!"},
+	// Simple test with 1 iteration (just SHA256(salt || password))
+	{"$sisha256$1$73616c7413601bda4ea78e55a07b98866d2be6be0744e3866f13c00c811cab608a28f322", "password"},
+	{NULL}
+};
+
+/*
+ * Untagged hash format (Cisco-ISE): 128 hex chars
+ *   <hex_hash><hex_salt>  (32-byte hash + 32-byte salt)
+ *
+ * Tagged hash format (variable salt length):
+ *   $sisha256$N$<hex_salt><hex_hash>
+ *   where N is the total number of hash rounds (1 means only the initial hash)
+ */
+int iterated_sha256_valid(char *ciphertext, struct fmt_main *self)
+{
+	if (!strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN)) {
+		int extra;
+		int len;
+		int iter;
+
+		ciphertext += FORMAT_TAG_LEN;
+
+		iter = getdec(ciphertext, '$');
+		if (iter < 1 || iter > MAX_ITERATIONS)
+			return 0;
+
+		ciphertext = strchr(ciphertext, '$');
+		if (!ciphertext)
+			return 0;
+		ciphertext++;
+
+		len = strnlen(ciphertext, BINARY_SIZE * 2 + MAX_SALT_BYTES * 2 + 1);
+		if (len & 1)
+			return 0;
+		if (len < BINARY_SIZE * 2 || len > BINARY_SIZE * 2 + MAX_SALT_BYTES * 2)
+			return 0;
+		if (hexlenl(ciphertext, &extra) != len || extra)
+			return 0;
+
+		return 1;
+	}
+
+	if (strlen(ciphertext) != CIPHERTEXT_LENGTH)
+		return 0;
+	if (!ishex(ciphertext))
+		return 0;
+	return 1;
+}
+
+void *iterated_sha256_get_binary(char *ciphertext)
+{
+	static union {
+		unsigned char b[BINARY_SIZE];
+		uint32_t dummy;
+	} out;
+	const char *p = ciphertext;
+	int i;
+
+	if (!strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN)) {
+		p += FORMAT_TAG_LEN;
+		p = strchr(p, '$') + 1;
+		p += strlen(p) - (BINARY_SIZE * 2);
+	}
+
+	for (i = 0; i < BINARY_SIZE; i++) {
+		out.b[i] = (atoi16[ARCH_INDEX(p[0])] << 4) | atoi16[ARCH_INDEX(p[1])];
+		p += 2;
+	}
+
+	return out.b;
+}
+
+void *iterated_sha256_get_salt(char *ciphertext)
+{
+	static salt_t out;
+	const char *p = ciphertext;
+	int i;
+
+	memset(&out, 0, sizeof(out));
+
+	if (!strncmp(ciphertext, FORMAT_TAG, FORMAT_TAG_LEN)) {
+		int len;
+
+		p += FORMAT_TAG_LEN;
+		out.iter = getdec(p, '$');
+		p = strchr(p, '$') + 1;
+
+		len = strlen(p);
+		out.len = (len - BINARY_SIZE * 2) / 2;
+
+		for (i = 0; i < (int)out.len; i++) {
+			((unsigned char *)out.salt)[i] =
+			    (atoi16[ARCH_INDEX(p[0])] << 4) | atoi16[ARCH_INDEX(p[1])];
+			p += 2;
+		}
+	} else {
+		out.iter = ISE_TOTAL_ROUNDS;
+		out.len = SALT_BYTES;
+		p += CIPHERTEXT_LENGTH - (SALT_BYTES * 2);
+
+		for (i = 0; i < SALT_BYTES; i++) {
+			((unsigned char *)out.salt)[i] =
+			    (atoi16[ARCH_INDEX(p[0])] << 4) | atoi16[ARCH_INDEX(p[1])];
+			p += 2;
+		}
+	}
+
+	return &out;
+}
+
+int iterated_sha256_salt_hash(void *salt)
+{
+	salt_t *s = salt;
+
+	return (s->iter ^ s->len ^ s->salt[0]) & (SALT_HASH_SIZE - 1);
+}
+
+unsigned int iterated_sha256_iterations(void *salt)
+{
+	salt_t *s = salt;
+
+	return s->iter;
+}

--- a/src/iterated_sha256_fmt_plug.c
+++ b/src/iterated_sha256_fmt_plug.c
@@ -1,0 +1,305 @@
+/*
+ * This software is Copyright (c) 2026 Dhiru Kholia and it is hereby released
+ * to the general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * Algorithm:
+ *   digest = SHA256(salt || password)
+ *   repeat N times: digest = SHA256(digest)
+ */
+
+#if FMT_EXTERNS_H
+extern struct fmt_main fmt_iterated_sha256;
+#elif FMT_REGISTERS_H
+john_register_one(&fmt_iterated_sha256);
+#else
+
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "arch.h"
+#include "johnswap.h"
+#include "common.h"
+#include "formats.h"
+#include "misc.h"
+#include "sha2.h"
+#include "iterated_sha256_common.h"
+#include "simd-intrinsics.h"
+
+#define FORMAT_LABEL            "Iterated-SHA256"
+#define ALGORITHM_NAME          "SHA256 ($s.$p) " SHA256_ALGORITHM_NAME
+
+#ifdef SIMD_COEF_32
+#define NBKEYS                  (SIMD_COEF_32 * SIMD_PARA_SHA256)
+#define FMT_IS_BE
+#include "common-simd-getpos.h"
+#define MIN_KEYS_PER_CRYPT      NBKEYS
+#define MAX_KEYS_PER_CRYPT      (NBKEYS * 512)
+#else
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      16
+#endif
+
+#ifndef OMP_SCALE
+#define OMP_SCALE               256
+#endif
+
+static salt_t *cur_salt;
+
+static char (*saved_key)[PLAINTEXT_LENGTH + 1];
+static int (*saved_len);
+
+#ifdef SIMD_COEF_32
+static uint32_t(*simd_keybuf)[SHA_BUF_SIZ * NBKEYS];
+static uint32_t(*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+#else
+static uint32_t(*crypt_out)[BINARY_SIZE / sizeof(uint32_t)];
+#endif
+
+static void init(struct fmt_main *self)
+{
+	omp_autotune(self, OMP_SCALE);
+
+	saved_key = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*saved_key));
+	saved_len = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*saved_len));
+#ifdef SIMD_COEF_32
+	simd_keybuf = mem_calloc_align(self->params.max_keys_per_crypt / NBKEYS,
+	                               sizeof(*simd_keybuf), MEM_ALIGN_SIMD);
+	crypt_out = mem_calloc_align(self->params.max_keys_per_crypt,
+	                             sizeof(*crypt_out), MEM_ALIGN_SIMD);
+#else
+	crypt_out = mem_calloc(self->params.max_keys_per_crypt,
+	                       sizeof(*crypt_out));
+#endif
+}
+
+static void done(void)
+{
+	MEM_FREE(crypt_out);
+	MEM_FREE(saved_len);
+	MEM_FREE(saved_key);
+#ifdef SIMD_COEF_32
+	MEM_FREE(simd_keybuf);
+#endif
+}
+
+static void set_salt(void *salt)
+{
+	cur_salt = salt;
+}
+
+static void set_key(char *key, int index)
+{
+	saved_len[index] = strnzcpyn(saved_key[index], key, sizeof(*saved_key));
+}
+
+static char *get_key(int index)
+{
+	return saved_key[index];
+}
+
+static int cmp_all(void *binary, int count)
+{
+	uint32_t b0 = *(uint32_t *) binary;
+	int i;
+
+	for (i = 0; i < count; i++) {
+		if (b0 != crypt_out[i][0])
+			continue;
+		if (!memcmp(binary, crypt_out[i], BINARY_SIZE))
+			return 1;
+	}
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return !memcmp(binary, crypt_out[index], BINARY_SIZE);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	return 1;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	int count = *pcount;
+	int index;
+
+#ifdef SIMD_COEF_32
+	int simd_count = count / NBKEYS * NBKEYS;
+
+#ifdef _OPENMP
+	#pragma omp parallel for
+#endif
+	for (index = 0; index < simd_count; index += NBKEYS) {
+		SHA256_CTX ctx;
+		unsigned char digest[BINARY_SIZE];
+		unsigned char *keys;
+		uint32_t *keys32;
+		int iter, i, j;
+
+		iter = cur_salt->iter;
+		keys = (unsigned char *)simd_keybuf[index / NBKEYS];
+		keys32 = (uint32_t *) keys;
+		memset(keys, 0, 64 * NBKEYS);
+
+		for (i = 0; i < NBKEYS; i++) {
+			int idx = index + i;
+
+			SHA256_Init(&ctx);
+			SHA256_Update(&ctx, (unsigned char *)cur_salt->salt,
+			              cur_salt->len);
+			SHA256_Update(&ctx, saved_key[idx], saved_len[idx]);
+			SHA256_Final(digest, &ctx);
+
+			if (iter == 1) {
+				memcpy(crypt_out[idx], digest, BINARY_SIZE);
+				continue;
+			}
+
+			for (j = 0; j < 32; j++)
+				keys[GETPOS(j, i)] = digest[j];
+			keys[GETPOS(j, i)] = 0x80;
+			keys[GETPOS(62, i)] = 0x01;
+		}
+
+		if (iter > 1) {
+			int remaining = iter - 1;
+			uint32_t *out = (uint32_t *) crypt_out[index];
+
+			if (remaining == 1) {
+				SIMDSHA256body(keys32, out, NULL,
+				               SSEi_MIXED_IN | SSEi_OUTPUT_AS_INP_FMT | SSEi_FLAT_OUT);
+			} else {
+				for (i = 0; i < remaining - 1; i++)
+					SIMDSHA256body(keys32, keys32, NULL,
+					               SSEi_MIXED_IN | SSEi_OUTPUT_AS_INP_FMT);
+				SIMDSHA256body(keys32, out, NULL,
+				               SSEi_MIXED_IN | SSEi_OUTPUT_AS_INP_FMT | SSEi_FLAT_OUT);
+			}
+		}
+	}
+
+	for (index = simd_count; index < count; index++) {
+		SHA256_CTX ctx;
+		unsigned char digest[BINARY_SIZE];
+		int iter;
+
+		iter = cur_salt->iter;
+
+		SHA256_Init(&ctx);
+		SHA256_Update(&ctx, (unsigned char *)cur_salt->salt, cur_salt->len);
+		SHA256_Update(&ctx, saved_key[index], saved_len[index]);
+		SHA256_Final(digest, &ctx);
+
+		while (--iter) {
+			SHA256_Init(&ctx);
+			SHA256_Update(&ctx, digest, BINARY_SIZE);
+			SHA256_Final(digest, &ctx);
+		}
+
+		memcpy(crypt_out[index], digest, BINARY_SIZE);
+	}
+#else
+#ifdef _OPENMP
+	#pragma omp parallel for default(none) private(index) shared(count, saved_key, saved_len, crypt_out, cur_salt)
+#endif
+	for (index = 0; index < count; index++) {
+		SHA256_CTX ctx;
+		unsigned char digest[BINARY_SIZE];
+		int iter;
+
+		iter = cur_salt->iter;
+
+		SHA256_Init(&ctx);
+		SHA256_Update(&ctx, (unsigned char *)cur_salt->salt, cur_salt->len);
+		SHA256_Update(&ctx, saved_key[index], saved_len[index]);
+		SHA256_Final(digest, &ctx);
+
+		while (--iter) {
+			SHA256_Init(&ctx);
+			SHA256_Update(&ctx, digest, BINARY_SIZE);
+			SHA256_Final(digest, &ctx);
+		}
+
+		memcpy(crypt_out[index], digest, BINARY_SIZE);
+	}
+#endif
+
+	return count;
+}
+
+#define COMMON_GET_HASH_VAR crypt_out
+#include "common-get-hash.h"
+
+struct fmt_main fmt_iterated_sha256 = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_OMP,
+		{ "iterations"},
+		{
+			FORMAT_TAG,
+			""
+		},
+		iterated_sha256_tests
+	}, {
+		init,
+		done,
+		fmt_default_reset,
+		fmt_default_prepare,
+		iterated_sha256_valid,
+		fmt_default_split,
+		iterated_sha256_get_binary,
+		iterated_sha256_get_salt,
+		{
+			iterated_sha256_iterations
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
+		},
+		iterated_sha256_salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		fmt_default_clear_keys,
+		crypt_all,
+		{
+#define COMMON_GET_HASH_LINK
+#include "common-get-hash.h"
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+};
+
+#endif

--- a/src/opencl_iterated_sha256_fmt_plug.c
+++ b/src/opencl_iterated_sha256_fmt_plug.c
@@ -1,0 +1,1139 @@
+/*
+ * Copyright (c) 2025, magnum
+ * This software is hereby released to the general public under
+ * the following terms: Redistribution and use in source and binary
+ * forms, with or without modification, are permitted.
+ */
+
+#ifdef HAVE_OPENCL
+#define FMT_STRUCT fmt_opencl_sha256_iterated
+
+#if FMT_EXTERNS_H
+extern struct fmt_main FMT_STRUCT;
+#elif FMT_REGISTERS_H
+john_register_one(&FMT_STRUCT);
+#else
+
+#include <string.h>
+#include <sys/time.h>
+
+#include "arch.h"
+#include "params.h"
+#include "path.h"
+#include "common.h"
+#include "opencl_common.h"
+#include "config.h"
+#include "options.h"
+#define PLAINTEXT_LENGTH 63
+#include "iterated_sha256_common.h"
+#include "mask_ext.h"
+#include "base64_convert.h"
+#include "bt_interface.h"
+
+#define FORMAT_LABEL        "Iterated-SHA256-opencl"
+#define ALGORITHM_NAME      "SHA256 ($s.$p) OpenCL"
+
+#define BUFSIZE             ((PLAINTEXT_LENGTH + 3) / 4 * 4)
+#define HASH_WORDS          8
+#define BT_WORDS            6
+#define HASH_IDX(i, w)      (BT_WORDS * (i) + (w))
+
+static cl_mem pinned_saved_keys, pinned_saved_idx, pinned_int_key_loc;
+static cl_mem buffer_keys, buffer_idx, buffer_int_keys, buffer_int_key_loc;
+static cl_uint *saved_plain, *saved_idx, *saved_int_key_loc;
+static int static_gpu_locations[MASK_FMT_INT_PLHDR];
+
+static cl_mem buffer_offset_table, buffer_hash_table, buffer_return_hashes,
+       buffer_hash_ids, buffer_bitmap_dupe, buffer_bitmaps, buffer_salt;
+static OFFSET_TABLE_WORD *offset_table = NULL;
+static cl_uint *loaded_hashes = NULL, *loaded_hashes_tail = NULL,
+                num_loaded_hashes, *hash_ids = NULL, *bitmaps = NULL;
+static cl_uint *loaded_hashes_original = NULL;
+static unsigned int num_loaded_hashes_original = 0;
+static unsigned int hash_table_size, offset_table_size, shift64_ht_sz,
+       shift64_ot_sz, shift128_ht_sz, shift128_ot_sz;
+static cl_ulong bitmap_size_bits = 0;
+static unsigned int new_keys = 1;
+
+static unsigned int key_idx = 0;
+static struct fmt_main *self;
+static cl_uint *zero_buffer;
+
+#define MIN_KEYS_PER_CRYPT      1
+#define MAX_KEYS_PER_CRYPT      1
+
+struct fmt_main FMT_STRUCT;
+
+static void set_kernel_args_kpc()
+{
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 0, sizeof(buffer_keys),
+	                              (void *) &buffer_keys), "Error setting argument 1.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 1, sizeof(buffer_idx),
+	                              (void *) &buffer_idx), "Error setting argument 2.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 2, sizeof(buffer_int_key_loc),
+	                              (void *) &buffer_int_key_loc), "Error setting argument 3.");
+}
+
+static void set_kernel_args()
+{
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 3, sizeof(buffer_int_keys),
+	                              (void *) &buffer_int_keys), "Error setting argument 4.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 4, sizeof(buffer_salt),
+	                              (void *) &buffer_salt), "Error setting argument 5.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 5, sizeof(buffer_bitmaps),
+	                              (void *) &buffer_bitmaps), "Error setting argument 6.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 6, sizeof(buffer_offset_table),
+	                              (void *) &buffer_offset_table), "Error setting argument 7.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 7, sizeof(buffer_hash_table),
+	                              (void *) &buffer_hash_table), "Error setting argument 8.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 8, sizeof(buffer_return_hashes),
+	                              (void *) &buffer_return_hashes), "Error setting argument 9.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 9, sizeof(buffer_hash_ids),
+	                              (void *) &buffer_hash_ids), "Error setting argument 10.");
+	HANDLE_CLERROR(clSetKernelArg(crypt_kernel, 10, sizeof(buffer_bitmap_dupe),
+	                              (void *) &buffer_bitmap_dupe), "Error setting argument 11.");
+}
+
+static void release_clobj_kpc(void);
+static void release_clobj(void);
+
+static void create_clobj_kpc(size_t kpc)
+{
+	global_work_size = kpc;
+	release_clobj_kpc();
+
+	pinned_saved_keys = clCreateBuffer(context[gpu_id],
+	                                   CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR, BUFSIZE * kpc, NULL, &ret_code);
+	if (ret_code != CL_SUCCESS) {
+		saved_plain = (cl_uint *) mem_alloc(BUFSIZE * kpc);
+		if (saved_plain == NULL)
+			HANDLE_CLERROR(ret_code,
+			               "Error creating page-locked memory pinned_saved_keys.");
+	} else {
+		saved_plain = (cl_uint *) clEnqueueMapBuffer(queue[gpu_id], pinned_saved_keys,
+		              CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, BUFSIZE * kpc, 0, NULL, NULL,
+		              &ret_code);
+		HANDLE_CLERROR(ret_code, "Error mapping page-locked memory saved_plain.");
+	}
+
+	pinned_saved_idx = clCreateBuffer(context[gpu_id],
+	                                  CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR, sizeof(cl_uint) * kpc, NULL,
+	                                  &ret_code);
+	HANDLE_CLERROR(ret_code,
+	               "Error creating page-locked memory pinned_saved_idx.");
+	saved_idx = (cl_uint *) clEnqueueMapBuffer(queue[gpu_id], pinned_saved_idx,
+	            CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0, sizeof(cl_uint) * kpc, 0, NULL, NULL,
+	            &ret_code);
+	HANDLE_CLERROR(ret_code, "Error mapping page-locked memory saved_idx.");
+
+	pinned_int_key_loc = clCreateBuffer(context[gpu_id],
+	                                    CL_MEM_READ_ONLY | CL_MEM_ALLOC_HOST_PTR, sizeof(cl_uint) * kpc, NULL,
+	                                    &ret_code);
+	HANDLE_CLERROR(ret_code,
+	               "Error creating page-locked memory pinned_int_key_loc.");
+	saved_int_key_loc = (cl_uint *) clEnqueueMapBuffer(queue[gpu_id],
+	                    pinned_int_key_loc, CL_TRUE, CL_MAP_READ | CL_MAP_WRITE, 0,
+	                    sizeof(cl_uint) * kpc, 0, NULL, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code,
+	               "Error mapping page-locked memory saved_int_key_loc.");
+
+	// create and set arguments
+	buffer_keys = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, BUFSIZE * kpc,
+	                             NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_keys.");
+
+	buffer_idx = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, 4 * kpc, NULL,
+	                            &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_idx.");
+
+	buffer_int_key_loc = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY,
+	                                    sizeof(cl_uint) * kpc, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_int_key_loc.");
+}
+
+static void create_clobj(void)
+{
+	cl_ulong max_alloc_size_bytes = 0;
+	cl_ulong cache_size_bytes = 0;
+	cl_uint dummy = 0;
+
+	release_clobj();
+
+	HANDLE_CLERROR(clGetDeviceInfo(devices[gpu_id], CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+	                               sizeof(cl_ulong), &max_alloc_size_bytes, 0),
+	               "failed to get CL_DEVICE_MAX_MEM_ALLOC_SIZE.");
+	HANDLE_CLERROR(clGetDeviceInfo(devices[gpu_id],
+	                               CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, sizeof(cl_ulong), &cache_size_bytes, 0),
+	               "failed to get CL_DEVICE_GLOBAL_MEM_CACHE_SIZE.");
+
+	if (max_alloc_size_bytes & (max_alloc_size_bytes - 1)) {
+		get_power_of_two(max_alloc_size_bytes);
+		max_alloc_size_bytes >>= 1;
+	}
+	if (max_alloc_size_bytes >= 536870912) max_alloc_size_bytes = 536870912;
+
+	if (!cache_size_bytes) cache_size_bytes = 1024;
+
+	zero_buffer = (cl_uint *) mem_calloc(hash_table_size / 32 + 1,
+	                                     sizeof(cl_uint));
+
+	buffer_return_hashes = clCreateBuffer(context[gpu_id], CL_MEM_WRITE_ONLY,
+	                                      2 * sizeof(cl_uint) * num_loaded_hashes, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code,
+	               "Error creating buffer argument buffer_return_hashes.");
+
+	buffer_hash_ids = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE,
+	                                 (3 * num_loaded_hashes + 1) * sizeof(cl_uint), NULL, &ret_code);
+	HANDLE_CLERROR(ret_code,
+	               "Error creating buffer argument buffer_buffer_hash_ids.");
+
+	buffer_salt = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY, SALT_SIZE,
+	                             NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_salt.");
+
+	buffer_bitmap_dupe = clCreateBuffer(context[gpu_id],
+	                                    CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+	                                    (hash_table_size / 32 + 1) * sizeof(cl_uint), zero_buffer, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_bitmap_dupe.");
+
+	buffer_bitmaps = clCreateBuffer(context[gpu_id], CL_MEM_READ_WRITE,
+	                                max_alloc_size_bytes, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_bitmaps.");
+
+	//dummy is used as dummy parameter
+	buffer_int_keys = clCreateBuffer(context[gpu_id],
+	                                 CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, 4 * mask_int_cand.num_int_cand,
+	                                 mask_int_cand.int_cand ? mask_int_cand.int_cand : (void *)&dummy, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_int_keys.");
+
+	buffer_offset_table = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY,
+	                                     offset_table_size * sizeof(OFFSET_TABLE_WORD), NULL, &ret_code);
+	HANDLE_CLERROR(ret_code,
+	               "Error creating buffer argument buffer_offset_table.");
+
+	buffer_hash_table = clCreateBuffer(context[gpu_id], CL_MEM_READ_ONLY,
+	                                   hash_table_size * sizeof(unsigned int) * 2, NULL, &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating buffer argument buffer_hash_table.");
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0,
+	                                    sizeof(cl_uint), zero_buffer, 0, NULL, NULL),
+	               "failed in clEnqueueWriteBuffer buffer_hash_ids.");
+}
+
+static void release_clobj_kpc(void)
+{
+	if (buffer_idx) {
+		if (pinned_saved_keys) {
+			HANDLE_CLERROR(clEnqueueUnmapMemObject(queue[gpu_id], pinned_saved_keys,
+			                                       saved_plain, 0, NULL, NULL), "Error Unmapping saved_plain.");
+			HANDLE_CLERROR(clReleaseMemObject(pinned_saved_keys),
+			               "Error Releasing pinned_saved_keys.");
+		} else
+			MEM_FREE(saved_plain);
+		HANDLE_CLERROR(clEnqueueUnmapMemObject(queue[gpu_id], pinned_saved_idx,
+		                                       saved_idx, 0, NULL, NULL), "Error Unmapping saved_idx.");
+		HANDLE_CLERROR(clEnqueueUnmapMemObject(queue[gpu_id], pinned_int_key_loc,
+		                                       saved_int_key_loc, 0, NULL, NULL), "Error Unmapping saved_int_key_loc.");
+		HANDLE_CLERROR(clFinish(queue[gpu_id]), "Error releasing mappings.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_keys),
+		               "Error Releasing buffer_keys.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_idx), "Error Releasing buffer_idx.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_int_key_loc),
+		               "Error Releasing buffer_int_key_loc.");
+		HANDLE_CLERROR(clReleaseMemObject(pinned_saved_idx),
+		               "Error Releasing pinned_saved_idx.");
+		HANDLE_CLERROR(clReleaseMemObject(pinned_int_key_loc),
+		               "Error Releasing pinned_int_key_loc.");
+		buffer_idx = 0;
+	}
+}
+
+static void release_clobj(void)
+{
+	if (buffer_offset_table) {
+		HANDLE_CLERROR(clReleaseMemObject(buffer_int_keys),
+		               "Error Releasing buffer_int_keys.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_return_hashes),
+		               "Error Releasing buffer_return_hashes.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_salt),
+		               "Error Releasing buffer_salt.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_offset_table),
+		               "Error Releasing buffer_offset_table.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_hash_table),
+		               "Error Releasing buffer_hash_table.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_bitmap_dupe),
+		               "Error Releasing buffer_bitmap_dupe.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_hash_ids),
+		               "Error Releasing buffer_hash_ids.");
+		HANDLE_CLERROR(clReleaseMemObject(buffer_bitmaps),
+		               "Error Releasing buffer_bitmap.");
+		MEM_FREE(zero_buffer);
+		buffer_offset_table = 0;
+	}
+}
+
+static void done(void)
+{
+	release_clobj_kpc();
+	release_clobj();
+
+	if (crypt_kernel) {
+		HANDLE_CLERROR(clReleaseKernel(crypt_kernel), "Release kernel.");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program.");
+
+		crypt_kernel = NULL;
+	}
+
+	if (loaded_hashes)
+		MEM_FREE(loaded_hashes);
+	if (loaded_hashes_tail)
+		MEM_FREE(loaded_hashes_tail);
+	if (loaded_hashes_original)
+		MEM_FREE(loaded_hashes_original);
+	if (hash_ids)
+		MEM_FREE(hash_ids);
+	if (bitmaps)
+		MEM_FREE(bitmaps);
+	if (offset_table)
+		MEM_FREE(offset_table);
+	if (bt_hash_table_192)
+		MEM_FREE(bt_hash_table_192);
+}
+
+static void init_kernel(unsigned int num_ld_hashes, char *bitmap_para)
+{
+	char build_opts[5000];
+	int i;
+	uint64_t shift128;
+	cl_ulong const_cache_size;
+
+	if (crypt_kernel) {
+		HANDLE_CLERROR(clReleaseKernel(crypt_kernel), "Release kernel.");
+		HANDLE_CLERROR(clReleaseProgram(program[gpu_id]), "Release Program.");
+
+		crypt_kernel = NULL;
+	}
+
+	shift64_ht_sz = (((1ULL << 63) % hash_table_size) * 2) % hash_table_size;
+	shift64_ot_sz = (((1ULL << 63) % offset_table_size) * 2) % offset_table_size;
+
+	shift128 = (uint64_t)shift64_ht_sz * shift64_ht_sz;
+	shift128_ht_sz = shift128 % hash_table_size;
+
+	shift128 = (uint64_t)shift64_ot_sz * shift64_ot_sz;
+	shift128_ot_sz = shift128 % offset_table_size;
+
+	for (i = 0; i < MASK_FMT_INT_PLHDR; i++)
+		if (mask_skip_ranges && mask_skip_ranges[i] != -1)
+			static_gpu_locations[i] = mask_int_cand.int_cpu_mask_ctx->
+			                          ranges[mask_skip_ranges[i]].pos;
+		else
+			static_gpu_locations[i] = -1;
+
+	HANDLE_CLERROR(clGetDeviceInfo(devices[gpu_id],
+	                               CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, sizeof(cl_ulong), &const_cache_size, 0),
+	               "failed to get CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE.");
+
+	sprintf(build_opts,
+	        "-DMAX_SALT_SIZE=%u -DOFFSET_TABLE_SIZE=%u -DHASH_TABLE_SIZE=%u"
+	        " -DSHIFT64_OT_SZ=%u -DSHIFT64_HT_SZ=%u -DSHIFT128_OT_SZ=%u"
+	        " -DSHIFT128_HT_SZ=%u -DNUM_LOADED_HASHES=%u"
+	        " -DNUM_INT_KEYS=%u %s -DIS_STATIC_GPU_MASK=%d"
+	        " -DCONST_CACHE_SIZE=%llu -DLOC_0=%d"
+#if MASK_FMT_INT_PLHDR > 1
+	        " -DLOC_1=%d "
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+	        "-DLOC_2=%d "
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+	        "-DLOC_3=%d"
+#endif
+	        , MAX_SALT_SIZE, offset_table_size, hash_table_size, shift64_ot_sz,
+	        shift64_ht_sz,
+	        shift128_ot_sz, shift128_ht_sz, num_ld_hashes,
+	        mask_int_cand.num_int_cand, bitmap_para, mask_gpu_is_static,
+	        (unsigned long long)const_cache_size, static_gpu_locations[0]
+#if MASK_FMT_INT_PLHDR > 1
+	        , static_gpu_locations[1]
+#endif
+#if MASK_FMT_INT_PLHDR > 2
+	        , static_gpu_locations[2]
+#endif
+#if MASK_FMT_INT_PLHDR > 3
+	        , static_gpu_locations[3]
+#endif
+	       );
+
+	opencl_build_kernel("$JOHN/opencl/iterated_sha256_kernel.cl",
+	                    gpu_id, build_opts, 0);
+	crypt_kernel = clCreateKernel(program[gpu_id], "sha256", &ret_code);
+	HANDLE_CLERROR(ret_code, "Error creating kernel. Double-check kernel name?");
+}
+
+static void init(struct fmt_main *_self)
+{
+	self = _self;
+	num_loaded_hashes = 0;
+
+	opencl_prepare_dev(gpu_id);
+	mask_int_cand_target = 0; //opencl_speed_index(gpu_id) / 950000;
+}
+
+static void set_salt(void *salt)
+{
+	salt_t *cur_salt = salt;
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_salt, CL_FALSE, 0,
+	                                    SALT_SIZE,
+	                                    cur_salt, 0, NULL, NULL), "failed in clEnqueueWriteBuffer mysalt");
+	HANDLE_CLERROR(clFlush(queue[gpu_id]), "clFlush failed in set_salt()");
+}
+
+static int get_hash_0(int index)
+{
+	return bt_hash_table_192[hash_ids[3 + 3 * index]] & PH_MASK_0;
+}
+static int get_hash_1(int index)
+{
+	return bt_hash_table_192[hash_ids[3 + 3 * index]] & PH_MASK_1;
+}
+static int get_hash_2(int index)
+{
+	return bt_hash_table_192[hash_ids[3 + 3 * index]] & PH_MASK_2;
+}
+static int get_hash_3(int index)
+{
+	return bt_hash_table_192[hash_ids[3 + 3 * index]] & PH_MASK_3;
+}
+static int get_hash_4(int index)
+{
+	return bt_hash_table_192[hash_ids[3 + 3 * index]] & PH_MASK_4;
+}
+static int get_hash_5(int index)
+{
+	return bt_hash_table_192[hash_ids[3 + 3 * index]] & PH_MASK_5;
+}
+static int get_hash_6(int index)
+{
+	return bt_hash_table_192[hash_ids[3 + 3 * index]] & PH_MASK_6;
+}
+
+static void clear_keys(void)
+{
+	memset(saved_idx, 0, sizeof(cl_uint) * global_work_size);
+	key_idx = 0;
+}
+
+static void set_key(char *_key, int index)
+{
+	const uint32_t *key = (uint32_t *)_key;
+	int len = strlen(_key);
+
+	if (mask_int_cand.num_int_cand > 1 && !mask_gpu_is_static) {
+		int i;
+		saved_int_key_loc[index] = 0;
+		for (i = 0; i < MASK_FMT_INT_PLHDR; i++) {
+			if (mask_skip_ranges[i] != -1)  {
+				saved_int_key_loc[index] |= ((mask_int_cand.
+				                              int_cpu_mask_ctx->ranges[mask_skip_ranges[i]].offset +
+				                              mask_int_cand.int_cpu_mask_ctx->
+				                              ranges[mask_skip_ranges[i]].pos) & 0xff) << (i << 3);
+			} else
+				saved_int_key_loc[index] |= 0x80 << (i << 3);
+		}
+	}
+
+	saved_idx[index] = (key_idx << 6) | len;
+
+	while (len > 4) {
+		saved_plain[key_idx++] = *key++;
+		len -= 4;
+	}
+	if (len)
+		saved_plain[key_idx++] = *key & (0xffffffffU >> (32 - (len << 3)));
+
+	new_keys = 1;
+}
+
+static char *get_key(int index)
+{
+	static char out[PLAINTEXT_LENGTH + 1];
+	int i, len, int_index, t;
+	char *key;
+
+	if (hash_ids == NULL || hash_ids[0] == 0 ||
+	        index >= hash_ids[0] || hash_ids[0] > num_loaded_hashes) {
+		t = index;
+		int_index = 0;
+	} else  {
+		t = hash_ids[1 + 3 * index];
+		int_index = hash_ids[2 + 3 * index];
+
+	}
+
+	if (t >= global_work_size) {
+		//fprintf(stderr, "Get key error! %d %d\n", t, index);
+		t = 0;
+	}
+
+	len = saved_idx[t] & 63;
+	key = (char *)&saved_plain[saved_idx[t] >> 6];
+
+	for (i = 0; i < len; i++)
+		out[i] = *key++;
+	out[i] = 0;
+
+	if (len && mask_skip_ranges && mask_int_cand.num_int_cand > 1) {
+		for (i = 0; i < MASK_FMT_INT_PLHDR && mask_skip_ranges[i] != -1; i++)
+			if (mask_gpu_is_static)
+				out[static_gpu_locations[i]] =
+				    mask_int_cand.int_cand[int_index].x[i];
+			else
+				out[(saved_int_key_loc[t] & (0xff << (i * 8))) >> (i * 8)] =
+				    mask_int_cand.int_cand[int_index].x[i];
+	}
+
+	return out;
+}
+
+static void prepare_table(struct db_main *db)
+{
+	unsigned int *bin, i;
+	struct db_password *pw, *last;
+	struct db_salt *salt;
+
+	num_loaded_hashes = (db->password_count);
+
+	MEM_FREE(loaded_hashes);
+	MEM_FREE(loaded_hashes_tail);
+	MEM_FREE(hash_ids);
+	MEM_FREE(offset_table);
+	MEM_FREE(bt_hash_table_192);
+
+	loaded_hashes = (cl_uint *) mem_alloc(BT_WORDS * num_loaded_hashes * sizeof(
+	        cl_uint));
+	loaded_hashes_tail = (cl_uint *) mem_alloc(2 * num_loaded_hashes * sizeof(
+	                         cl_uint));
+	hash_ids = (cl_uint *) mem_calloc((3 * num_loaded_hashes + 1),
+	                                  sizeof(cl_uint));
+
+	i = 0;
+	salt = db->salts;
+	do {
+		last = pw = salt->list;
+		do {
+			bin = (unsigned int *)pw->binary;
+			if (bin == NULL) {
+				if (last == pw)
+					salt->list = pw->next;
+				else
+					last->next = pw->next;
+			} else {
+				last = pw;
+				loaded_hashes[BT_WORDS * i + 0] = bin[0];
+				loaded_hashes[BT_WORDS * i + 1] = bin[1];
+				loaded_hashes[BT_WORDS * i + 2] = bin[2];
+				loaded_hashes[BT_WORDS * i + 3] = bin[3];
+				loaded_hashes[BT_WORDS * i + 4] = bin[4];
+				loaded_hashes[BT_WORDS * i + 5] = bin[5];
+				loaded_hashes_tail[2 * i] = bin[6];
+				loaded_hashes_tail[2 * i + 1] = bin[7];
+				i++;
+			}
+		} while ((pw = pw->next));
+	} while ((salt = salt->next));
+
+	if (i != (db->password_count)) {
+		fprintf(stderr,
+		        "Something went wrong while preparing hashes..Exiting..\n");
+		error();
+	}
+
+	// Save original hashes for bitmap population before bt_create destroys them
+	num_loaded_hashes_original = num_loaded_hashes;
+	MEM_FREE(loaded_hashes_original);
+	loaded_hashes_original = (cl_uint *) mem_alloc(BT_WORDS *
+	                         num_loaded_hashes_original * sizeof(cl_uint));
+	memcpy(loaded_hashes_original, loaded_hashes,
+	       BT_WORDS * num_loaded_hashes_original * sizeof(cl_uint));
+
+	num_loaded_hashes = bt_create_perfect_hash_table(192, (void *)loaded_hashes,
+	                    num_loaded_hashes,
+	                    &offset_table,
+	                    &offset_table_size,
+	                    &hash_table_size, 0);
+
+	if (!num_loaded_hashes) {
+		MEM_FREE(bt_hash_table_192);
+		MEM_FREE(offset_table);
+		fprintf(stderr, "Failed to create Hash Table for cracking.\n");
+		error();
+	}
+}
+
+/* Use only for bitmaps up to 64K (0xffff) */
+static void prepare_bitmap_8(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
+{
+	unsigned int i;
+	MEM_FREE(*bitmap_ptr);
+	*bitmap_ptr = (cl_uint *) mem_calloc((bmp_sz >> 2), sizeof(cl_uint));
+
+	for (i = 0; i < num_loaded_hashes_original; i++) {
+		unsigned int bmp_idx = (loaded_hashes_original[HASH_IDX(i, 0)]) & (bmp_sz - 1);
+		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
+
+		bmp_idx = (loaded_hashes_original[HASH_IDX(i, 0)] >> 16) & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+
+		bmp_idx = (loaded_hashes_original[HASH_IDX(i, 1)]) & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 4) + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+
+		bmp_idx = (loaded_hashes_original[HASH_IDX(i, 1)] >> 16) & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) * 3 + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+
+		bmp_idx = (loaded_hashes_original[HASH_IDX(i, 2)]) & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 3) + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+
+		bmp_idx = (loaded_hashes_original[HASH_IDX(i, 2)] >> 16) & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) * 5 + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+
+		bmp_idx = (loaded_hashes_original[HASH_IDX(i, 3)]) & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) * 6 + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+
+		bmp_idx = (loaded_hashes_original[HASH_IDX(i, 3)] >> 16) & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) * 7 + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+	}
+}
+
+static void prepare_bitmap_4(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
+{
+	unsigned int i;
+	MEM_FREE(*bitmap_ptr);
+	*bitmap_ptr = (cl_uint *) mem_calloc((bmp_sz >> 3), sizeof(cl_uint));
+
+	for (i = 0; i < num_loaded_hashes_original; i++) {
+		unsigned int bmp_idx = loaded_hashes_original[HASH_IDX(i, 3)] & (bmp_sz - 1);
+		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
+
+		bmp_idx = loaded_hashes_original[HASH_IDX(i, 2)] & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+
+		bmp_idx = loaded_hashes_original[HASH_IDX(i, 1)] & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 4) + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+
+		bmp_idx = loaded_hashes_original[HASH_IDX(i, 0)] & (bmp_sz - 1);
+		(*bitmap_ptr)[(bmp_sz >> 5) * 3 + (bmp_idx >> 5)] |=
+		    (1U << (bmp_idx & 31));
+	}
+}
+
+static void prepare_bitmap_1(cl_ulong bmp_sz, cl_uint **bitmap_ptr)
+{
+	unsigned int i;
+	MEM_FREE(*bitmap_ptr);
+	*bitmap_ptr = (cl_uint *) mem_calloc((bmp_sz >> 5), sizeof(cl_uint));
+
+	for (i = 0; i < num_loaded_hashes_original; i++) {
+		unsigned int bmp_idx = loaded_hashes_original[HASH_IDX(i, 3)] & (bmp_sz - 1);
+		(*bitmap_ptr)[bmp_idx >> 5] |= (1U << (bmp_idx & 31));
+	}
+}
+
+static char *select_bitmap(unsigned int num_ld_hashes)
+{
+	static char kernel_params[200];
+	cl_ulong max_local_mem_sz_bytes = 0;
+	unsigned int cmp_steps = 2, use_local = 0;
+
+	HANDLE_CLERROR(clGetDeviceInfo(devices[gpu_id], CL_DEVICE_LOCAL_MEM_SIZE,
+	                               sizeof(cl_ulong), &max_local_mem_sz_bytes, 0),
+	               "failed to get CL_DEVICE_LOCAL_MEM_SIZE.");
+
+	if (num_loaded_hashes <= 5100) {
+		if (amd_gcn_10(device_info[gpu_id]) ||
+		        amd_vliw4(device_info[gpu_id]))
+			bitmap_size_bits = 512 * 1024;
+
+		else if (amd_gcn_11(device_info[gpu_id]) ||
+		         max_local_mem_sz_bytes < 16384 ||
+		         cpu(device_info[gpu_id]))
+			bitmap_size_bits = 256 * 1024;
+
+		else {
+			bitmap_size_bits = 32 * 1024;
+			cmp_steps = 4;
+			use_local = 1;
+		}
+	}
+
+	else if (num_loaded_hashes <= 10100) {
+		if (amd_gcn_10(device_info[gpu_id]) ||
+		        amd_vliw4(device_info[gpu_id]))
+			bitmap_size_bits = 512 * 1024;
+
+		else if (amd_gcn_11(device_info[gpu_id]) ||
+		         max_local_mem_sz_bytes < 32768 ||
+		         cpu(device_info[gpu_id]))
+			bitmap_size_bits = 256 * 1024;
+
+		else {
+			bitmap_size_bits = 64 * 1024;
+			cmp_steps = 4;
+			use_local = 1;
+		}
+	}
+
+	else if (num_loaded_hashes <= 20100) {
+		if (amd_gcn_10(device_info[gpu_id]))
+			bitmap_size_bits = 1024 * 1024;
+
+		else if (amd_gcn_11(device_info[gpu_id]) ||
+		         max_local_mem_sz_bytes < 32768)
+			bitmap_size_bits = 512 * 1024;
+
+		else if (amd_vliw4(device_info[gpu_id]) ||
+		         cpu(device_info[gpu_id])) {
+			bitmap_size_bits = 256 * 1024;
+			cmp_steps = 4;
+		}
+
+		else {
+			bitmap_size_bits = 32 * 1024;
+			cmp_steps = 8;
+			use_local = 1;
+		}
+	}
+
+	else if (num_loaded_hashes <= 250100)
+		bitmap_size_bits = 2048 * 1024;
+
+	else if (num_loaded_hashes <= 1100100) {
+		if (!amd_gcn_11(device_info[gpu_id]))
+			bitmap_size_bits = 4096 * 1024;
+
+		else
+			bitmap_size_bits = 2048 * 1024;
+	}
+
+	else if (num_loaded_hashes <= 1500100) {
+		bitmap_size_bits = 4096 * 1024 * 2;
+		cmp_steps = 1;
+	}
+
+	else if (num_loaded_hashes <= 2700100) {
+		bitmap_size_bits = 4096 * 1024 * 2 * 2;
+		cmp_steps = 1;
+	}
+
+	else {
+		cl_ulong mult = num_loaded_hashes / 2700100;
+		cl_ulong buf_sz;
+		bitmap_size_bits = 4096 * 4096;
+		get_power_of_two(mult);
+		bitmap_size_bits *= mult;
+		buf_sz = get_max_mem_alloc_size(gpu_id);
+		if (buf_sz & (buf_sz - 1)) {
+			get_power_of_two(buf_sz);
+			buf_sz >>= 1;
+		}
+		if (buf_sz >= 536870912)
+			buf_sz = 536870912;
+		if ((bitmap_size_bits >> 3) > buf_sz)
+			bitmap_size_bits = buf_sz << 3;
+		cmp_steps = 1;
+	}
+
+	if (cmp_steps == 1)
+		prepare_bitmap_1(bitmap_size_bits, &bitmaps);
+
+	else if (cmp_steps <= 4)
+		prepare_bitmap_4(bitmap_size_bits, &bitmaps);
+
+	else
+		prepare_bitmap_8(bitmap_size_bits, &bitmaps);
+
+	sprintf(kernel_params,
+	        "-DSELECT_CMP_STEPS=%u -DBITMAP_MASK=0x%xU -DUSE_LOCAL_BITMAPS=%u",
+	        cmp_steps, (uint32_t)bitmap_size_bits - 1, use_local);
+
+	bitmap_size_bits *= cmp_steps;
+
+	return kernel_params;
+}
+
+static int crypt_all(int *pcount, struct db_salt *salt)
+{
+	const int count = *pcount;
+	size_t *lws = (local_work_size && !(count % local_work_size)) ?
+	              &local_work_size : NULL;
+
+	global_work_size = count;
+
+	if (new_keys) {
+		// copy keys to the device
+		if (key_idx)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_keys, CL_TRUE, 0,
+			                                   4 * key_idx, saved_plain, 0, NULL, NULL),
+			              "failed in clEnqueueWriteBuffer buffer_keys.");
+
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_idx, CL_TRUE, 0,
+		                                   4 * global_work_size, saved_idx, 0, NULL, NULL),
+		              "failed in clEnqueueWriteBuffer buffer_idx.");
+
+		if (!mask_gpu_is_static)
+			BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_int_key_loc, CL_TRUE,
+			                                   0, 4 * global_work_size, saved_int_key_loc, 0, NULL, NULL),
+			              "failed in clEnqueueWriteBuffer buffer_int_key_loc.");
+
+		new_keys = 0;
+	}
+
+	BENCH_CLERROR(clEnqueueNDRangeKernel(queue[gpu_id], crypt_kernel, 1, NULL,
+	                                     &global_work_size, lws, 0, NULL, NULL), "failed in clEnqueueNDRangeKernel");
+
+	BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0,
+	                                  sizeof(cl_uint), hash_ids, 0, NULL, NULL),
+	              "failed in reading back num cracked hashes.");
+
+	if (hash_ids[0] > num_loaded_hashes) {
+		fprintf(stderr, "Error, crypt_all kernel.\n");
+		error();
+	}
+
+	if (hash_ids[0]) {
+		BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_return_hashes, CL_TRUE,
+		                                  0, 2 * sizeof(cl_uint) * hash_ids[0], loaded_hashes_tail, 0, NULL, NULL),
+		              "failed in reading back return_hashes.");
+		BENCH_CLERROR(clEnqueueReadBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0,
+		                                  (3 * hash_ids[0] + 1) * sizeof(cl_uint), hash_ids, 0, NULL, NULL),
+		              "failed in reading data back hash_ids.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_bitmap_dupe, CL_TRUE,
+		                                   0, (hash_table_size / 32 + 1) * sizeof(cl_uint), zero_buffer, 0, NULL, NULL),
+		              "failed in clEnqueueWriteBuffer buffer_bitmap_dupe.");
+		BENCH_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_hash_ids, CL_TRUE, 0,
+		                                   sizeof(cl_uint), zero_buffer, 0, NULL, NULL),
+		              "failed in clEnqueueWriteBuffer buffer_hash_ids.");
+	}
+
+	*pcount *=  mask_int_cand.num_int_cand;
+	return hash_ids[0];
+}
+
+static int cmp_all(void *binary, int count)
+{
+	if (count) return 1;
+	return 0;
+}
+
+static int cmp_one(void *binary, int index)
+{
+	return (((unsigned int *)binary)[0] ==
+	        bt_hash_table_192[hash_ids[3 + 3 * index]]);
+}
+
+static int cmp_exact(char *source, int index)
+{
+	unsigned int *t = (unsigned int *) iterated_sha256_get_binary(source);
+
+	if (t[6] != loaded_hashes_tail[2 * index])
+		return 0;
+	if (t[7] != loaded_hashes_tail[2 * index + 1])
+		return 0;
+	return 1;
+}
+
+static void auto_tune(struct db_main *db, long double kernel_run_ms)
+{
+	size_t gws_limit, gws_init;
+	size_t lws_limit, lws_init;
+
+	struct timeval startc, endc;
+	long double time_ms = 0, old_time_ms = 0;
+
+	size_t pcount, count;
+	size_t i;
+
+	int tune_gws = 1, tune_lws = 1;
+
+	char key[PLAINTEXT_LENGTH + 1];
+
+	memset(key, 0xF5, PLAINTEXT_LENGTH);
+	key[PLAINTEXT_LENGTH] = 0;
+
+	gws_limit = MIN((0xf << 22) * 4 / BUFSIZE,
+	                get_max_mem_alloc_size(gpu_id) / BUFSIZE);
+	get_power_of_two(gws_limit);
+	if (gws_limit > MIN((0xf << 22) * 4 / BUFSIZE,
+	                    get_max_mem_alloc_size(gpu_id) / BUFSIZE))
+		gws_limit >>= 1;
+
+#if SIZEOF_SIZE_T > 4
+	/* We can't process more than 4G keys per crypt() */
+	while (gws_limit * mask_int_cand.num_int_cand > 0xffffffffUL)
+		gws_limit >>= 1;
+#endif
+
+	lws_limit = get_kernel_max_lws(gpu_id, crypt_kernel);
+
+	lws_init = get_kernel_preferred_multiple(gpu_id, crypt_kernel);
+
+	if (gpu_amd(device_info[gpu_id]))
+		gws_init = gws_limit >> 6;
+	else if (gpu_nvidia(device_info[gpu_id]))
+		gws_init = gws_limit >> 8;
+	else
+		gws_init = 1024;
+
+	if (gws_init > gws_limit)
+		gws_init = gws_limit;
+	if (gws_init < lws_init)
+		lws_init = gws_init;
+
+	if (self_test_running) {
+		opencl_get_sane_lws_gws_values();
+	} else {
+		local_work_size = 0;
+		global_work_size = 0;
+		opencl_get_user_preferences(FORMAT_LABEL);
+	}
+	if (local_work_size) {
+		tune_lws = 0;
+		if (local_work_size & (local_work_size - 1))
+			get_power_of_two(local_work_size);
+		if (local_work_size > lws_limit)
+			local_work_size = lws_limit;
+	}
+	if (global_work_size)
+		tune_gws = 0;
+
+	/* Auto tune start.*/
+	char *ciphertext = fmt_opencl_sha256_iterated.params.tests[0].ciphertext;
+	set_salt(iterated_sha256_get_salt(ciphertext));
+	pcount = gws_init;
+	count = 0;
+#define calc_ms(start, end) \
+        ((long double)(end.tv_sec - start.tv_sec) * 1000.000 + \
+            (long double)(end.tv_usec - start.tv_usec) / 1000.000)
+	if (tune_gws) {
+		create_clobj_kpc(pcount);
+		set_kernel_args_kpc();
+		clear_keys();
+		for (i = 0; i < pcount; i++)
+			set_key(key, i);
+		gettimeofday(&startc, NULL);
+		crypt_all((int *)&pcount, NULL);
+		gettimeofday(&endc, NULL);
+		time_ms = calc_ms(startc, endc);
+		count = (size_t)((kernel_run_ms / time_ms) * (long double)gws_init);
+		get_power_of_two(count);
+	}
+
+	if (tune_gws && tune_lws)
+		release_clobj_kpc();
+
+	if (tune_lws) {
+		count = tune_gws ? count : global_work_size;
+		if (count > gws_limit)
+			count = gws_limit;
+		create_clobj_kpc(count);
+		set_kernel_args_kpc();
+		pcount = count;
+		clear_keys();
+		for (i = 0; i < pcount; i++)
+			set_key(key, i);
+		local_work_size = lws_init;
+		gettimeofday(&startc, NULL);
+		crypt_all((int *)&pcount, NULL);
+		gettimeofday(&endc, NULL);
+		old_time_ms = calc_ms(startc, endc);
+		local_work_size = 2 * lws_init;
+
+		while (local_work_size <= lws_limit) {
+			gettimeofday(&startc, NULL);
+			pcount = count;
+			crypt_all((int *)&pcount, NULL);
+			gettimeofday(&endc, NULL);
+			time_ms = calc_ms(startc, endc);
+			if (old_time_ms < time_ms) {
+				local_work_size /= 2;
+				break;
+			}
+			old_time_ms = time_ms;
+			local_work_size *= 2;
+		}
+
+		if (local_work_size > lws_limit)
+			local_work_size = lws_limit;
+	}
+
+	if (tune_gws && tune_lws) {
+		if (old_time_ms > kernel_run_ms) {
+			count /= 2;
+		} else {
+			count = (size_t)((kernel_run_ms / old_time_ms) * (long double)count);
+			get_power_of_two(count);
+		}
+	}
+
+	if (tune_gws) {
+		if (count > gws_limit)
+			count = gws_limit;
+		release_clobj_kpc();
+		create_clobj_kpc(count);
+		set_kernel_args_kpc();
+		global_work_size = count;
+	}
+
+	if (!tune_gws && !tune_lws) {
+		create_clobj_kpc(global_work_size);
+		set_kernel_args_kpc();
+	}
+	/* Auto tune finish.*/
+
+	if (global_work_size % local_work_size) {
+		global_work_size = GET_NEXT_MULTIPLE(global_work_size, local_work_size);
+		get_power_of_two(global_work_size);
+		release_clobj_kpc();
+		if (global_work_size > gws_limit)
+			global_work_size = gws_limit;
+		create_clobj_kpc(global_work_size);
+		set_kernel_args_kpc();
+	}
+	if (global_work_size > gws_limit) {
+		release_clobj_kpc();
+		global_work_size = gws_limit;
+		create_clobj_kpc(global_work_size);
+		set_kernel_args_kpc();
+	}
+
+	clear_keys();
+
+	self->params.max_keys_per_crypt = global_work_size;
+
+	if ((!self_test_running && options.verbosity >= VERB_DEFAULT)
+	        || ocl_always_show_ws) {
+		if (mask_int_cand.num_int_cand > 1)
+			fprintf(stderr, "LWS="Zu" GWS="Zu" x%d%s", local_work_size,
+			        global_work_size, mask_int_cand.num_int_cand,
+			        (options.flags & FLG_TEST_CHK) ? " " : "\n");
+		else
+			fprintf(stderr, "LWS="Zu" GWS="Zu"%s", local_work_size,
+			        global_work_size, (options.flags & FLG_TEST_CHK) ? " " : "\n");
+	}
+
+#undef calc_ms
+}
+
+static void reset(struct db_main *db)
+{
+	release_clobj();
+	release_clobj_kpc();
+
+	num_loaded_hashes = db->password_count;
+	unsigned int original_count = db->password_count;
+
+	prepare_table(db);
+
+	// Ensure mask system is initialized
+	if (!mask_int_cand.num_int_cand)
+		mask_int_cand.num_int_cand = 1;
+
+	// Use original count for bitmap size (before deduplication)
+	init_kernel(num_loaded_hashes, select_bitmap(original_count));
+
+	create_clobj();
+	set_kernel_args();
+
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_bitmaps, CL_TRUE, 0,
+	                                    (size_t)(bitmap_size_bits >> 3), bitmaps, 0, NULL, NULL),
+	               "failed in clEnqueueWriteBuffer buffer_bitmaps.");
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_offset_table,
+	                                    CL_TRUE, 0, sizeof(OFFSET_TABLE_WORD) * offset_table_size, offset_table, 0,
+	                                    NULL, NULL), "failed in clEnqueueWriteBuffer buffer_offset_table.");
+	HANDLE_CLERROR(clEnqueueWriteBuffer(queue[gpu_id], buffer_hash_table, CL_TRUE,
+	                                    0, sizeof(cl_uint) * hash_table_size * 2, bt_hash_table_192, 0, NULL, NULL),
+	               "failed in clEnqueueWriteBuffer buffer_hash_table.");
+
+	auto_tune(db, 100);
+}
+
+struct fmt_main FMT_STRUCT = {
+	{
+		FORMAT_LABEL,
+		FORMAT_NAME,
+		ALGORITHM_NAME,
+		BENCHMARK_COMMENT,
+		BENCHMARK_LENGTH,
+		0,
+		PLAINTEXT_LENGTH,
+		BINARY_SIZE,
+		BINARY_ALIGN,
+		SALT_SIZE,
+		SALT_ALIGN,
+		MIN_KEYS_PER_CRYPT,
+		MAX_KEYS_PER_CRYPT,
+		FMT_CASE | FMT_8_BIT | FMT_REMOVE | FMT_MASK,
+		{ "iterations" },
+		{
+			FORMAT_TAG,
+			""
+		},
+		iterated_sha256_tests
+	}, {
+		init,
+		done,
+		reset,
+		fmt_default_prepare,
+		iterated_sha256_valid,
+		fmt_default_split,
+		iterated_sha256_get_binary,
+		iterated_sha256_get_salt,
+		{
+			iterated_sha256_iterations
+		},
+		fmt_default_source,
+		{
+			fmt_default_binary_hash_0,
+			fmt_default_binary_hash_1,
+			fmt_default_binary_hash_2,
+			fmt_default_binary_hash_3,
+			fmt_default_binary_hash_4,
+			fmt_default_binary_hash_5,
+			fmt_default_binary_hash_6
+		},
+		iterated_sha256_salt_hash,
+		NULL,
+		set_salt,
+		set_key,
+		get_key,
+		clear_keys,
+		crypt_all,
+		{
+			get_hash_0,
+			get_hash_1,
+			get_hash_2,
+			get_hash_3,
+			get_hash_4,
+			get_hash_5,
+			get_hash_6
+		},
+		cmp_all,
+		cmp_one,
+		cmp_exact
+	}
+
+};
+
+#endif /* plugin stanza */
+
+#endif /* HAVE_OPENCL */


### PR DESCRIPTION
Tests:

```
$ ../run/john --format=Iterated-SHA256-OpenCL --test
Device 1: NVIDIA GeForce RTX 3060 Laptop GPU
Benchmarking: Iterated-SHA256-opencl, salted [SHA256 ($s.$p) OpenCL]... LWS=128 GWS=2097152 DONE
Speed for cost 1 (iterations) of 129
Warning: "Many salts" test limited: 16/256
Many salts:	16054K c/s real, 15978K c/s virtual, Dev#1 util: 100%
Only one salt:	13170K c/s real, 13170K c/s virtual, Dev#1 util: 69%

$ OMP_NUM_THREADS=4 ../run/john --format=Iterated-SHA256 --test
Will run 4 OpenMP threads
Benchmarking: Iterated-SHA256, salted [SHA256 ($s.$p) 256/256 AVX2 8x]... (4xOMP) DONE
Speed for cost 1 (iterations) of 129
Warning: "Many salts" test limited: 2/256
Many salts:	673783 c/s real, 169227 c/s virtual
Only one salt:	682000 c/s real, 171686 c/s virtual
```

M4 Mac Mini:

```
user@mini src % ../run/john --format=Iterated-SHA256-OpenCL --test
Device 1: Apple M4
Benchmarking: Iterated-SHA256-opencl, salted [SHA256 ($s.$p) OpenCL]... LWS=256 GWS=1048576 DONE
Speed for cost 1 (iterations) of 129
Warning: "Many salts" test limited: 12/256
Many salts:	5907K c/s
Only one salt:	5738K c/s real, 230686K c/s virtual

user@mini src % ../run/john --format=Iterated-SHA256 --test       
Will run 10 OpenMP threads
Benchmarking: Iterated-SHA256, salted [SHA256 ($s.$p) 128/128 ASIMD 4x]... (10xOMP) DONE
Speed for cost 1 (iterations) of 129
Warning: "Many salts" test limited: 11/256
Many salts:	830525 c/s real, 97788 c/s virtual
Only one salt:	826715 c/s real, 97947 c/s virtual
```

It has been a while... ;)

PS: I am trying out `Codex CLI` to auto-generate the code.