### PR TITLE
pdf2john: accept space-padded xref offsets

### DIFF
--- a/run/lib/PDF.pm
+++ b/run/lib/PDF.pm
@@ -1815,7 +1815,8 @@ XRef:
                 my $i;
                 for ($i=0; $i<$num; ++$i) {
                     $raf->Read($buff, 20) == 20 or return -6;
-                    $buff =~ /^\s*(\d{10}) (\d{5}) (f|n)/s or return -4;
+                    # relax fixed \d{10}/\d{5} widths: some PDFs space-pad offsets instead of zero-padding
+                    $buff =~ /^\s*(\d+)\s+(\d+)\s+(f|n)/s or return -4;
                     my $num = $start + $i;
                     # save offset for newest copy of all objects
                     # (or next object number for free objects)


### PR DESCRIPTION
Some encrypted PDFs pad their cross-reference table with spaces instead of zeros. 
These open fine in normal readers, but `pdf2john` rejected the table and produced an empty hash, so John had nothing to crack. Relax the parser to accept them. Well-formed PDFs are unaffected.

Fixes https://github.com/openwall/john/issues/6018