### PR TITLE
pdf2john: Treat PDF Permissions value as a signed 32-bit integer

### DIFF
--- a/run/lib/PDF.pm
+++ b/run/lib/PDF.pm
@@ -1204,7 +1204,11 @@ sub DecryptInit($$$)
         $$encrypt{_meta} = 1;
     }
 
-    printf("\$pdf\$%d*%d*%d*%d*%d*%d*", $ver, $rev, $$encrypt{Length} || 40, $$encrypt{P}, $$encrypt{_meta} || 0, length($id));
+    # PDF /P is a signed 32-bit integer
+    my $perm = $$encrypt{P};
+    $perm -= 4294967296 if $perm >= 2147483648;
+
+    printf("\$pdf\$%d*%d*%d*%d*%d*%d*", $ver, $rev, $$encrypt{Length} || 40, $perm, $$encrypt{_meta} || 0, length($id));
     my $str = $id;
     $str =~ s/(.)/ sprintf '%02x', ord $1 /seg;
     printf("%s*", $str);

--- a/run/pdf2john.py
+++ b/run/pdf2john.py
@@ -73,6 +73,8 @@ class PdfHashExtractor:
             self.algorithm: int = self.encrypt_dict.get("/V")
             self.length: int = self.encrypt_dict.get("/Length", 40)
             self.permissions: int = self.encrypt_dict["/P"]
+            if self.permissions >= 2**31:
+                self.permissions -= 2**32
             self.revision: int = self.encrypt_dict["/R"]
 
     @property


### PR DESCRIPTION
Fixes #5992.

The problem is that `pdf2john.pl` and `pdf2john.py` tools print the PDF `/P` value as-is, without converting it to a signed integer. These proposed fixes print the permissions value as a signed integer.