### PR TITLE
Make 'output may be large' note size-conditional + extend to rar2john / dmg2john / keepass2john (#4051)

### DIFF
--- a/src/2john_common.h
+++ b/src/2john_common.h
@@ -1,0 +1,72 @@
+/*
+ * Shared helpers used by the family of *2john converters (zip2john,
+ * rar2john, dmg2john, keepass2john, ...). See:
+ *   https://github.com/openwall/john/issues/4051
+ *
+ * Many of these converters embed the encrypted blob from the input archive
+ * directly into the JtR hash line they print to stdout. For large archives
+ * (encrypted disk images, password-protected RARs, KeePass databases with
+ * sizeable key files) the resulting hash line can run into hundreds of
+ * megabytes or more, which routinely surprises new users into thinking the
+ * tool has malfunctioned. The helpers here let each *2john print a single
+ * one-shot stderr note up front when the input is large enough that a big
+ * stdout output is expected.
+ */
+
+#ifndef _JOHN_2JOHN_COMMON_H
+#define _JOHN_2JOHN_COMMON_H
+
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+/*
+ * Default threshold (in bytes) above which a *2john tool should print the
+ * "output may be very large" stderr note. Roughly 1 MiB matches the
+ * suggestion in https://github.com/openwall/john/issues/4051. Each tool can
+ * override this if its output is more (or less) bloated relative to the
+ * input.
+ */
+#define LARGE_OUTPUT_THRESHOLD_BYTES (1L << 20)
+
+/*
+ * Print a one-shot stderr explanation that the output may be very large.
+ * The note is suppressed after the first call within a process so users
+ * who feed in many archives don't see it once per file.
+ */
+static inline void large_output_note(const char *progname)
+{
+	static int announced;
+
+	if (announced)
+		return;
+	announced = 1;
+
+	fprintf(stderr,
+		"Note: %s output can be very large for large inputs (often 2x the\n"
+		"input size or more, since the encrypted blob is hex-encoded into the\n"
+		"hash line). This is normal — redirect the output into a file with\n"
+		"'%s <archive> > hashes.txt'.\n",
+		progname, progname);
+}
+
+/*
+ * Stat path and call large_output_note() iff the file is at least
+ * threshold bytes. Errors from stat() are silently ignored — the note is a
+ * best-effort UX hint, not a correctness check.
+ */
+static inline void large_output_note_if_input_large(const char *progname,
+						    const char *path,
+						    off_t threshold)
+{
+	struct stat st;
+
+	if (path == NULL)
+		return;
+	if (stat(path, &st) != 0)
+		return;
+	if (st.st_size >= threshold)
+		large_output_note(progname);
+}
+
+#endif /* _JOHN_2JOHN_COMMON_H */

--- a/src/dmg2john.c
+++ b/src/dmg2john.c
@@ -42,6 +42,7 @@
 #include "jumbo.h"
 #include "memory.h"
 #include "johnswap.h"
+#include "2john_common.h"
 
 #define inplace_ntohl(x) do { (x) = john_ntohl((x)); } while (0)
 
@@ -514,8 +515,11 @@ int main(int argc, char **argv)
 		puts("Usage: dmg2john [DMG files]");
 		return -1;
 	}
-	for (i = 1; i < argc; i++)
+	for (i = 1; i < argc; i++) {
+		large_output_note_if_input_large("dmg2john", argv[i],
+						 LARGE_OUTPUT_THRESHOLD_BYTES);
 		hash_plugin_parse_hash(argv[i]);
+	}
 
 	return 0;
 }

--- a/src/keepass2john.c
+++ b/src/keepass2john.c
@@ -60,6 +60,7 @@
 #include "aes.h"
 #include "base64_convert.h"
 #include "johnswap.h"
+#include "2john_common.h"
 
 //#define KEEPASS_DEBUG
 
@@ -966,8 +967,13 @@ int main(int argc, char **argv)
 		return usage(argv[0]);
 	argv += optind;
 
-	while (argc--)
-		process_database(*argv++);
+	while (argc--) {
+		char *path = *argv++;
+
+		large_output_note_if_input_large("keepass2john", path,
+						 LARGE_OUTPUT_THRESHOLD_BYTES);
+		process_database(path);
+	}
 
 	return 0;
 }

--- a/src/rar2john.c
+++ b/src/rar2john.c
@@ -63,6 +63,7 @@
 #include "base64_convert.h"
 #include "sha2.h"
 #include "rar2john.h"
+#include "2john_common.h"
 #ifdef _MSC_VER
 #include "missing_getopt.h"
 #endif
@@ -997,8 +998,13 @@ int rar2john(int argc, char **argv)
 		return usage(argv[0]);
 	argv += optind;
 
-	while (argc--)
-		process_file(*argv++);
+	while (argc--) {
+		const char *path = *argv++;
+
+		large_output_note_if_input_large("rar2john", path,
+						 LARGE_OUTPUT_THRESHOLD_BYTES);
+		process_file(path);
+	}
 
 	return EXIT_SUCCESS;
 }

--- a/src/zip2john.c
+++ b/src/zip2john.c
@@ -139,6 +139,7 @@
 #include "missing_getopt.h"
 #endif
 #include "johnswap.h"
+#include "2john_common.h"
 
 #define _STR_VALUE(arg) #arg
 #define STR_MACRO(n)    _STR_VALUE(n)
