### PR TITLE
Add back a BOM check in wordlist.c that was mistakenly dropped

### DIFF
--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -710,6 +710,9 @@ void do_wordlist_crack(struct db_main *db, const char *name, int rules)
 
 					if (!mgetl(line))
 						break;
+
+					check_bom(line);
+
 					if (!strncmp(line, "#!comment", 9))
 						continue;
 					lp = convert(line);


### PR DESCRIPTION
It was dropped in a7c8fa66a for reasons unknown. In certain situations (the combination of node/fork, mmap, rules, UTF-8 input encoding and reading a UTF-8 BOM) this lead to problems. The UTF-8 BOM should never be there in the first place but we need to handle it without crashing or aborting.

Closes #5968