### PR TITLE
Fix misleading comments in SHA-crypt and derived code

### DIFF
--- a/src/gost12256hash_fmt_plug.c
+++ b/src/gost12256hash_fmt_plug.c
@@ -258,7 +258,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		/* Start computation of S byte sequence. */
 		GOST34112012Init(&alt_ctx, 256);
 
-		/* For every character in the password add the entire password. */
+		/* Repeat the following 16+A[0] times, where A[0] represents the
+		   first byte in digest A interpreted as an 8-bit unsigned value */
 		for (cnt = 0; cnt < 16 + ((unsigned char*)crypt_out[index])[0]; ++cnt)
 			GOST34112012Update(&alt_ctx, cur_salt->salt, cur_salt->len);
 

--- a/src/gost94hash_fmt_plug.c
+++ b/src/gost94hash_fmt_plug.c
@@ -258,7 +258,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		/* Start computation of S byte sequence. */
 		john_gost_init(&alt_ctx);
 
-		/* For every character in the password add the entire password. */
+		/* Repeat the following 16+A[0] times, where A[0] represents the
+		   first byte in digest A interpreted as an 8-bit unsigned value */
 		for (cnt = 0; cnt < 16 + ((unsigned char*)crypt_out[index])[0]; ++cnt)
 			john_gost_update(&alt_ctx, cur_salt->salt, cur_salt->len);
 

--- a/src/sm3crypt_fmt_plug.c
+++ b/src/sm3crypt_fmt_plug.c
@@ -255,7 +255,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
 		/* Start computation of S byte sequence. */
 		sm3_init(&alt_ctx);
 
-		/* For every character in the password add the entire password. */
+		/* Repeat the following 16+A[0] times, where A[0] represents the
+		   first byte in digest A interpreted as an 8-bit unsigned value */
 		for (cnt = 0; cnt < 16 + ((unsigned char*)crypt_out[index])[0]; ++cnt)
 			sm3_update(&alt_ctx, cur_salt->salt, cur_salt->len);
 


### PR DESCRIPTION
Cross checked and fixed the following modules for duplicate comments that does not reflect the action of the code.

```
./sm3crypt_fmt_plug.c:		/* For every character in the password add the entire password. */
./sm3crypt_fmt_plug.c:		/* For every character in the password add the entire password. */
./sha512crypt_fmt_plug.c:			/* For every character in the password add the entire password.  */
./ztex/fpga-sha512crypt/sha512crypt/cpu/program.vh:	// "For every character in the password add the entire password."
./ztex/fpga-sha256crypt/sha256crypt/cpu/program.vh:	// "For every character in the password add the entire password."
./sha256crypt_fmt_plug.c:			/* For every character in the password add the entire password.  */
./gost12256hash_fmt_plug.c:		/* For every character in the password add the entire password. */
./gost12256hash_fmt_plug.c:		/* For every character in the password add the entire password. */
./gost12512hash_fmt_plug.c:		/* For every character in the password add the entire password.  */
./gost94hash_fmt_plug.c:		/* For every character in the password add the entire password. */
./gost94hash_fmt_plug.c:		/* For every character in the password add the entire password. */
```