@@ -945,9 +946,14 @@ static void print_and_cleanup(zip_context *ctx)
 			"If that is not the case, the hash may be uncrackable. To avoid this, use\n"
 			"option -o to pick a file at a time.\n");
 
-	// Give warning to user for potentially large output of zip2john
-	fprintf(stderr,
-		"Note: It is normal for some outputs to be very large\n");
+	/*
+	 * The "output may be very large" note is now printed up front by
+	 * large_output_note_if_input_large() in zip2john(), only when the
+	 * input archive is big enough that the user is actually going to see
+	 * a confusingly large hash line. This avoids the previous behaviour
+	 * of always printing it after every output, which spammed users who
+	 * fed in many small archives.
+	 */
 
 	for (i = 0; i < ctx->num_candidates; ++i) {
 		MEM_FREE(ctx->best_files[i].hash_data);
@@ -1179,10 +1185,14 @@ int zip2john(int argc, char **argv)
 	argv += optind;
 
 	while(argc--) {
+		const char *path = *argv++;
+
+		large_output_note_if_input_large("zip2john", path,
+						 LARGE_OUTPUT_THRESHOLD_BYTES);
 		if (do_scan) {
-			scan_from_start(*argv++);
+			scan_from_start(path);
 		} else {
-			scan_central_index(*argv++);
+			scan_central_index(path);
 		}
 	}
 


### PR DESCRIPTION
Closes (or substantially closes) #4051.

The \`*2john\` family of converters embed the encrypted blob from the input archive directly into the JtR hash line written to stdout. For large inputs (encrypted disk images, password-protected RARs, KeePass DBs with big key files) the resulting hash line can run into hundreds of megabytes — which routinely surprises new users into thinking the tool malfunctioned.

@gartikis added an unconditional one-liner to zip2john in #5837 to address that. It helped, but:

1. It fires *after* each output, so by the time it appears the user has already watched MBs scroll by (and sometimes Ctrl+C'd).
2. It fires for every archive, including tiny ones — \`zip2john tiny.zip\` would always print \"It is normal for some outputs to be very large\" even when the output was 200 bytes.
3. The other converters most likely to surprise users (rar2john, dmg2john, keepass2john) didn't get the same hint.

This PR replaces the unconditional zip2john message with a size-conditional version and extends it to the other three converters, sharing one tiny static-inline helper.

## What changes

### \`src/2john_common.h\` (new)

Single header, no link-time dep:

\`\`\`c
LARGE_OUTPUT_THRESHOLD_BYTES        1 MiB, matching the suggestion in #4051
large_output_note(progname)         one-shot stderr note ('output may be very
                                    large; redirect into a file with...')
large_output_note_if_input_large(progname, path, threshold)
                                    stat(path); fire note iff size >= threshold;
                                    stat() failures silently ignored — the note
                                    is UX, not correctness
\`\`\`

\`large_output_note\` uses a static \`announced\` flag so feeding many archives in one invocation only prints it once.

### \`src/zip2john.c\`

- Includes \`2john_common.h\`.
- Calls the helper at the top of each per-archive iteration in \`zip2john()\`.
- Removes the previous \`fprintf(stderr, \"Note: It is normal for some outputs to be very large\\n\");\` from \`process_one()\` (replaced by an inline comment pointing at the new helper) so users scanning many small archives no longer see the note 100x.

### \`src/rar2john.c\` / \`src/dmg2john.c\` / \`src/keepass2john.c\`

Same pattern: include the header, call the helper before the per-file processing function.

## Live verification

Built with \`./configure && make\` from \`src/\`. Only warning is a pre-existing \`-Wcpp\` one about libbz2 unrelated to this change.

\`\`\`
$ ./run/zip2john tiny.zip          # 207 B input
ver 1.0 efh 5455 efh 7875 tiny.zip/small.txt PKZIP Encr: 2b chk, ...
tiny.zip/small.txt:\$pkzip\$1*2*2*0*17*b*467677b6*0*43*0*17*8ab0*5da8b9...
                                  # NO note — was previously printed unconditionally

$ ./run/zip2john big.zip 2>&1 1>/dev/null  # ~2 MiB input
Note: zip2john output can be very large for large inputs (often 2x the
input size or more, since the encrypted blob is hex-encoded into the
hash line). This is normal — redirect the output into a file with
'zip2john <archive> > hashes.txt'.

$ ./run/keepass2john big.kdbx 2>&1 | head -5  # ~2 MiB input
Note: keepass2john output can be very large for large inputs (often 2x the
input size or more, since the encrypted blob is hex-encoded into the
hash line). This is normal — redirect the output into a file with
'keepass2john <archive> > hashes.txt'.
! big.kdbx : Unknown format: File signature invalid
\`\`\`

## Notes for review

- I picked the four converters that are most likely to embed multi-megabyte encrypted blobs (zip2john, rar2john, dmg2john, keepass2john). If you'd like I can extend the same pattern to others (gpg2john, hccap2john, putty2john, wpapcap2john, etc.) in a follow-up; happy to do whichever subset feels right.
- Threshold defaults to 1 MiB but is a parameter on \`large_output_note_if_input_large(...)\`, so per-tool tuning is possible without touching the helper.
- No DCO sign-off on the commit yet — happy to add it if needed.