### PR TITLE
fix(ssh2john): correct bcrypt rounds assignment and update exception …

### DIFF
--- a/run/ssh2john.py
+++ b/run/ssh2john.py
@@ -118,7 +118,7 @@ def read_private_key(filename):
         try:
             data = ''.join(lines[start:end]).encode()
             data = base64.b64decode(data)
-        except base64.binascii.Error:
+        except binascii.Error:
             e = sys.exc_info()[1]
             raise Exception('base64 decoding error: ' + str(e))
 
@@ -178,7 +178,7 @@ def read_private_key(filename):
             rounds = data[rounds_offset: rounds_offset+4]
             rounds = unpack(">I", rounds)[0]
             if rounds == 0:
-                rounds == 16
+                rounds = 16
 
         keysize = CIPHER_TABLE[encryption_type]['keysize']
         salt = binascii.unhexlify(saltstr)


### PR DESCRIPTION
…handling

This commit addresses two issues in the OpenSSH private key extraction process:
1. Exception Handling: Updated the decoding try-except block to catch `binascii.Error` directly, ensuring decode failures are handled gracefully in Python 3 environments.
2. Logic Bug: Fixed a fallback assignment issue for OpenSSH `bcrypt_pbkdf` keys. Replaced an incorrect equality check (`rounds == 16`) with an assignment (`rounds = 16`) so that the iteration count defaults correctly when initially read as 0.